### PR TITLE
Move root component reducers reference to be instance specific

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -26,9 +26,11 @@ import { isVersionCompatible } from './discoverServices';
 import { setLocale, setSinglePlugin, setBindings, setOkapiToken } from './okapiActions';
 import { loadTranslations } from './loginServices';
 
-const reducers = { ...initialReducers };
-
 class Root extends Component {
+  constructor() {
+    super(...arguments);
+    this.reducers = { ...initialReducers };
+  }
 
   getChildContext() {
     return { addReducer: this.addReducer.bind(this) };
@@ -40,9 +42,9 @@ class Root extends Component {
   }
 
   addReducer = (key, reducer) => {
-    if (reducers[key] === undefined) {
-      reducers[key] = reducer;
-      this.props.store.replaceReducer(enhanceReducer(combineReducers({ ...reducers })));
+    if (this.reducers[key] === undefined) {
+      this.reducers[key] = reducer;
+      this.props.store.replaceReducer(enhanceReducer(combineReducers({ ...this.reducers })));
       return true;
     }
     return false;


### PR DESCRIPTION
If the Root component were to be mounted and unmounted any reducers
previously added would remain in the reducers object and so new
reducers with the same key would never be overridden.

This can be problematic during testing when you want a new app (and store)
instance for each test case. In those instances the new store reducers
are never added to the new store because their keys would be present
in the already existing reducers hash.

This change simply moves the reducers reference to be instance
specific. So when new instances of the Root component are created the
reducers hash is set to it's initial value.