### PR TITLE
Stcor 85 exit code

### DIFF
--- a/stripes.js
+++ b/stripes.js
@@ -34,6 +34,7 @@ function processStats(err, stats) {
     chunks: false,
     colors: true
   }));
+  // Check for webpack compile errors and exit
   if(err || stats.hasErrors()){
     process.exit(1);
   }

--- a/stripes.js
+++ b/stripes.js
@@ -34,6 +34,9 @@ function processStats(err, stats) {
     chunks: false,
     colors: true
   }));
+  if(err || stats.hasErrors()){
+    process.exit(1);
+  }
 }
 
 commander


### PR DESCRIPTION
Builds with webpack compilation errors were passing CI because of a missing exit code.  Fixes STCOR-85