### PR TITLE
Support "_path" within anointed stripes-connect resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Removing `examples/trivial`; it's now a separate module. Fixes STCOR-94.
 * Extend hasPermission to accept a list of permissions, update documentation. Fixes STCOR-98.
 * Show a user's Notifications. Fixes STSMACOM-11; refs STCOM-48.
+* Assignment to special parameter `_path` within the anointed stripes-connect resource will change the URL path. Fixes STCOR-105.
 
 ## [2.7.0](https://github.com/folio-org/stripes-core/tree/v2.7.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.6.1...v2.7.0)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -116,7 +116,7 @@ class MainNav extends Component {
         const keys = Object.keys(allParams);
 
         let url = allParams._path || location.pathname;
-        delete allParams._path
+        delete allParams._path;
 
         if (keys.length) {
           url += `?${queryString.stringify(allParams)}`;

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -115,7 +115,8 @@ class MainNav extends Component {
         const allParams = Object.assign({}, query, this.queryValues);
         const keys = Object.keys(allParams);
 
-        let url = location.pathname;
+        let url = allParams._path || location.pathname;
+        delete allParams._path
 
         if (keys.length) {
           url += `?${queryString.stringify(allParams)}`;


### PR DESCRIPTION
Assignment to special parameter `_path` within the anointed
stripes-connect resource will change the URL path.

Fixes STCOR-105.