### PR TITLE
Turn on CSS source maps

### DIFF
--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -33,9 +33,17 @@ devConfig.module.rules.push({
   use: [
     {
       loader: 'style-loader',
+      options: {
+        sourceMap: true,
+      },
     },
     {
-      loader: 'css-loader?modules&localIdentName=[local]---[hash:base64:5]',
+      loader: 'css-loader',
+      options: {
+        localIdentName: '[local]---[hash:base64:5]',
+        modules: true,
+        sourceMap: true,
+      },
     },
     {
       loader: 'postcss-loader',
@@ -51,6 +59,7 @@ devConfig.module.rules.push({
           postCssMediaMinMax(),
           postCssColorFunction(),
         ],
+        sourceMap: true,
       },
     },
   ],

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -32,7 +32,11 @@ prodConfig.module.rules.push({
     fallback: 'style-loader',
     use: [
       {
-        loader: 'css-loader?modules&localIdentName=[local]---[hash:base64:5]',
+        loader: 'css-loader',
+        options: {
+          localIdentName: '[local]---[hash:base64:5]',
+          modules: true,
+        },
       },
       {
         loader: 'postcss-loader',


### PR DESCRIPTION
## Purpose
Source mapping will make CSS debugging much easier.

## Approach
- Set `sourceMap` to true for each of the webpack style loaders in a dev environment.
- Do not deliver source maps in a production build.

## Learning
https://github.com/postcss/postcss-loader#sourcemap

### Screenshots
#### Before
![before](https://user-images.githubusercontent.com/230597/31726849-a572243e-b3ed-11e7-9a40-46d027d04ef2.png)

#### After
![after](https://user-images.githubusercontent.com/230597/31726856-a8036f28-b3ed-11e7-8ba6-685a2df8cccc.png)