### PR TITLE
Wait until discovery is finished before rendering the module container

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -120,6 +120,7 @@ Root.propTypes = {
   discovery: PropTypes.shape({
     modules: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     interfaces: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    isFinished: PropTypes.boolean,
   }),
   history: PropTypes.shape({
     length: PropTypes.number.isRequired,

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -32,21 +32,23 @@ const RootWithIntl = (props, context) => {
           { token || disableAuth ?
             <MainContainer>
               <MainNav stripes={stripes} />
-              <ModuleContainer id="content">
-                <Switch>
-                  <Route exact path="/" component={() => <Front stripes={stripes} />} key="root" />
-                  <Route path="/sso-landing" component={() => <SSORedirect stripes={stripes} />} key="sso-landing" />
-                  <Route path="/about" component={() => <About stripes={stripes} />} key="about" />
-                  <Route path="/settings" render={() => <Settings stripes={stripes} />} />
-                  {getModuleRoutes(stripes)}
-                  <Route
-                    component={() => (<div>
-                      <h2>Uh-oh!</h2>
-                      <p>This route does not exist.</p>
-                    </div>)}
-                  />
-                </Switch>
-              </ModuleContainer>
+              { stripes.discovery.isFinished && (
+                <ModuleContainer id="content">
+                  <Switch>
+                    <Route exact path="/" component={() => <Front stripes={stripes} />} key="root" />
+                    <Route path="/sso-landing" component={() => <SSORedirect stripes={stripes} />} key="sso-landing" />
+                    <Route path="/about" component={() => <About stripes={stripes} />} key="about" />
+                    <Route path="/settings" render={() => <Settings stripes={stripes} />} />
+                    {getModuleRoutes(stripes)}
+                    <Route
+                      component={() => (<div>
+                        <h2>Uh-oh!</h2>
+                        <p>This route does not exist.</p>
+                      </div>)}
+                    />
+                  </Switch>
+                </ModuleContainer>
+              )}
             </MainContainer> :
             <Switch>
               <Route exact path="/sso-landing" component={() => <CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>} key="sso-landing" />


### PR DESCRIPTION
## Problem

Application modules can be rendered before the services that they depend on have been discovered. The `discoverServices` thunk can potentially dispatch multiple `DISCOVERY_SUCCESS` and `DISCOVERY_FAILURE` actions while discovery is happening, but there is no action to mark when the discovery process is fully complete. Without this capability, it is possible for an application to render without knowing if its dependencies are satisfied on the backend.

## Approach

This ensures that whenever a promise is generated inside the discovery process, it is returned so that it can be used for sequencing further promises. Then, once the discovery process is complete, a final `DISCOVERY_COMPLETE` is dispatched. Because individual discovery errors are caught, this will happen regardless of whether the discovery partially failed.

To signal readiness to application modules, the `discovery.isFinished` property is added to the redux state, and app modules are _only rendered if discovery is complete_

## Topics for further discussion

- refactor the discovery process to use redux-observable epics.
- finer grained tracking of which components have been discovered. That way, if my app only needs a single interface, I don't need to wait for others to be discovered.
- have OKAPI gateway make all discovery information available in a single request (unlike the 10+ it makes now.)