### PR TITLE
Remove unused nav buttons

### DIFF
--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -174,12 +174,6 @@ class MainNav extends Component {
           <NavGroup>
             {menuLinks}
             <NavDivider md="hide" />
-            <NavButton md="hide" ><NavIcon color="#7eb970" /></NavButton>
-            <NavButton md="hide"><NavIcon color="#b33f3f" /></NavButton>
-            <NavButton md="hide"><NavIcon color="#3fb38e" /></NavButton>
-            <NavButton md="hide"><NavIcon color="#3f6cb3" /></NavButton>
-            <NavDivider md="hide" />
-            <NavButton md="hide"><NavIcon color="#7d3fb3" /></NavButton>
           </NavGroup>
           <NavGroup className={css.smallAlignRight}>
             <Dropdown open={this.state.userMenuOpen} id="UserMenuDropDown" onToggle={this.toggleUserMenu} pullRight >


### PR DESCRIPTION
The top navigation bar is populated via the automatically discovered list of applications. However, in addition to those, there is a list of six navigation buttons that don't appear to serve any purpose other than to demonstrate the visual style. For someone using the system this can be confusing since it immediately raises the question "should this do something?", or "should it go somewhere?"

This removes those questions by removing those buttons.

## Before

![2017-08-04 10 46 57](https://user-images.githubusercontent.com/4205/28976241-c3e6c08a-7902-11e7-9676-075401c15aa1.gif)

## After

![2017-08-04 10 52 03](https://user-images.githubusercontent.com/4205/28976328-0c512608-7903-11e7-8e0b-b2c26bfc7ae5.gif)

