### PR TITLE
Allow for contextual epics

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -16,10 +16,11 @@ class Root extends Component {
   constructor(...args) {
     super(...args);
     this.reducers = { ...initialReducers };
+    this.epics = {};
   }
 
   getChildContext() {
-    return { addReducer: this.addReducer.bind(this) };
+    return { addReducer: this.addReducer, addEpic: this.addEpic };
   }
 
   componentWillMount() {
@@ -40,6 +41,16 @@ class Root extends Component {
       return true;
     }
     return false;
+  }
+
+  addEpic = (key, epic) => {
+    if (this.epics[key] === undefined) {
+      this.epics[key] = epic;
+      this.props.epics.add(epic);
+      return true;
+    } else {
+      return false;
+    }
   }
 
   render() {
@@ -79,6 +90,7 @@ class Root extends Component {
 
 Root.childContextTypes = {
   addReducer: PropTypes.func,
+  addEpic: PropTypes.func
 };
 
 Root.propTypes = {

--- a/src/configureEpics.js
+++ b/src/configureEpics.js
@@ -1,4 +1,4 @@
-import { configureEpics } from '@folio/stripes-redux';
+import { configureEpics as _configureEpics } from '@folio/stripes-redux';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/throttleTime';
@@ -7,7 +7,6 @@ import 'rxjs/add/operator/take';
 
 import connectErrorEpic from './connectErrorEpic';
 
-const epics = configureEpics();
-epics.add(connectErrorEpic);
-
-export default epics;
+export default function configureEpics() {
+  return _configureEpics(connectErrorEpic);
+}

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -3,9 +3,8 @@ import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
 import initialReducers from './initialReducers';
 import enhanceReducer from './enhanceReducer';
-import epics from './epics';
 
-export default function configureStore(initialState, stripesLogger) {
+export default function configureStore(initialState, stripesLogger, epics) {
   const logger = createLogger({
     // Show logging unless explicitly set false
     predicate: () => stripesLogger.hasCategory('redux'),

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import { okapi, config } from 'stripes-loader'; // eslint-disable-line
 
-import epics from './epics';
+import configureEpics from './configureEpics';
 import configureLogger from './configureLogger';
 import configureStore from './configureStore';
 import { discoverServices } from './discoverServices';
@@ -12,9 +12,10 @@ import gatherActions from './gatherActions';
 import Root from './Root';
 
 const initialState = { okapi };
+const epics = configureEpics();
 const logger = configureLogger(config);
 logger.log('core', 'Starting Stripes ...');
-const store = configureStore(initialState, logger);
+const store = configureStore(initialState, logger, epics);
 discoverServices(okapi.url, store);
 const actionNames = gatherActions();
 


### PR DESCRIPTION
### Background

As an application container, Stripes cannot know ahead of time which epics will be installed into its Redux middleware. Because of that, if apps or extensions are going to use epics, then they will need to have a way to add them from within their own lifecycle. E.g. when the application component mounts, it can communicate which epics it contains.

Furthermore, it is a possibility that a stripes application contained by the platform will be mounted and unmounted several times, and so the extension mechanism must not "overinstall" epics as the user navigates to and from an application so that they end up being run in duplicate, triplicate, etc...

### Approach

This change contains two enhancements. First, the epics Redux middleware was removed from being held as a static constant in the `src/epics` module definition (which amounts to basically being a shared mutable global value). Following the established pattern for the logger and store, you now have a factory method `configureEpics()` which ensures a new instance every time. Now every `Root` object gets its own epics that can live and die with it. This is particularly important for testing, where there might be thousands of roots.

Next, a function `addEpic(key, epic)` is added to the context which installs an epic idemptotently. Follows the pattern of `addReducer`, if `addEpic` is called more than once with the same key, it is safely ignored.