### PR TITLE
redux dev tools extension

### DIFF
--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -7,18 +7,13 @@ import enhanceReducer from './enhanceReducer';
 import connectErrorEpic from './connectErrorEpic';
 
 export default function configureStore(initialState, config, stripesLogger) {
-  let createStoreWithMiddleware;
   const reducer = enhanceReducer(combineReducers(initialReducers));
   const middleware = applyMiddleware(thunk, epicMiddleware);
  /* eslint-disable no-underscore-dangle */
-  if (stripesLogger.hasCategory('redux')) {
-    createStoreWithMiddleware = compose(
+  const createStoreWithMiddleware = compose(
     middleware,
       window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f,
     );
-  } else {
-    createStoreWithMiddleware = compose(middleware);
-  }
   /* eslint-enable */
 
   addEpics([connectErrorEpic]);


### PR DESCRIPTION
This is a quick set up for enabling the redux-devtools extenstion without any additional packages installed.
To test this we should install either the browser or non-browser Redux DevTools extenstion.For more details below are few references.
https://github.com/zalmoxisus/redux-devtools-extension
https://medium.com/@zalmoxis/using-redux-devtools-in-production-4c5b56c5600f 

Also If you feel like playing with it more with some complex objects .Try logging into slack.com in browser with the extension installed.
@skomorokh 