### PR TITLE
Label a tenant's disabled modules on `/about`. Fixes STCOR-69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Move epics to core. STCOR-82.
 * Move stripes-loader logic into stripes-core as a webpack plugin. STCOR-25.
 * Trivial app uses props.resources, not props.data. Fixes STCOR-92.
+* Label a tenant's disabled modules on `/about`. Fixes STCOR-69.
 
 ## [2.7.0](https://github.com/folio-org/stripes-core/tree/v2.7.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.6.1...v2.7.0)
@@ -269,4 +270,3 @@
 
 * Requires v0.0.9 of `stripes-connect`.
 * First version to have a documented change-log. Each subsequent version will describe its differences from the previous one.
-

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import { CookiesProvider } from 'react-cookie';
 import { HotKeys } from '@folio/stripes-components/lib/HotKeys';
 import { intlShape } from 'react-intl';
+import { connectFor } from '@folio/stripes-connect';
 
 import MainContainer from './components/MainContainer';
 import MainNav from './components/MainNav';
@@ -20,49 +21,65 @@ import LoginCtrl from './components/Login';
 import getModuleRoutes from './moduleRoutes';
 import { stripesShape } from './Stripes';
 
-const RootWithIntl = (props, context) => {
-  const intl = context.intl;
-  const stripes = props.stripes.clone({ intl });
-  const { token, disableAuth, history } = props;
 
-  return (
-    <HotKeys keyMap={stripes.bindings} noWrapper>
-      <Provider store={stripes.store}>
-        <Router history={history}>
-          { token || disableAuth ?
-            <MainContainer>
-              <MainNav stripes={stripes} />
-              { stripes.discovery.isFinished && (
-                <ModuleContainer id="content">
-                  <Switch>
-                    <Route exact path="/" component={() => <Front stripes={stripes} />} key="root" />
-                    <Route path="/sso-landing" component={() => <SSORedirect stripes={stripes} />} key="sso-landing" />
-                    <Route path="/about" component={() => <About stripes={stripes} />} key="about" />
-                    <Route path="/settings" render={() => <Settings stripes={stripes} />} />
-                    {getModuleRoutes(stripes)}
-                    <Route
-                      component={() => (<div>
-                        <h2>Uh-oh!</h2>
-                        <p>This route does not exist.</p>
-                      </div>)}
-                    />
-                  </Switch>
-                </ModuleContainer>
-              )}
-            </MainContainer> :
-            <Switch>
-              <Route exact path="/sso-landing" component={() => <CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>} key="sso-landing" />
-              <Route component={() => <LoginCtrl autoLogin={stripes.config.autoLogin} />} />
-            </Switch>
-          }
-        </Router>
-      </Provider>
-    </HotKeys>
-  );
-};
+class RootWithIntl extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    const intl = context.intl;
+    this.stripes = props.stripes.clone({ intl });
+  }
+
+  getChildContext() {
+    return { coreConnect: connectFor('@folio/core', this.stripes.epics, this.stripes.logger) };
+  }
+
+  render() {
+    const { token, disableAuth, history } = this.props;
+    const stripes = this.stripes;
+    return (
+      <HotKeys keyMap={stripes.bindings} noWrapper>
+        <Provider store={stripes.store}>
+          <Router history={history}>
+            { token || disableAuth ?
+              <MainContainer>
+                <MainNav stripes={stripes} />
+                { stripes.discovery.isFinished && (
+                  <ModuleContainer id="content">
+                    <Switch>
+                      <Route exact path="/" component={() => <Front stripes={stripes} />} key="root" />
+                      <Route path="/sso-landing" component={() => <SSORedirect stripes={stripes} />} key="sso-landing" />
+                      <Route path="/about" component={() => <About stripes={stripes} />} key="about" />
+                      <Route path="/settings" render={() => <Settings stripes={stripes} />} />
+                      {getModuleRoutes(stripes)}
+                      <Route
+                        component={() => (<div>
+                          <h2>Uh-oh!</h2>
+                          <p>This route does not exist.</p>
+                        </div>)}
+                      />
+                    </Switch>
+                  </ModuleContainer>
+                )}
+              </MainContainer> :
+              <Switch>
+                <Route exact path="/sso-landing" component={() => <CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>} key="sso-landing" />
+                <Route component={() => <LoginCtrl autoLogin={stripes.config.autoLogin} />} />
+              </Switch>
+            }
+          </Router>
+        </Provider>
+      </HotKeys>
+    );
+  }
+}
 
 RootWithIntl.contextTypes = {
   intl: intlShape.isRequired,
+};
+
+RootWithIntl.childContextTypes = {
+  coreConnect: PropTypes.func,
 };
 
 RootWithIntl.propTypes = {

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -14,8 +14,9 @@ import Pane from '@folio/stripes-components/lib/Pane';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 
 import { isVersionCompatible } from '../discoverServices';
+import AboutEnabledModules from './AboutEnabledModules';
 
-const About = (props) => {
+const About = (props, context) => {
   function renderDependencies(m, interfaces) {
     const base = `${m.module} ${m.version}`;
     if (!interfaces) {
@@ -68,6 +69,8 @@ const About = (props) => {
   const nm = Object.keys(modules).length;
   const ni = Object.keys(interfaces).length;
 
+  const ConnectedAboutEnabledModules = context.coreConnect(AboutEnabledModules);
+
   return (
     <Paneset>
       <Pane defaultWidth="30%" paneTitle="User interface">
@@ -96,9 +99,14 @@ const About = (props) => {
           <li>On URL {_.get(props.stripes, ['okapi', 'url']) || 'unknown'}</li>
         </ul>
         <h4>{nm} module{nm === 1 ? '' : 's'}</h4>
-        <ul>
-          {Object.keys(modules).sort().map(key => <li key={key}>{modules[key]} (<tt>{key}</tt>)</li>)}
-        </ul>
+        <ConnectedAboutEnabledModules tenantid={_.get(props.stripes, ['okapi', 'tenant']) || 'unknown'} availableModules={modules} />
+        <p>
+          <b>Key.</b>
+          <br />
+          Installed modules that are not enabled for this tenant are
+          displayed <span style={{ textDecoration: 'line-through' }}>struck
+          through</span>.
+        </p>
 
         <h4>{ni} interface{ni === 1 ? '' : 's'}</h4>
         <ul>
@@ -136,6 +144,10 @@ About.propTypes = {
       interfaces: PropTypes.object,
     }),
   }).isRequired,
+};
+
+About.contextTypes = {
+  coreConnect: PropTypes.func,
 };
 
 export default About;

--- a/src/components/AboutEnabledModules.js
+++ b/src/components/AboutEnabledModules.js
@@ -1,0 +1,44 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class AboutEnabledModules extends React.Component {
+  static propTypes = {
+    resources: PropTypes.shape({
+      enabledModules: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
+    }),
+    availableModules: PropTypes.object,
+    tenantid: PropTypes.string.isRequired, // eslint-disable-line
+  };
+
+  static manifest = Object.freeze({
+    enabledModules: {
+      type: 'okapi',
+      path: '_/proxy/tenants/!{tenantid}/modules',
+    },
+  });
+
+  render() {
+    const em = {};
+    _.each((this.props.resources.enabledModules || {}).records || [], (m) => { em[m.id] = true; });
+
+    return (
+      <ul>
+        {
+          Object.keys(this.props.availableModules).sort().map((key) => {
+            let style = {};
+            if (!em[key]) {
+              style = { textDecoration: 'line-through' };
+            }
+
+            return <li key={key} style={style}>{this.props.availableModules[key]} (<tt>{key}</tt>)</li>;
+          })
+        }
+      </ul>
+    );
+  }
+}
+
+export default AboutEnabledModules;


### PR DESCRIPTION
In order to label a tenant's disabled modules, we need to be able to
query Okapi from within stripes-core, but `stripes.connect()`, which is
actually the result of calling `connectFor('@folio/some-module')` for
each dynamically-loaded module, wasn't available within stripes-core.

The approach taken here was to hard-code a call to
`connectFor('@folio/core')` and stash it in the context. The benefit of
using context is that we stash it in one place and every component that
wants it just specifies a static `contextTypes = { coreConnect:
PropTypes.func,}` element. The downside is that connecting a component
in stripes-core is now slightly different than connecting a component in
an app even though the end result is the same.

RootWithIntl had to be refactored into a stateful component because
of how `getChildContext` is implemented; `context` is not avaiable in
child components if the context is defined on a stateless component.

Note: To disable a module for a tenant, issue an empty DELETE request for the module, e.g. `http://localhost:9130/_/proxy/tenants/diku/modules/mod-notes-2.0.1-SNAPSHOT.29`. 

To enable a module for a tenant, issue a POST request to `http://localhost:9130/_/proxy/tenants/diku/modules` with the module-id in the body, e.g. 
```
{
	"id": "mod-notes-2.0.1-SNAPSHOT.29"
}
```
