### PR TITLE
STCOR-86 Add connect-history-api-fallback to stripes dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-preset-stage-2": "^6.16.0",
     "bootstrap": "^3.3.7",
     "commander": "^2.9.0",
+    "connect-history-api-fallback": "^1.3.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.4",
     "express": "^4.14.0",

--- a/stripes.js
+++ b/stripes.js
@@ -67,6 +67,10 @@ commander
 
     app.use(express.static(__dirname + '/public'));
 
+    // Process index rewrite before webpack-dev-middleware
+    // to respond with webpack's dist copy of index.html
+    app.use(require('connect-history-api-fallback')({}));
+
     app.use(require('webpack-dev-middleware')(compiler, {
       noInfo: true,
       publicPath: config.output.publicPath
@@ -76,10 +80,6 @@ commander
 
     app.get('/favicon.ico', function(req, res) {
       res.sendFile(path.join(__dirname, 'favicon.ico'));
-    });
-
-    app.get('*', function(req, res) {
-      res.sendFile(path.join(__dirname, 'index.html'));
     });
 
     app.listen(port, host, function(err) {


### PR DESCRIPTION
This allows direct requests to routes such as /users to fallback to webpack's built version of index.html.  The previous res.sendFile() is no longer sufficient because we need the copy of index that webpack has in memory and not the version on disk.  Fixes STCOR-86