### PR TITLE
Delint padded block

### DIFF
--- a/src/Stripes.js
+++ b/src/Stripes.js
@@ -60,7 +60,6 @@ class Stripes {
   extendStripesProps(Module, extraProps = {}) {
     return props => <Module {...props} stripes={this.clone(extraProps)} />;
   }
-
 }
 
 export default Stripes;


### PR DESCRIPTION
Fixes padded-block violation.

*before*
```
$ yarn lint                                                                           
yarn lint v1.0.2
$ eslint src || true

/Code/stripes-core/src/Stripes.js
  64:1  error  Block must not be padded by blank lines  padded-blocks

✖ 1 problem (1 error, 0 warnings)
  1 error, 0 warnings potentially fixable with the `--fix` option.

✨  Done in 3.27s.
```

*after*

```
$ yarn lint                                                                           
yarn lint v1.0.2
$ eslint src || true
✨  Done in 3.19s.
```