### PR TITLE
Adjust MainNav flex behavior

### DIFF
--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -1,11 +1,12 @@
 @import '../variables.css';
 
 .navRoot{
-    display: flex;
-    justify-content: space-between;
-    align-content: stretch;
-    width: 100%;
-    border-bottom: 2px solid #ccc;
+  display: flex;
+  justify-content: space-between;
+  align-content: stretch;
+  width: 100%;
+  border-bottom: 2px solid #ccc;
+  flex: 0 0 auto;
 }
 
 .nowrap{
@@ -74,11 +75,10 @@
   .ddButton{
     height: var(--controlHeightSmall);
   }
-  
+
   .ddLink{
     height: var(--controlHeightSmall);
     display: flex;
     align-items: center;
   }
 }
-

--- a/src/components/ModuleContainer/ModuleContainer.css
+++ b/src/components/ModuleContainer/ModuleContainer.css
@@ -1,5 +1,7 @@
 .moduleContainer{
-    flex-grow: 2;
-    position: relative;
-    outline: none;
+  flex-grow: 2;
+  position: relative;
+  outline: none;
+  flex: 1 1 auto;
+  overflow-y: auto;
 }


### PR DESCRIPTION
When a module used a layout without a parent `Paneset`, the `MainNav` would collapse. This ensures the `MainNav` maintains its height with or without a `Paneset`.

### Before
![n9e4mkrc2g](https://user-images.githubusercontent.com/230597/32462034-96398682-c2fd-11e7-802e-3575e16bec25.gif)

### After
![ciaen1faa1](https://user-images.githubusercontent.com/230597/32462039-99fd479a-c2fd-11e7-9287-eaf90ea03dca.gif)
