### PR TITLE
Set initial viewport state with meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Folio UI Experimentation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css">
   </head>
   <body>


### PR DESCRIPTION
## Before
Currently, opening a FOLIO application on a mobile browser will usually result in the page width being calculated as much wider than the device's screen (and zoomed out):

![before](https://user-images.githubusercontent.com/230597/29181082-7d0462d2-7dbf-11e7-9956-04a137d5db28.png)

## After
Instead, by default we can set the width of the page to equal the width of the device, with the zoom at 100%. Users can then zoom in more if needed. https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag

![after](https://user-images.githubusercontent.com/230597/29181104-8834b1c0-7dbf-11e7-9a3a-e5c5dd908880.png)
