### PR TITLE
Clean up prop-types related deprecations

### DIFF
--- a/src/AddContext.js
+++ b/src/AddContext.js
@@ -1,17 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class AddContext extends React.Component {
   static propTypes = {
-    context: React.PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.array,
+    context: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+    children: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array,
     ]),
   };
 
   static childContextTypes = {
     // It seems wrong that we have to tell this generic component what specific properties to put in the context
-    stripes: React.PropTypes.object,
+    stripes: PropTypes.object,
   };
 
   getChildContext() {

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { combineReducers } from 'redux';
 import { Provider, connect } from 'react-redux';
 import Router from 'react-router-dom/BrowserRouter';

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { modules as uiModules } from 'stripes-loader'; // eslint-disable-line
 
 import stripesCore from '@folio/stripes-core/package.json'; // eslint-disable-line

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { reduxForm, Field } from 'redux-form';
 import css from './Login.css';
 

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'; // eslint-disable-line
+import React, { Component } from 'react'; // eslint-disable-line
+import PropTypes from 'prop-types';
 import { connect as reduxConnect } from 'react-redux'; // eslint-disable-line
 
 import { requestLogin, checkUser } from '../../loginServices';

--- a/src/components/MainContainer/MainContainer.js
+++ b/src/components/MainContainer/MainContainer.js
@@ -1,11 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 // import globalCssReset from '!style!css!normalize.css';
 import globalSystemCss from '!style-loader!css-loader!./global.css'; // eslint-disable-line
 
 import css from './MainContainer.css';
 
 const propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 function MainContainer(props) {

--- a/src/components/MainNav/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/MainNav/Breadcrumbs/Breadcrumbs.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import css from './Breadcrumbs.css';
 
 const propTypes = {
-  links: React.PropTypes.array,
+  links: PropTypes.array,
 };
 
 function Breadcrumbs(props) {

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Dropdown } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 import localforage from 'localforage';
@@ -36,8 +37,8 @@ class MainNav extends Component {
         dispatch: PropTypes.func.isRequired,
       }),
     }),
-    history: React.PropTypes.shape({
-      listen: React.PropTypes.func.isRequired,
+    history: PropTypes.shape({
+      listen: PropTypes.func.isRequired,
     }).isRequired,
     location: PropTypes.shape({
       pathname: PropTypes.string,

--- a/src/components/MainNav/NavButton/NavButton.js
+++ b/src/components/MainNav/NavButton/NavButton.js
@@ -1,15 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
 import css from './NavButton.css';
 
 const propTypes = {
-  href: React.PropTypes.string,
-  title: React.PropTypes.string,
-  onClick: React.PropTypes.func,
-  onKeyDown: React.PropTypes.func,
-  children: React.PropTypes.node.isRequired,
-  md: React.PropTypes.string, // eslint-disable-line
-  selected: React.PropTypes.bool,
+  href: PropTypes.string,
+  title: PropTypes.string,
+  onClick: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  children: PropTypes.node.isRequired,
+  md: PropTypes.string, // eslint-disable-line
+  selected: PropTypes.bool,
 };
 
 function NavButton(props) {

--- a/src/components/MainNav/NavDivider/NavDivider.js
+++ b/src/components/MainNav/NavDivider/NavDivider.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import css from './NavDivider.css';
 
 const propTypes = {
-  md: React.PropTypes.string, // Temporary as we work out the responsiveness of the header.
+  md: PropTypes.string, // Temporary as we work out the responsiveness of the header.
 };
 
 function NavDivider(props) {
@@ -18,4 +19,3 @@ function NavDivider(props) {
 NavDivider.propTypes = propTypes;
 
 export default NavDivider;
-

--- a/src/components/MainNav/NavDropdownMenu/NavDropdownMenu.js
+++ b/src/components/MainNav/NavDropdownMenu/NavDropdownMenu.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 // import ReactDOM from 'react-dom';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper'; // eslint-disable-line
 import css from './NavDropdownMenu.css';
 
 const propTypes = {
-  pullRight: React.PropTypes.bool,
-  size: React.PropTypes.string,
-  open: React.PropTypes.bool,
-  children: React.PropTypes.element.isRequired,
+  pullRight: PropTypes.bool,
+  size: PropTypes.string,
+  open: PropTypes.bool,
+  children: PropTypes.element.isRequired,
 };
 
 class NavDropdownMenu extends React.Component {

--- a/src/components/MainNav/NavGroup/NavGroup.js
+++ b/src/components/MainNav/NavGroup/NavGroup.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import css from './NavGroup.css';
 
 const propTypes = {
-  children: React.PropTypes.node.isRequired,
-  className: React.PropTypes.string, // eslint-disable-line
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string, // eslint-disable-line
 };
 
 function NavGroup(props) {

--- a/src/components/MainNav/NavIcon/NavIcon.js
+++ b/src/components/MainNav/NavIcon/NavIcon.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
-  color: React.PropTypes.string,
-  icon: React.PropTypes.element,
+  color: PropTypes.string,
+  icon: PropTypes.element,
 };
 
 const defaultProps = {

--- a/src/components/ModuleContainer/ModuleContainer.js
+++ b/src/components/ModuleContainer/ModuleContainer.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import style from './ModuleContainer.css';
 
 const propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 function ModuleContainer(props) {

--- a/src/components/Notification/Toast.js
+++ b/src/components/Notification/Toast.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Portal } from 'react-overlays'; // eslint-disable-line
 import ToastNotification from './ToastNotification';
 import css from './Toast.css';
@@ -8,11 +9,11 @@ const propTypes = {
    * Array of message objects with properties {message, type, timeout, id, position, transition}
    * message and id are required.
    */
-  notifications: React.PropTypes.array,
+  notifications: PropTypes.array,
   /*
    * Hide handler for dismissing toasts.
    */
-  onHide: React.PropTypes.func,
+  onHide: PropTypes.func,
 };
 
 class Toast extends React.Component {

--- a/src/components/Notification/ToastNotification.js
+++ b/src/components/Notification/ToastNotification.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Button from '@folio/stripes-components/lib/Button';
 import Icon from '@folio/stripes-components/lib/Icon';
 import Layout from '@folio/stripes-components/lib/Layout';
@@ -10,32 +11,32 @@ const propTypes = {
   /*
    * String to be printed on the notification
    */
-  message: React.PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
   /*
    * Screen positioning of notification: e.g "start" or "end top". Defaults to "end bottom".
    */
-  position: React.PropTypes.string,
+  position: PropTypes.string,
   /*
    * How the notification animates into the page. Possible values are "slide" and "fade". Defaults to "slide".
    */
-  transition: React.PropTypes.string,
+  transition: PropTypes.string,
   /*
    * Determines the styling of the notification. Possible values are "success" and "error". Defaults to "info".
    */
-  type: React.PropTypes.string,
+  type: PropTypes.string,
   /*
    * Determines how long the Notification stays before it disappears. a value of 0 will stay until the user dismisses it
    * by clicking the "X." Defaults to 6000 (6 seconds.)
    */
-  timeout: React.PropTypes.number,
+  timeout: PropTypes.number,
   /*
    * Unique identifier
    */
-  id: React.PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
   /*
    * Handler for hiding the Toast
    */
-  onHide: React.PropTypes.func,
+  onHide: PropTypes.func,
 };
 
 const defaultProps = {

--- a/src/components/Settings/NavList/NavList.js
+++ b/src/components/Settings/NavList/NavList.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import css from '../NavListSection/NavListSection.css';
 
 const propTypes = {
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(React.PropTypes.node),
-    React.PropTypes.node,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
   ]),
 };
 
@@ -22,7 +23,7 @@ class NavList extends React.Component {
     e.target.classList.add(css.active);
   }
 
-/* eslint-disable */   
+/* eslint-disable */
   render() {
     return (
       <nav ref={(ref) => { this.nav = ref; }} onClick={this.handleNavigationClick} >

--- a/src/components/Settings/NavListSection/NavListSection.js
+++ b/src/components/Settings/NavListSection/NavListSection.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import css from './NavListSection.css';
 
 const propTypes = {
-  label: React.PropTypes.string,
-  activeLink: React.PropTypes.string,
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(React.PropTypes.node),
-    React.PropTypes.node,
+  label: PropTypes.string,
+  activeLink: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
   ]),
 };
 

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Switch from 'react-router-dom/Switch';
 import Route from 'react-router-dom/Route';
 import Link from 'react-router-dom/Link';


### PR DESCRIPTION
This removes warnings generated like the following:

>Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs