### PR TITLE
Add switchMap operator to stripes-core

### DIFF
--- a/src/configureEpics.js
+++ b/src/configureEpics.js
@@ -2,6 +2,7 @@ import { combineEpics, createEpicMiddleware } from 'redux-observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/throttleTime';
 import 'rxjs/add/operator/filter';


### PR DESCRIPTION
## Purpose
When modules such as `eholdings` are loaded into a folio application the epic they receive comes from stripes-core. So if you need access to a method/rxjs-operator off of `action$` such as `action$.ofType().switchMap()` in that module it needs to be in stripes-core so when stripes-core combines its epics the operator will be present.

Without this operator being imported at the `stripes-core` level user of an module such as `eholdings` that makes use of switchMap will receive this error `Uncaught TypeError: action$.ofType(...).filter(...).switchMap is not a function` 

## Approach
Add import statement to bring in rxjs switchMap operator
`import 'rxjs/add/operator/switchMap';`
