### PR TITLE
STCOR-29 move build logic

### DIFF
--- a/stripes.js
+++ b/stripes.js
@@ -1,35 +1,11 @@
 #!/usr/bin/env node
 
 const commander = require('commander');
-const webpack = require('webpack');
-const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const path = require('path');
-const nodeObjectHash = require('node-object-hash');
-const express = require('express');
-const webpackDevMiddleware = require('webpack-dev-middleware');
-const webpackHotMiddleware = require('webpack-hot-middleware');
-const connectHistoryApiFallback = require('connect-history-api-fallback');
-
-const StripesConfigPlugin = require('./webpack/stripes-config-plugin');
-
-const cwd = path.resolve();
-const cwdModules = path.join(cwd, 'node_modules');
-const coreModules = path.join(__dirname, 'node_modules');
-
+const stripes = require('./webpack/stripes-node-api');
 const packageJSON = require('./package.json');
 
 commander.version(packageJSON.version);
-
-const cachePlugin = new HardSourceWebpackPlugin({
-  cacheDirectory: path.join(cwd, 'webpackcache'),
-  recordsPath: path.join(cwd, 'webpackcache/records.json'),
-  configHash(webpackConfig) {
-    // Build a string value used by HardSource to determine which cache to
-    // use if [confighash] is in cacheDirectory or if the cache should be
-    // replaced if [confighash] does not appear in cacheDirectory.
-    return nodeObjectHash().hash(webpackConfig);
-  },
-});
 
 // Display webpack output to the console
 function processStats(err, stats) {
@@ -55,46 +31,8 @@ commander
   .arguments('<config>')
   .description('Launch a webpack-dev-server')
   .action((stripesConfigFile, options) => {
-    const app = express();
-    const devConfig = require('./webpack.config.cli.dev'); // eslint-disable-line
-    const config = Object.assign({}, devConfig);
     const stripesConfig = require(path.resolve(stripesConfigFile)); // eslint-disable-line
-    config.plugins.push(new StripesConfigPlugin(stripesConfig));
-    // Look for modules in node_modules, then the platform, then stripes-core
-    config.resolve.modules = ['node_modules', cwdModules, coreModules];
-    config.resolveLoader = { modules: ['node_modules', cwdModules, coreModules] };
-    if (options.cache) config.plugins.push(cachePlugin);
-    if (options.devtool) config.devtool = options.devtool;
-    const compiler = webpack(config);
-
-    const port = options.port || process.env.STRIPES_PORT || 3000;
-    const host = options.host || process.env.STRIPES_HOST || 'localhost';
-
-    app.use(express.static(`${__dirname}/public`));
-
-    // Process index rewrite before webpack-dev-middleware
-    // to respond with webpack's dist copy of index.html
-    app.use(connectHistoryApiFallback({}));
-
-    app.use(webpackDevMiddleware(compiler, {
-      noInfo: true,
-      publicPath: config.output.publicPath,
-    }));
-
-    app.use(webpackHotMiddleware(compiler));
-
-    app.get('/favicon.ico', (req, res) => {
-      res.sendFile(path.join(__dirname, 'favicon.ico'));
-    });
-
-    app.listen(port, host, (err) => {
-      if (err) {
-        console.log(err);
-        return;
-      }
-
-      console.log(`Listening at http://${host}:${port}`);
-    });
+    stripes.serve(stripesConfig, options);
   });
 
 commander
@@ -103,20 +41,9 @@ commander
   .arguments('<config> <output>')
   .description('Build a tenant bundle')
   .action((stripesConfigFile, outputPath, options) => {
-    const prodConfig = require('./webpack.config.cli.prod'); // eslint-disable-line
-    const config = Object.assign({}, prodConfig);
     const stripesConfig = require(path.resolve(stripesConfigFile)); // eslint-disable-line
-    config.plugins.push(new StripesConfigPlugin(stripesConfig));
-    config.resolve.modules = ['node_modules', cwdModules];
-    config.resolveLoader = { modules: ['node_modules', cwdModules] };
-    config.output.path = path.resolve(outputPath);
-    if (options.publicPath) {
-      config.output.publicPath = options.publicPath;
-    }
-    const compiler = webpack(config);
-    compiler.run((err, stats) => {
-      processStats(err, stats);
-    });
+    options.outputPath = outputPath;
+    stripes.build(stripesConfig, options, processStats);
   });
 
 commander.parse(process.argv);

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -5,7 +5,7 @@ const StripesConfigPlugin = require('./stripes-config-plugin');
 const platformModulePath = path.join(path.resolve(), 'node_modules');
 
 module.exports = function build(stripesConfig, options, callback) {
-  const config = require('../webpack.config.cli.prod'); // eslint-disable-line
+  let config = require('../webpack.config.cli.prod'); // eslint-disable-line
 
   config.plugins.push(new StripesConfigPlugin(stripesConfig));
   config.resolve.modules = ['node_modules', platformModulePath];
@@ -18,7 +18,7 @@ module.exports = function build(stripesConfig, options, callback) {
   }
   // Give the caller a chance to apply their own webpack overrides
   if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
-    options.webpackOverrides(config);
+    config = options.webpackOverrides(config);
   }
 
   const compiler = webpack(config);

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -16,6 +16,10 @@ module.exports = function build(stripesConfig, options, callback) {
   if (options.publicPath) {
     config.output.publicPath = options.publicPath;
   }
+  // Give the caller a chance to apply their own webpack overrides
+  if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
+    options.webpackOverrides(config);
+  }
 
   const compiler = webpack(config);
   compiler.run(callback);

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -17,11 +17,6 @@ module.exports = function build(stripesConfig, options, callback) {
     config.output.publicPath = options.publicPath;
   }
 
-  // Give the caller a chance to apply their own webpack overrides
-  if (options.webpackOverrides && typeof webpackOverrides === 'function') {
-    options.webpackOverrides(config);
-  }
-
   const compiler = webpack(config);
   compiler.run(callback);
 };

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -1,0 +1,27 @@
+const webpack = require('webpack');
+const path = require('path');
+const StripesConfigPlugin = require('./stripes-config-plugin');
+
+const platformModulePath = path.join(path.resolve(), 'node_modules');
+
+module.exports = function build(stripesConfig, options, callback) {
+  const config = require('../webpack.config.cli.prod'); // eslint-disable-line
+
+  config.plugins.push(new StripesConfigPlugin(stripesConfig));
+  config.resolve.modules = ['node_modules', platformModulePath];
+
+  if (options.outputPath) {
+    config.output.path = path.resolve(options.outputPath);
+  }
+  if (options.publicPath) {
+    config.output.publicPath = options.publicPath;
+  }
+
+  // Give the caller a chance to apply their own webpack overrides
+  if (options.webpackOverrides && typeof webpackOverrides === 'function') {
+    options.webpackOverrides(config);
+  }
+
+  const compiler = webpack(config);
+  compiler.run(callback);
+};

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -26,7 +26,7 @@ const cachePlugin = new HardSourceWebpackPlugin({
 
 module.exports = function serve(stripesConfig, options) {
   const app = express();
-  const config = require('../webpack.config.cli.dev'); // eslint-disable-line
+  let config = require('../webpack.config.cli.dev'); // eslint-disable-line
 
   config.plugins.push(new StripesConfigPlugin(stripesConfig));
 
@@ -41,7 +41,7 @@ module.exports = function serve(stripesConfig, options) {
   }
   // Give the caller a chance to apply their own webpack overrides
   if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
-    options.webpackOverrides(config);
+    config = options.webpackOverrides(config);
   }
 
   const compiler = webpack(config);

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -39,6 +39,10 @@ module.exports = function serve(stripesConfig, options) {
   if (options.devtool) {
     config.devtool = options.devtool;
   }
+  // Give the caller a chance to apply their own webpack overrides
+  if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
+    options.webpackOverrides(config);
+  }
 
   const compiler = webpack(config);
 

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -1,0 +1,72 @@
+const webpack = require('webpack');
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+const path = require('path');
+const nodeObjectHash = require('node-object-hash');
+const express = require('express');
+const webpackDevMiddleware = require('webpack-dev-middleware');
+const webpackHotMiddleware = require('webpack-hot-middleware');
+const connectHistoryApiFallback = require('connect-history-api-fallback');
+const StripesConfigPlugin = require('./stripes-config-plugin');
+
+const cwd = path.resolve();
+const platformModulePath = path.join(cwd, 'node_modules');
+const coreModulePath = path.join(__dirname, '..', 'node_modules');
+const serverRoot = path.join(__dirname, '..');
+
+const cachePlugin = new HardSourceWebpackPlugin({
+  cacheDirectory: path.join(cwd, 'webpackcache'),
+  recordsPath: path.join(cwd, 'webpackcache/records.json'),
+  configHash(webpackConfig) {
+    // Build a string value used by HardSource to determine which cache to
+    // use if [confighash] is in cacheDirectory or if the cache should be
+    // replaced if [confighash] does not appear in cacheDirectory.
+    return nodeObjectHash().hash(webpackConfig);
+  },
+});
+
+module.exports = function serve(stripesConfig, options) {
+  const app = express();
+  const config = require('../webpack.config.cli.dev'); // eslint-disable-line
+
+  config.plugins.push(new StripesConfigPlugin(stripesConfig));
+
+  // Look for modules in node_modules, then the platform, then stripes-core
+  config.resolve.modules = ['node_modules', platformModulePath, coreModulePath];
+
+  if (options.cache) {
+    config.plugins.push(cachePlugin);
+  }
+  if (options.devtool) {
+    config.devtool = options.devtool;
+  }
+
+  const compiler = webpack(config);
+
+  const port = options.port || process.env.STRIPES_PORT || 3000;
+  const host = options.host || process.env.STRIPES_HOST || 'localhost';
+
+  app.use(express.static(`${serverRoot}/public`));
+
+  // Process index rewrite before webpack-dev-middleware
+  // to respond with webpack's dist copy of index.html
+  app.use(connectHistoryApiFallback({}));
+
+  app.use(webpackDevMiddleware(compiler, {
+    noInfo: true,
+    publicPath: config.output.publicPath,
+  }));
+
+  app.use(webpackHotMiddleware(compiler));
+
+  app.get('/favicon.ico', (req, res) => {
+    res.sendFile(`${serverRoot}/favicon.ico`);
+  });
+
+  app.listen(port, host, (err) => {
+    if (err) {
+      console.log(err);
+      return;
+    }
+    console.log(`Listening at http://${host}:${port}`);
+  });
+};

--- a/webpack/stripes-node-api.js
+++ b/webpack/stripes-node-api.js
@@ -1,0 +1,7 @@
+const build = require('./build');
+const serve = require('./serve');
+
+module.exports = {
+  build,
+  serve,
+};


### PR DESCRIPTION
Stripes.js now focuses on command and config file input only.  This allows build logic to more readily be reused outside of a CLI. Related to STCOR-29 and prep for FOLIO-852