### PR TITLE
Allow pluggable history interface in stripes router.

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -1,7 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import { combineReducers } from 'redux';
 import { Provider, connect } from 'react-redux';
-import Router from 'react-router-dom/BrowserRouter';
+import Router from 'react-router-dom/Router';
+import createBrowserHistory from 'history/createBrowserHistory';
 import Route from 'react-router-dom/Route';
 import Switch from 'react-router-dom/Switch';
 import { CookiesProvider } from 'react-cookie';
@@ -46,7 +47,7 @@ class Root extends Component {
   }
 
   render() {
-    const { logger, store, config, okapi, actionNames, token, disableAuth, currentUser, currentPerms, locale, plugins, bindings, discovery, translations } = this.props;
+    const { logger, store, config, okapi, actionNames, token, disableAuth, currentUser, currentPerms, locale, plugins, bindings, discovery, translations, history } = this.props;
 
     if (!translations) return (<div />);
 
@@ -110,7 +111,7 @@ class Root extends Component {
       <IntlProvider locale={locale} key={locale} messages={translations}>
         <HotKeys keyMap={bindings} noWrapper>
           <Provider store={store}>
-            <Router>
+            <Router history={history}>
               { token || disableAuth ?
                 <MainContainer>
                   <MainNav stripes={stripes} />
@@ -175,6 +176,16 @@ Root.propTypes = {
     modules: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     interfaces: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   }),
+  history: PropTypes.shape({
+    length: PropTypes.number.isRequired,
+    action: PropTypes.string.isRequired,
+    push: PropTypes.func.isRequired,
+    replace: PropTypes.func.isRequired
+  }),
+};
+
+Root.defaultProps = {
+  history: createBrowserHistory()
 };
 
 // TODO: remove after locale is accessible from a global config


### PR DESCRIPTION
Popular test runners like [Karma][1] and [Testem][2] allow you to run your test suite against multiple browsers. In order to do this, they invert control so that a browser is driving the test suite, and not that the test suite is driving a browser.

However, this creates a problem in certain scenarios because in order for the browser to "capture" an application, it can't have the URL _actually_ changing as the test navigates around the application. As a result, in order to use one of these runners with react router, it needs to use an instance of `MemoryHistory` and not `BrowserHistory`. That way, the URL changes only from the perspective of the application, but not from the perspective of the actual browser.

This change allows the `Root` component to accept a `history` property, which should be an instance of [History][3], so that inside a browser test harness, you can drive your stripes application with a MemoryHistory.

To accomplish this, we use the prop types mechanism, supplying the current history (browser history) as the default.

> Note: in order to add some structurual sanity checking for the history object, we check for the `length`, `action`, `push`, and `replace` properties. This isn't a complete list, but should prevent something that is clearly bogus from getting passed in. We can't just check the constructor, because the history library just uses simple objects.

For reference, here is [an example][4] of a test harness that uses the in-memory history object instead of the default browser history.

[1]: https://karma-runner.github.io/1.0/index.html
[2]: https://github.com/testem/testem
[3]: https://github.com/reacttraining/history
[4]: https://github.com/thefrontside/ui-eholdings/blob/master/tests/harness.js#L43-L53