### PR TITLE
Switch to babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-2", "react"]
+  "presets": ["env", "stage-2", "react"]
 }

--- a/examples/trivial/package.json
+++ b/examples/trivial/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.0.0",
-    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-loader": "^7.0.0",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-polyfill": "^6.16.0",
-    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-2": "^6.16.0",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -45,13 +45,13 @@ module.exports = {
           // fn is the path after all symlinks are resolved so we need to be
           // wary of all the edge cases yarn link will find for us.
           const nmidx = fn.lastIndexOf('node_modules')
-          if (fn.endsWith('.js') && (nmidx === -1 || fn.lastIndexOf('@folio') > nmidx)) return true 
+          if (fn.endsWith('.js') && (nmidx === -1 || fn.lastIndexOf('@folio') > nmidx)) return true
         },
         loader: 'babel-loader',
         options: {
           cacheDirectory: true,
           presets: [
-            [require.resolve("babel-preset-es2015"), { modules: false }],
+            [require.resolve("babel-preset-env"), { modules: false }],
             [require.resolve("babel-preset-stage-2")],
             [require.resolve("babel-preset-react")]
           ]


### PR DESCRIPTION
By default, `babel-preset-env` will continue to have the same behavior we had with `babel-preset-es2015`. It has additional options for delivering more modern JavaScript, depending on the browser configuration provided.

Switching will eliminate this warning:
`We're super 😸  excited that you're trying to use ES2015 syntax, but instead of continuing yearly presets 😭 , we recommend using babel-preset-env: npm install babel-preset-env. preset-env without options will compile ES2015+ down to ES5. And by targeting specific browsers, Babel can do less work and you can ship native ES2015+ to users 😎 ! Also, we are in the process of releasing v7, so give http://babeljs.io/blog/2017/09/12/planning-for-7.0 a read and test it! Thanks so much for using Babel 🙏 , please give us a follow @babeljs for updates, join slack.babeljs.io for discussion and help support at opencollective.com/babel`