### PR TITLE
Return promise for build() and serve()

### DIFF
--- a/stripes.js
+++ b/stripes.js
@@ -7,18 +7,23 @@ const packageJSON = require('./package.json');
 
 commander.version(packageJSON.version);
 
-// Display webpack output to the console
-function processStats(err, stats) {
+// Display error to the console and exit
+function processError(err) {
   if (err) {
     console.error(err);
   }
+  process.exit(1);
+}
+
+// Display webpack output to the console
+function processStats(stats) {
   console.log(stats.toString({
     chunks: false,
     colors: true,
   }));
   // Check for webpack compile errors and exit
-  if (err || stats.hasErrors()) {
-    process.exit(1);
+  if (stats.hasErrors()) {
+    processError();
   }
 }
 
@@ -43,7 +48,9 @@ commander
   .action((stripesConfigFile, outputPath, options) => {
     const stripesConfig = require(path.resolve(stripesConfigFile)); // eslint-disable-line
     options.outputPath = outputPath;
-    stripes.build(stripesConfig, options, processStats);
+    stripes.build(stripesConfig, options)
+      .then(stats => processStats(stats))
+      .catch(err => processError(err));
   });
 
 commander.parse(process.argv);

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -4,24 +4,32 @@ const StripesConfigPlugin = require('./stripes-config-plugin');
 
 const platformModulePath = path.join(path.resolve(), 'node_modules');
 
-module.exports = function build(stripesConfig, options, callback) {
-  let config = require('../webpack.config.cli.prod'); // eslint-disable-line
+module.exports = function build(stripesConfig, options) {
+  return new Promise((resolve, reject) => {
+    let config = require('../webpack.config.cli.prod'); // eslint-disable-line
 
-  config.plugins.push(new StripesConfigPlugin(stripesConfig));
-  config.resolve.modules = ['node_modules', platformModulePath];
-  config.resolveLoader = { modules: ['node_modules', platformModulePath] };
+    config.plugins.push(new StripesConfigPlugin(stripesConfig));
+    config.resolve.modules = ['node_modules', platformModulePath];
+    config.resolveLoader = { modules: ['node_modules', platformModulePath] };
 
-  if (options.outputPath) {
-    config.output.path = path.resolve(options.outputPath);
-  }
-  if (options.publicPath) {
-    config.output.publicPath = options.publicPath;
-  }
-  // Give the caller a chance to apply their own webpack overrides
-  if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
-    config = options.webpackOverrides(config);
-  }
+    if (options.outputPath) {
+      config.output.path = path.resolve(options.outputPath);
+    }
+    if (options.publicPath) {
+      config.output.publicPath = options.publicPath;
+    }
+    // Give the caller a chance to apply their own webpack overrides
+    if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
+      config = options.webpackOverrides(config);
+    }
 
-  const compiler = webpack(config);
-  compiler.run(callback);
+    const compiler = webpack(config);
+    compiler.run((err, stats) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stats);
+      }
+    });
+  });
 };

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -25,53 +25,56 @@ const cachePlugin = new HardSourceWebpackPlugin({
 });
 
 module.exports = function serve(stripesConfig, options) {
-  const app = express();
-  let config = require('../webpack.config.cli.dev'); // eslint-disable-line
+  return new Promise((resolve) => {
+    const app = express();
+    let config = require('../webpack.config.cli.dev'); // eslint-disable-line
 
-  config.plugins.push(new StripesConfigPlugin(stripesConfig));
+    config.plugins.push(new StripesConfigPlugin(stripesConfig));
 
-  // Look for modules in node_modules, then the platform, then stripes-core
-  config.resolve.modules = ['node_modules', platformModulePath, coreModulePath];
-  config.resolveLoader = { modules: ['node_modules', platformModulePath, coreModulePath] };
+    // Look for modules in node_modules, then the platform, then stripes-core
+    config.resolve.modules = ['node_modules', platformModulePath, coreModulePath];
+    config.resolveLoader = { modules: ['node_modules', platformModulePath, coreModulePath] };
 
-  if (options.cache) {
-    config.plugins.push(cachePlugin);
-  }
-  if (options.devtool) {
-    config.devtool = options.devtool;
-  }
-  // Give the caller a chance to apply their own webpack overrides
-  if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
-    config = options.webpackOverrides(config);
-  }
-
-  const compiler = webpack(config);
-
-  const port = options.port || process.env.STRIPES_PORT || 3000;
-  const host = options.host || process.env.STRIPES_HOST || 'localhost';
-
-  app.use(express.static(`${serverRoot}/public`));
-
-  // Process index rewrite before webpack-dev-middleware
-  // to respond with webpack's dist copy of index.html
-  app.use(connectHistoryApiFallback({}));
-
-  app.use(webpackDevMiddleware(compiler, {
-    noInfo: true,
-    publicPath: config.output.publicPath,
-  }));
-
-  app.use(webpackHotMiddleware(compiler));
-
-  app.get('/favicon.ico', (req, res) => {
-    res.sendFile(`${serverRoot}/favicon.ico`);
-  });
-
-  app.listen(port, host, (err) => {
-    if (err) {
-      console.log(err);
-      return;
+    if (options.cache) {
+      config.plugins.push(cachePlugin);
     }
-    console.log(`Listening at http://${host}:${port}`);
+    if (options.devtool) {
+      config.devtool = options.devtool;
+    }
+    // Give the caller a chance to apply their own webpack overrides
+    if (options.webpackOverrides && typeof options.webpackOverrides === 'function') {
+      config = options.webpackOverrides(config);
+    }
+
+    const compiler = webpack(config);
+    compiler.plugin('done', stats => resolve(stats));
+
+    const port = options.port || process.env.STRIPES_PORT || 3000;
+    const host = options.host || process.env.STRIPES_HOST || 'localhost';
+
+    app.use(express.static(`${serverRoot}/public`));
+
+    // Process index rewrite before webpack-dev-middleware
+    // to respond with webpack's dist copy of index.html
+    app.use(connectHistoryApiFallback({}));
+
+    app.use(webpackDevMiddleware(compiler, {
+      noInfo: true,
+      publicPath: config.output.publicPath,
+    }));
+
+    app.use(webpackHotMiddleware(compiler));
+
+    app.get('/favicon.ico', (req, res) => {
+      res.sendFile(`${serverRoot}/favicon.ico`);
+    });
+
+    app.listen(port, host, (err) => {
+      if (err) {
+        console.log(err);
+        return;
+      }
+      console.log(`Listening at http://${host}:${port}`);
+    });
   });
 };


### PR DESCRIPTION
This will facilitate usage in consumers like stripes-cli by knowing when webpack has finished its initial build.