### PR TITLE
Restore resolveLoaders config omitted from previous refactor

### DIFF
--- a/webpack/build.js
+++ b/webpack/build.js
@@ -9,6 +9,7 @@ module.exports = function build(stripesConfig, options, callback) {
 
   config.plugins.push(new StripesConfigPlugin(stripesConfig));
   config.resolve.modules = ['node_modules', platformModulePath];
+  config.resolveLoader = { modules: ['node_modules', platformModulePath] };
 
   if (options.outputPath) {
     config.output.path = path.resolve(options.outputPath);

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -32,6 +32,7 @@ module.exports = function serve(stripesConfig, options) {
 
   // Look for modules in node_modules, then the platform, then stripes-core
   config.resolve.modules = ['node_modules', platformModulePath, coreModulePath];
+  config.resolveLoader = { modules: ['node_modules', platformModulePath, coreModulePath] };
 
   if (options.cache) {
     config.plugins.push(cachePlugin);


### PR DESCRIPTION
This looks to still be necessary for locating loaders in certain build scenarios