### PR TITLE
Webpack build enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "rxjs": "^5.4.3",
     "serialize-javascript": "^1.4.0",
     "style-loader": "^0.18.2",
+    "uglifyjs-webpack-plugin": "^1.0.1",
     "uuid": "^3.0.0",
     "webpack": "^3.4.1",
     "webpack-dev-middleware": "^1.10.0",

--- a/stripes.js
+++ b/stripes.js
@@ -38,6 +38,7 @@ commander
 commander
   .command('build')
   .option('--publicPath [publicPath]', 'publicPath')
+  .option('--sourcemap', 'include sourcemaps in build')
   .arguments('<config> <output>')
   .description('Build a tenant bundle')
   .action((stripesConfigFile, outputPath, options) => {

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -1,6 +1,7 @@
 // Top level Webpack configuration for building static files for
 // production deployment from the command line
 
+const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const postCssImport = require('postcss-import');
@@ -24,6 +25,7 @@ prodConfig.plugins = prodConfig.plugins.concat([
   new ExtractTextPlugin({ filename: 'style.[contenthash].css', allChunks: true }),
   new OptimizeCssAssetsPlugin(),
   new StripesDuplicatesPlugin(),
+  new webpack.EnvironmentPlugin(['NODE_ENV']),
 ]);
 
 prodConfig.module.rules.push({

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const StripesConfigPlugin = require('./stripes-config-plugin');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 const platformModulePath = path.join(path.resolve(), 'node_modules');
 
@@ -20,6 +21,10 @@ module.exports = function build(stripesConfig, options, callback) {
   if (options.sourcemap) {
     config.devtool = 'source-map';
   }
+  config.plugins.push(new UglifyJSPlugin({
+    sourceMap: config.devtool && config.devtool === 'source-map',
+  }));
+
   // Give the caller a chance to apply their own webpack overrides
   if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
     config = options.webpackOverrides(config);

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -17,6 +17,9 @@ module.exports = function build(stripesConfig, options, callback) {
   if (options.publicPath) {
     config.output.publicPath = options.publicPath;
   }
+  if (options.sourcemap) {
+    config.devtool = 'source-map';
+  }
   // Give the caller a chance to apply their own webpack overrides
   if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
     config = options.webpackOverrides(config);


### PR DESCRIPTION
- New `--sourcemap` option for builds (STCOR-64)
- Re-enables javascript minification using the ES6 compatible version of UglifyJS (STRIPES-102)
- Put React in production mode via EnvironmentPlugin (set`NODE_ENV=production` to enable)