### PR TITLE
STCOR-61 Update user retrieval after SSO login.

### DIFF
--- a/src/components/SSOLanding.js
+++ b/src/components/SSOLanding.js
@@ -21,10 +21,9 @@ class SSOLanding extends Component {
 
   componentWillMount() {
     const token = this.getToken();
-    const userId = this.getUserId();
 
-    if (token && userId) {
-      requestUserWithPermsDeb(this.okapiUrl, this.store, this.tenant, token, userId);
+    if (token) {
+      requestUserWithPermsDeb(this.okapiUrl, this.store, this.tenant, token);
     }
   }
 
@@ -40,27 +39,17 @@ class SSOLanding extends Component {
     return cookies.get('ssoToken') || params.ssoToken;
   }
 
-  getUserId() {
-    const params = this.getParams();
-    const cookies = this.props.cookies;
-    return cookies.get('userId') || params.userId;
-  }
-
   render() {
     const params = this.getParams();
     const token = this.getToken();
-    const userId = this.getUserId();
 
     if (!token) {
       return <div>No <tt>ssoToken</tt> cookie or query parameter</div>;
-    } else if (!userId) {
-      return <div>No <tt>UserId</tt> cookie or query parameter</div>;
     }
 
     return (
       <div>
         <p>Logged in with token <tt>{token}</tt> from {params.ssoToken ? 'param' : 'cookie'}</p>
-        <p>Logged in with user id <tt>{userId}</tt> from {params.userId ? 'param' : 'cookie'}</p>
       </div>
     );
   }

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -240,8 +240,8 @@ export function requestLogin(okapiUrl, store, tenant, data) {
   .then(resp => processOkapiSession(okapiUrl, store, tenant, resp));
 }
 
-export function requestUserWithPerms(okapiUrl, store, tenant, token, userId) {
-  fetch(`${okapiUrl}/bl-users/by-id/${userId}?expandPermissions=true&fullPermissions=true`,
+export function requestUserWithPerms(okapiUrl, store, tenant, token) {
+  fetch(`${okapiUrl}/bl-users/_self?expandPermissions=true&fullPermissions=true`,
     { headers: getHeaders(tenant, token) })
   .then(resp => processOkapiSession(okapiUrl, store, tenant, resp));
 }


### PR DESCRIPTION
The /_self endpoint should be used for retrieving the current user instead of the /bl-users/by-id/{userId} endpoint from mod-users-bl. If the latter is used the user is required to have a permission for retrieving the user.