### PR TITLE
Add sr-only class to global.css. Fixes STCOR-99

### DIFF
--- a/src/components/MainContainer/global.css
+++ b/src/components/MainContainer/global.css
@@ -69,6 +69,14 @@ hr{border: 1px solid #cdcdcd;
 .marginTopHalf{margin-top: .5rem !important;}
 .floatEnd{float: right !important;}
 
+.sr-only{
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    clip-path: inset(50%);
+    border: 0;
+}
+
 body[dir="rtl"] .floatEnd, html[dir="rtl"] .floatEnd{
 
     float: left !important;


### PR DESCRIPTION
Another thing that will further shore things up for removal of bootstrap styles... with an actually useful utility class that's used to hide would-be-redundant labels from sighted users, leaving them available to screen readers.