### PR TITLE
[STCOR-47] Don't specify defaultProps twice.

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -186,12 +186,9 @@ Root.propTypes = {
 };
 
 Root.defaultProps = {
-  history: createBrowserHistory()
-};
-
-// TODO: remove after locale is accessible from a global config
-Root.defaultProps = {
-  locale: 'en-US',
+  history: createBrowserHistory(),
+  // TODO: remove after locale is accessible from a global config
+  locale: 'en-US'
 };
 
 function mapStateToProps(state) {


### PR DESCRIPTION
Because of automatic merging, the `Root.defaultProps` were specified twice, which caused the default browser history not to get created.

Sounds like we need some sore of automated sanity testing to catch integration issues like this one.