### PR TITLE
Fix redux devtools compose

### DIFF
--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -4,19 +4,15 @@ import { createLogger } from 'redux-logger';
 import initialReducers from './initialReducers';
 import enhanceReducer from './enhanceReducer';
 
+const enhanceMiddleware = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
 export default function configureStore(initialState, stripesLogger, epics) {
   const logger = createLogger({
     // Show logging unless explicitly set false
     predicate: () => stripesLogger.hasCategory('redux'),
   });
   const reducer = enhanceReducer(combineReducers(initialReducers));
-  const middleware = applyMiddleware(thunk, logger, epics.middleware);
- /* eslint-disable no-underscore-dangle */
-  const createStoreWithMiddleware = compose(
-    middleware,
-      window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f,
-    );
-  /* eslint-enable */
+  const middleware = enhanceMiddleware(applyMiddleware(thunk, logger, epics.middleware));
 
-  return createStoreWithMiddleware(createStore)(reducer, initialState, middleware);
+  return createStore(reducer, initialState, middleware);
 }


### PR DESCRIPTION
The previous method of composing the middleware would call the middleware initializers twice, and so a side-effect of this was that epics would receive double the actions.

This changes the compose method to use redux devtool's own compose (according to [their docs](https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup)) and thus fixes the double epic calls.

This also fixes the logger logging itself (the `PERFORM_ACTION` action in the first gif below).

### Before
![bug](https://user-images.githubusercontent.com/5005153/30073255-c7bf1b14-9232-11e7-8e93-80e1976e9cc4.gif)

### After
![fix](https://user-images.githubusercontent.com/5005153/30073350-19c739be-9233-11e7-85c4-c6213833c091.gif)

