### PR TITLE
Label a tenant's disabled modules on `/about`. Fixes STCOR-69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Move epics to core. STCOR-82.
 * Move stripes-loader logic into stripes-core as a webpack plugin. STCOR-25.
 * Trivial app uses props.resources, not props.data. Fixes STCOR-92.
+* Label a tenant's disabled modules on `/about`. Fixes STCOR-69.
 
 ## [2.7.0](https://github.com/folio-org/stripes-core/tree/v2.7.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.6.1...v2.7.0)
@@ -269,4 +270,3 @@
 
 * Requires v0.0.9 of `stripes-connect`.
 * First version to have a documented change-log. Each subsequent version will describe its differences from the previous one.
-

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -6,6 +6,7 @@ import Switch from 'react-router-dom/Switch';
 import { Provider } from 'react-redux';
 import { CookiesProvider } from 'react-cookie';
 import { HotKeys } from '@folio/stripes-components/lib/HotKeys';
+import { connectFor } from '@folio/stripes-connect';
 import { intlShape } from 'react-intl';
 
 import MainContainer from './components/MainContainer';
@@ -22,7 +23,8 @@ import { stripesShape } from './Stripes';
 
 const RootWithIntl = (props, context) => {
   const intl = context.intl;
-  const stripes = props.stripes.clone({ intl });
+  const connect = connectFor('@folio/core', props.stripes.epics, props.stripes.logger)
+  const stripes = props.stripes.clone({ intl, connect });
   const { token, disableAuth, history } = props;
 
   return (

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -23,7 +23,7 @@ import { stripesShape } from './Stripes';
 
 const RootWithIntl = (props, context) => {
   const intl = context.intl;
-  const connect = connectFor('@folio/core', props.stripes.epics, props.stripes.logger)
+  const connect = connectFor('@folio/core', props.stripes.epics, props.stripes.logger);
   const stripes = props.stripes.clone({ intl, connect });
   const { token, disableAuth, history } = props;
 

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -12,8 +12,8 @@ import stripesLogger from '@folio/stripes-logger/package.json';
 
 import Pane from '@folio/stripes-components/lib/Pane';
 import Paneset from '@folio/stripes-components/lib/Paneset';
-
 import { isVersionCompatible } from '../discoverServices';
+import AboutEnabledModules from './AboutEnabledModules';
 
 const About = (props) => {
   function renderDependencies(m, interfaces) {
@@ -67,6 +67,7 @@ const About = (props) => {
   const interfaces = _.get(props.stripes, ['discovery', 'interfaces']) || {};
   const nm = Object.keys(modules).length;
   const ni = Object.keys(interfaces).length;
+  const ConnectedAboutEnabledModules = props.stripes.connect(AboutEnabledModules);
 
   return (
     <Paneset>
@@ -96,9 +97,14 @@ const About = (props) => {
           <li>On URL {_.get(props.stripes, ['okapi', 'url']) || 'unknown'}</li>
         </ul>
         <h4>{nm} module{nm === 1 ? '' : 's'}</h4>
-        <ul>
-          {Object.keys(modules).sort().map(key => <li key={key}>{modules[key]} (<tt>{key}</tt>)</li>)}
-        </ul>
+        <ConnectedAboutEnabledModules tenantid={_.get(props.stripes, ['okapi', 'tenant']) || 'unknown'} availableModules={modules} />
+        <p>
+          <b>Key.</b>
+          <br />
+          Installed modules that are not enabled for this tenant are
+           displayed <span style={{ textDecoration: 'line-through' }}>struck
+           through</span>.
+         </p>
 
         <h4>{ni} interface{ni === 1 ? '' : 's'}</h4>
         <ul>

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -102,9 +102,9 @@ const About = (props) => {
           <b>Key.</b>
           <br />
           Installed modules that are not enabled for this tenant are
-           displayed <span style={{ textDecoration: 'line-through' }}>struck
-           through</span>.
-         </p>
+          displayed <span style={{ textDecoration: 'line-through' }}>struck
+          through</span>.
+        </p>
 
         <h4>{ni} interface{ni === 1 ? '' : 's'}</h4>
         <ul>
@@ -141,6 +141,7 @@ About.propTypes = {
       modules: PropTypes.object,
       interfaces: PropTypes.object,
     }),
+    connect: PropTypes.func,
   }).isRequired,
 };
 

--- a/src/components/AboutEnabledModules.js
+++ b/src/components/AboutEnabledModules.js
@@ -1,0 +1,44 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class AboutEnabledModules extends React.Component {
+  static propTypes = {
+    resources: PropTypes.shape({
+      enabledModules: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
+    }),
+    availableModules: PropTypes.object,
+    tenantid: PropTypes.string.isRequired, // eslint-disable-line
+  };
+
+  static manifest = Object.freeze({
+    enabledModules: {
+      type: 'okapi',
+      path: '_/proxy/tenants/!{tenantid}/modules',
+    },
+  });
+
+  render() {
+    const em = {};
+    _.each((this.props.resources.enabledModules || {}).records || [], (m) => { em[m.id] = true; });
+
+    return (
+      <ul>
+        {
+          Object.keys(this.props.availableModules).sort().map((key) => {
+            let style = {};
+            if (!em[key]) {
+              style = { textDecoration: 'line-through' };
+            }
+
+            return <li key={key} style={style}>{this.props.availableModules[key]} (<tt>{key}</tt>)</li>;
+          })
+        }
+      </ul>
+    );
+  }
+}
+
+export default AboutEnabledModules;


### PR DESCRIPTION
In order to label a tenant's disabled modules, we need to be able to
query Okapi from within stripes-core, but `stripes.connect()`, which is
actually the result of calling `connectFor('@folio/some-module')` for
each dynamically-loaded module, wasn't available within stripes-core.

The approach taken here was to hard-code a call to
`connectFor('@folio/core')` on `RootWithIntl` and to replace the dummy
version of `stripes.connect` with the result of that call, as is done in
`moduleRoutes.js::getModuleRoutes()` for dynamically loaded modules.
This is in contrast to the approach taken in PR #81 where `connect` was
placed in the context rather than directly on the cloned stripes object.