### PR TITLE
[STCOR-46] Make Front page component pluggable.

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -95,6 +95,7 @@ class Root extends Component {
         user: currentUser,
         perms: currentPerms,
       },
+      connect(X) { return X; }
     });
 
     return (
@@ -106,8 +107,8 @@ class Root extends Component {
                 <MainNav stripes={stripes} />
                 <ModuleContainer id="content">
                   <Switch>
-                    <Route exact path="/" component={Front} key="root" />
-                    <Route path="/sso-landing" component={Front} key="sso-landing" />
+                    <Route exact path="/" component={()=> <Front stripes={stripes}/>} key="root" />
+                    <Route path="/sso-landing" component={()=> <Front stripes={stripes}/>} key="sso-landing" />
                     <Route path="/about" component={() => <About stripes={stripes} />} key="about" />
                     <Route path="/settings" render={() => <Settings stripes={stripes} />} />
                     {getModuleRoutes(stripes)}

--- a/src/components/Front.js
+++ b/src/components/Front.js
@@ -1,10 +1,27 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
+import AddContext from '../AddContext';
 
-export const Front = () => (
-  <div>
-    <h3>Welcome, the Future Of Libraries Is OPEN!</h3>
-    <p><Link to="/about">About</Link></p>
-  </div>
+// TODO: release version of @folio/stripes-components has a broken index.js
+// TODO: so just reach in and grab it from lib.
+// TODO: see https://github.com/folio-org/stripes-components/pull/39
+// import { Pluggable } from '@folio/stripes-components';
+import Pluggable from '@folio/stripes-components/lib/Pluggable';
+
+export const Front = ({ stripes }) => (
+  <AddContext context={{ stripes }}>
+    <Pluggable type="frontpage">
+      <div>
+        <h3>Welcome, the Future Of Libraries Is OPEN!</h3>
+        <p><Link to="/about">About</Link></p>
+      </div>
+    </Pluggable>
+  </AddContext>
 );
+
+Front.propTypes = {
+  stripes: PropTypes.object.isRequired
+};
+
 export default Front;


### PR DESCRIPTION
The landing page of a stripes application is the first thing that a user sees when they navigate to it. At the moment, there is a placeholder text there, but you can't customize that text.

This change adds a new type of plugin "frontpage" which, if present will be presented to the user.

![folio_ui_experimentation](https://user-images.githubusercontent.com/4205/29144241-d5b6a2e8-7d1d-11e7-9953-b019abfa6399.png)

Implementation Notes
====================

- if a plugged-in component is rendered in a stripes connected environment, the `Pluggable` component will attempt to connect the component that it wraps. However, if we're rendering outside the context of an app (as in the case of the frontpage), then the `connect()` method is not present on the stripes context. This adds a default `connect()` which passes through the original component without any decoration

- The `Front` component needed to be extended because it now needs to setup a context in order to support pluggability. We should consider having a default context that is set up at the very top of the render tree.