### PR TITLE
Fix promise catch order

### DIFF
--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -9,9 +9,7 @@ import 'isomorphic-fetch';
 
 function discoverInterfaces(okapiUrl, store, entry) {
   return fetch(`${okapiUrl}/_/proxy/modules/${entry.id}`)
-    .catch((reason) => {
-      store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
-    }).then((response) => { // eslint-disable-line consistent-return
+    .then((response) => { // eslint-disable-line consistent-return
       if (response.status >= 400) {
         store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
       } else {
@@ -19,15 +17,15 @@ function discoverInterfaces(okapiUrl, store, entry) {
           store.dispatch({ type: 'DISCOVERY_INTERFACES', data: json });
         });
       }
+    }).catch((reason) => {
+      store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
     });
 }
 
 export function discoverServices(okapiUrl, store) {
   return Promise.all([
     fetch(`${okapiUrl}/_/version`)
-      .catch((reason) => {
-        store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
-      }).then((response) => { // eslint-disable-line consistent-return
+      .then((response) => { // eslint-disable-line consistent-return
         if (response.status >= 400) {
           store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
         } else {
@@ -35,11 +33,11 @@ export function discoverServices(okapiUrl, store) {
             store.dispatch({ type: 'DISCOVERY_OKAPI', version: text });
           });
         }
+      }).catch((reason) => {
+        store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
       }),
     fetch(`${okapiUrl}/_/proxy/modules`)
-      .catch((reason) => {
-        store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
-      }).then((response) => { // eslint-disable-line consistent-return
+      .then((response) => { // eslint-disable-line consistent-return
         if (response.status >= 400) {
           store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
         } else {
@@ -48,6 +46,8 @@ export function discoverServices(okapiUrl, store) {
             return Promise.all(json.map(entry => discoverInterfaces(okapiUrl, store, entry)));
           });
         }
+      }).catch((reason) => {
+        store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
       }),
   ]).then(() => {
     store.dispatch({ type: 'DISCOVERY_FINISHED' });


### PR DESCRIPTION
## Purpose 
When you catch a promise, it does not stop the propagation of a chain. This allows you to handle errors before continuing the chain.

So when the discovery promises were failing and getting caught, the following `.then` chains were still called, except with the argument returned from the catch statement. Since the catch statements do not return anything, the resulting `response` is `undefined`. So properties like `response.status` throw errors.

## Approach
This simply moves those catch statements to be at the end of their respective chains so when a failure occurs it does not continue. If the promise is rejected before a preceding `then` block, that block will be skipped and the promise will immediately call the first `catch` statement it sees.

## Learning
[MDN - Using Promises (Chaining after a catch)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#Chaining_after_a_catch)