### PR TITLE
fill in global styles to facilitate deprecation of bootstrap styles

### DIFF
--- a/src/components/MainContainer/global.css
+++ b/src/components/MainContainer/global.css
@@ -6,14 +6,56 @@
 
 body, html{
     height: 100%;
+    margin: 0;
     /*font-family: 'Open Sans', sans-serif;*/
     font-family: -apple-system,  BlinkMacSystemFont, "Segoe UI", Noto, DroidSans, Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", /*specific Arabic fonts */ "Adobe Arabic", "Myriad Arabic", /*specific other fonts */ "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", メイリオ, Meiryo, "ＭＳ Ｐゴシック", sans-serif;
     font-size: 14px;
+    color: #444;
     -webkit-font-smoothing: antialiased; 
 }
 
 #root{
     height: 100%;
+}
+
+a{
+    text-decoration: none;
+}
+
+fieldset{
+    border: none;
+}
+
+legend{
+    font-size: 1.3em;
+    font-weight: bold;
+}
+
+h1{
+    font-size: 1.9rem;
+}
+h2{
+    font-size: 1.7rem;
+}
+h3{
+    font-size: 1.5rem;
+}
+h4{
+    font-size: 1.3rem;
+}
+h5{
+    font-size: 1.1rem;
+}
+h6{
+    font-size: 1rem;
+}
+
+#root{
+    height: 100%;
+}
+
+ul{
+    margin: 0 0 14px 0;
 }
 
 hr{border: 1px solid #cdcdcd;


### PR DESCRIPTION
Basic fill-in to ease the brunt of some changes due to removal of bootstrap.css here: https://github.com/folio-org/stripes-core/pull/61