### PR TITLE
STCOR-62 Redirect user to original url after SSO authentication

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -14,6 +14,7 @@ import ModuleContainer from './components/ModuleContainer';
 import Front from './components/Front';
 import About from './components/About';
 import SSOLanding from './components/SSOLanding';
+import SSORedirect from './components/SSORedirect';
 import Settings from './components/Settings/Settings';
 import LoginCtrl from './components/Login';
 import getModuleRoutes from './moduleRoutes';
@@ -34,6 +35,7 @@ const RootWithIntl = (props, context) => {
               <ModuleContainer id="content">
                 <Switch>
                   <Route exact path="/" component={() => <Front stripes={stripes} />} key="root" />
+                  <Route path="/sso-landing" component={() => <SSORedirect stripes={stripes} />} key="sso-landing" />
                   <Route path="/about" component={() => <About stripes={stripes} />} key="about" />
                   <Route path="/settings" render={() => <Settings stripes={stripes} />} />
                   {getModuleRoutes(stripes)}

--- a/src/components/SSORedirect.js
+++ b/src/components/SSORedirect.js
@@ -1,0 +1,35 @@
+import _ from 'lodash';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter, Redirect } from 'react-router';
+import queryString from 'query-string';
+
+class SSORedirect extends Component {
+
+  getParams() {
+    const search = this.props.location.search;
+    if (!search) return undefined;
+    return queryString.parse(search) || {};
+  }
+
+  getUrl() {
+    const params = this.getParams();
+    return params.fwd;
+  }
+
+  render() {
+    const forwardUrl = this.getUrl();
+    return (
+      <Redirect to={forwardUrl} />
+    );
+  }
+}
+
+SSORedirect.propTypes = {
+  // eslint-disable-next-line react/no-unused-prop-types
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }).isRequired,
+};
+
+export default withRouter(SSORedirect);

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -256,6 +256,8 @@ export function requestSSOLogin(okapiUrl, tenant) {
     stripesUrl = `${window.location.protocol}//${window.location.host}`;
   }
 
+  stripesUrl += window.location.pathname;
+
   fetch(`${okapiUrl}/saml/login`, {
     method: 'POST',
     headers: { 'X-Okapi-tenant': tenant, 'Content-Type': 'application/json' },

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -251,12 +251,7 @@ export function requestUserWithPerms(okapiUrl, store, tenant, token) {
 }
 
 export function requestSSOLogin(okapiUrl, tenant) {
-  let stripesUrl = window.location.origin;
-  if (!stripesUrl) {
-    stripesUrl = `${window.location.protocol}//${window.location.host}`;
-  }
-
-  stripesUrl += window.location.pathname;
+  const stripesUrl = (window.location.origin || `${window.location.protocol}//${window.location.host}`) + window.location.pathname;
 
   fetch(`${okapiUrl}/saml/login`, {
     method: 'POST',


### PR DESCRIPTION
A new component was created to redirect the user from the /sso-landing page after login to the original url. Also the path of the original login request is preserved (in loginServices).