### PR TITLE
Set up stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf static",
     "test": "mocha --compilers js:babel-core/register",
     "test-watch": "mocha --compilers js:babel-core/register -w --watch-extensions json",
-    "lint": "eslint ./"
+    "lint": "eslint ./ && stylelint \"src/**/*.css\""
   },
   "engines": {
     "node": ">=6.0.0"
@@ -40,7 +40,9 @@
     "eslint-config-stripes": "^1.0.0",
     "mocha": "^3.1.2",
     "mock-require": "^2.0.1",
-    "react-addons-test-utils": "^15.3.2"
+    "react-addons-test-utils": "^15.3.2",
+    "stylelint": "^8.2.0",
+    "stylelint-config-standard": "^17.0.0"
   },
   "dependencies": {
     "@folio/stripes-components": "^1.6.0",
@@ -103,8 +105,8 @@
     "rxjs": "^5.4.3",
     "serialize-javascript": "^1.4.0",
     "style-loader": "^0.18.2",
-    "uglifyjs-webpack-plugin": "^1.0.1",
     "typeface-source-sans-pro": "0.0.43",
+    "uglifyjs-webpack-plugin": "^1.0.1",
     "uuid": "^3.0.0",
     "webpack": "^3.4.1",
     "webpack-dev-middleware": "^1.10.0",

--- a/src/components/Login/Login.css
+++ b/src/components/Login/Login.css
@@ -91,12 +91,12 @@
 }
 
 .majorSlab {
-  composes: slab;
+  composes: slab; /* stylelint-disable-line property-no-unknown */
   background-color: #dcdcdc;
 }
 
 .minorSlab {
-  composes: slab;
+  composes: slab; /* stylelint-disable-line property-no-unknown */
   background-color: #ebebeb;
 }
 
@@ -121,7 +121,7 @@
 }
 
 .loginError {
-  composes: slab;
+  composes: slab; /* stylelint-disable-line property-no-unknown */
   color: #900;
 }
 

--- a/src/components/Login/Login.css
+++ b/src/components/Login/Login.css
@@ -1,9 +1,9 @@
-:root{
+:root {
   --radius: 6px;
   --primary: #106c9e;
 }
 
-.loginOverlay{
+.loginOverlay {
   width: 100%;
   height: 100%;
   position: absolute;
@@ -12,12 +12,28 @@
   z-index: 9999;
   overflow: auto;
   background: #f2f2f2;
-  background: -moz-radial-gradient(center, ellipse cover,  #fff 0%, #ececec 100%);
-  background: radial-gradient(ellipse at center,  #fff 0%, #ececec 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fff', endColorstr='#ececec',GradientType=1 );
+  background:
+    -moz-radial-gradient(
+      center,
+      ellipse cover,
+      #fff 0%,
+      #ececec 100%
+    );
+  background:
+    radial-gradient(
+      ellipse at center,
+      #fff 0%,
+      #ececec 100%
+    );
+  filter:
+    progid:dximagetransform.microsoft.gradient(
+      startColorstr='#fff',
+      endColorstr='#ececec',
+      GradientType=1
+    );
 }
 
-.loginContainer{
+.loginContainer {
   width: 40rem;
   margin: auto;
   margin-top: 2rem;
@@ -26,16 +42,18 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  & h1{
-    font-size:3.5rem;
+
+  & h1 {
+    font-size: 3.5rem;
     margin: 1rem auto;
   }
-  & form{
+
+  & form {
     width: 100%;
   }
 }
 
-.loginInput{
+.loginInput {
   font-size: 1.5rem;
   background-color: transparent;
   border-width: 0;
@@ -43,26 +61,27 @@
   width: 100%;
   height: 100%;
   align-self: stretch;
-  transition: background-color .2s ease;
+  transition: background-color 0.2s ease;
   border-radius: var(--radius);
-  &:focus{
+
+  &:focus {
     background-color: #fbfbfb;
-    -moz-box-shadow: 1px 11px 50px -18px rgba(0,0,0,0.75);
-    box-shadow: 1px 11px 50px -18px rgba(0,0,0,0.75);
+    -moz-box-shadow: 1px 11px 50px -18px rgba(0, 0, 0, 0.75);
+    box-shadow: 1px 11px 50px -18px rgba(0, 0, 0, 0.75);
   }
 }
 
-.slabStack{
+.slabStack {
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.slab{
+.slab {
   width: 100%;
   min-height: 6rem;
-  margin-top: .5rem;
+  margin-top: 0.5rem;
   text-align: center;
   display: flex;
   align-items: center;
@@ -71,71 +90,77 @@
   border-radius: var(--radius);
 }
 
-.majorSlab{
+.majorSlab {
   composes: slab;
   background-color: #dcdcdc;
 }
 
-.minorSlab{
+.minorSlab {
   composes: slab;
   background-color: #ebebeb;
 }
 
-.slabButton{
+.slabButton {
   width: 100%;
   min-height: 6rem;
-  margin-top: .5rem;
+  margin-top: 0.5rem;
   text-align: center;
   font-weight: bold;
   border-radius: var(--radius);
   background-color: var(--primary);
   color: #fff;
-  transition: background-color .3s;
+  transition: background-color 0.3s;
   appearance: none;
   border: 1px solid transparent;
   font-size: 1.5rem;
-  &:focus, &:hover{
+
+  &:focus,
+  &:hover {
     background-color: color(var(--primary) shade(12%));
   }
 }
 
-.loginError{
+.loginError {
   composes: slab;
   color: #900;
 }
 
-@keyframes loadingAnim{
-  0%{
+@keyframes loadingAnim {
+  0% {
     transform: rotate(0deg);
   }
-  50%{
+
+  50% {
     transform: rotate(180deg);
   }
-  100%{
+
+  100% {
     transform: rotate(360deg);
-  }  
+  }
 }
 
-.loading{
-  width: 40px; 
-  height: 40px; 
+.loading {
+  width: 40px;
+  height: 40px;
   margin: 1rem;
-  border-radius: 50%; 
-  border:4px solid transparent; 
+  border-radius: 50%;
+  border: 4px solid transparent;
   border-top-color: #cdcdcd;
   animation: loadingAnim 1s infinite linear;
-  &.blue{
+
+  &.blue {
     border-top-color: var(--primary);
   }
 }
 
-@media (max-width: 640px){
-  .loginOverlay{
+@media (max-width: 640px) {
+  .loginOverlay {
     display: block;
     height: 100%;
     overflow: auto;
   }
-  .loginContainer{
+
+  .loginContainer {
     width: 100%;
   }
 }

--- a/src/components/MainContainer/MainContainer.css
+++ b/src/components/MainContainer/MainContainer.css
@@ -1,7 +1,6 @@
-.root{
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    align-content: flex-start;
+.root {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-content: flex-start;
 }
-

--- a/src/components/MainNav/Breadcrumbs/Breadcrumbs.css
+++ b/src/components/MainNav/Breadcrumbs/Breadcrumbs.css
@@ -1,19 +1,18 @@
-.navBreadcrumbs{
-    list-style: none;
-    display: flex;
-    align-content: flex-start;
-    align-items: stretch;
-    padding: 0 6px;
-    
-    & li{
-        & a{
-            font-weight: bold;
-            text-decoration: none;
-            height: 100%;
-            color: #444;
-            display: block;
-            padding: 0 6px;
-        }
-    }
-}
+.navBreadcrumbs {
+  list-style: none;
+  display: flex;
+  align-content: flex-start;
+  align-items: stretch;
+  padding: 0 6px;
 
+  & li {
+    & a {
+      font-weight: bold;
+      text-decoration: none;
+      height: 100%;
+      color: #444;
+      display: block;
+      padding: 0 6px;
+    }
+  }
+}

--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -1,6 +1,6 @@
 @import '../variables.css';
 
-.navRoot{
+.navRoot {
   display: flex;
   justify-content: space-between;
   align-content: stretch;
@@ -9,11 +9,12 @@
   flex: 0 0 auto;
 }
 
-.nowrap{
+.nowrap {
   white-space: nowrap;
 }
 
-.ddButton, .ddLink{
+.ddButton,
+.ddLink {
   width: 100%;
   display: block;
   text-align: left;
@@ -26,7 +27,10 @@
   text-decoration: none;
   color: #333;
   cursor: pointer;
-  &:hover, &:focus, &:active{
+
+  &:hover,
+  &:focus,
+  &:active {
     background-color: #efefef;
     outline: none;
     color: #333;
@@ -34,49 +38,46 @@
   }
 }
 
-.ddTextItem{
+.ddTextItem {
   padding: 4px;
   display: block;
 }
 
-.ddDivider{
+.ddDivider {
   border-bottom: 1px solid #cdcdcd;
   padding: 4px;
   margin-bottom: 4px;
 }
 
-.skipLink{
+.skipLink {
   position: absolute;
   display: block;
-  padding: 6px 4px 0 4px;
+  padding: 6px 4px 0;
   top: -100px;
-  transition: top .15s linear;
-  &:focus{
+  transition: top 0.15s linear;
+
+  &:focus {
     position: relative;
     top: 0;
   }
 }
 
-@media (--large){
-  .linkLabel{
-    /*display: none;*/
+@media (--mediumDown) {
+  .brandingLabel {
+    display: none;
   }
-}
 
-@media (--mediumDown){
-  .brandingLabel{
-    display:none;
-  }
-  .smallAlignRight{
+  .smallAlignRight {
     position: absolute;
     top: 0;
     right: 0;
   }
-  .ddButton{
+
+  .ddButton {
     height: var(--controlHeightSmall);
   }
 
-  .ddLink{
+  .ddLink {
     height: var(--controlHeightSmall);
     display: flex;
     align-items: center;

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -1,49 +1,62 @@
 @import '../../variables.css';
 
-button.navButton{
-    background-color: transparent;
-    border-width: 0;
-    height: 42px;
-    cursor: pointer;
-    padding: 9px 5px;
-    transition: transform .2s ease;
-    & img, & div, & svg{
-      margin: 0 4px;
-      &+span{
-        align-self: center;
-        display: inline-block;
-      }
-    }
-    & > span{
-      display: flex;
-    }
-    &:hover{
-      & img, & div, & svg{
-        box-shadow: 0px 2px 4px 0px rgba(0,0,0,0.2);
+button.navButton {
+  background-color: transparent;
+  border-width: 0;
+  height: 42px;
+  cursor: pointer;
+  padding: 9px 5px;
+  transition: transform 0.2s ease;
 
-      }
+  & img,
+  & div,
+  & svg {
+    margin: 0 4px;
 
-      transform: scale(1.1);
+    & + span {
+      align-self: center;
+      display: inline-block;
     }
+  }
+
+  & > span {
+    display: flex;
+  }
+
+  &:hover {
+    & img,
+    & div,
+    & svg {
+      box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);
+    }
+
+    transform: scale(1.1);
+  }
 }
 
-a.navButton{
+a.navButton {
   display: flex;
   align-items: center;
   color: #555;
   padding: 9px 5px;
-  & img, & div, & svg{
+
+  & img,
+  & div,
+  & svg {
     margin: 0 4px;
   }
-  &:hover, &:visited, &:focus{
+
+  &:hover,
+  &:visited,
+  &:focus {
     text-decoration: none;
   }
 }
 
-.navButton{
-  & .selected{
+.navButton {
+  & .selected {
     position: absolute;
-    top: 0px;
+    top: 0;
     width: 22px;
     height: 4px;
     background-color: #3d75b5;
@@ -52,11 +65,9 @@ a.navButton{
   }
 }
 
-@media(--mediumDown){
-  .navButton.hideMed, a.navButton.hideMed{
+@media (--mediumDown) {
+  .navButton.hideMed,
+  a.navButton.hideMed {
     display: none;
   }
 }
-
-
-

--- a/src/components/MainNav/NavDivider/NavDivider.css
+++ b/src/components/MainNav/NavDivider/NavDivider.css
@@ -1,12 +1,12 @@
 @import '../../variables.css';
 
-.navDivider{
+.navDivider {
   border-left: 1px solid #bbb;
   height: 28px;
 }
 
-@media(--mediumDown){
-  .hideMed{
+@media (--mediumDown) {
+  .hideMed {
     display: none;
   }
 }

--- a/src/components/MainNav/NavDropdownMenu/NavDropdownMenu.css
+++ b/src/components/MainNav/NavDropdownMenu/NavDropdownMenu.css
@@ -1,6 +1,6 @@
 @import '../../variables.css';
 
-.DropdownMenu{
+.DropdownMenu {
   position: absolute;
   top: 105%;
   right: 0;
@@ -15,15 +15,16 @@
   background-color: #fff;
   background-clip: padding-box;
   border: 1px solid #ccc;
-  box-shadow: 0 6px 12px rgba(0,0,0,.175);
-  & ul{
-    list-style:none;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+
+  & ul {
+    list-style: none;
     padding: 0;
   }
 }
 
-@media (--mediumDown){
-  .DropdownMenu{
+@media (--mediumDown) {
+  .DropdownMenu {
     min-width: 29.5rem;
   }
 }

--- a/src/components/MainNav/NavGroup/NavGroup.css
+++ b/src/components/MainNav/NavGroup/NavGroup.css
@@ -1,22 +1,22 @@
 @import '../../variables.css';
 
-.navGroup{
-    list-style: none;
-    padding-left: 0;
-    display: flex;
-    align-items: center;
-    align-content: space-between;
-    margin: 0 5px;
-    & .navGroup{
-      margin: 0;
-    }
+.navGroup {
+  list-style: none;
+  padding-left: 0;
+  display: flex;
+  align-items: center;
+  align-content: space-between;
+  margin: 0 5px;
+
+  & .navGroup {
+    margin: 0;
+  }
 }
 
-
-@media (--mediumDown){
-  .navGroup{
-    &.hideMed{
-      display:none;
+@media (--mediumDown) {
+  .navGroup {
+    &.hideMed {
+      display: none;
     }
   }
 }

--- a/src/components/MainNav/Notifications/NotificationMenu.css
+++ b/src/components/MainNav/Notifications/NotificationMenu.css
@@ -1,39 +1,44 @@
 @import '@folio/stripes-components/lib/variables.css';
 
-.notificationMenu{
+.notificationMenu {
   height: 250px;
   min-width: 440px;
-  & a{
+
+  & a {
     color: #444;
-    &:hover{
+
+    &:hover {
       background-color: color(var(--bgHover) tint(20%));
       text-decoration: none;
     }
   }
 }
 
-.notification{
-  border: 1px solid rgba(255, 255, 255, .5);
-
+.notification {
+  border: 1px solid rgba(255, 255, 255, 0.5);
   background-color: var(--bgHover);
-  transition: background-color .2s ease;
-  &:hover{
+  transition: background-color 0.2s ease;
+
+  &:hover {
     background-color: color(var(--bgHover) tint(20%));
   }
-  &.new{
+
+  &.new {
     background-color: color(var(--bg) shade(5%));
-    &:hover{
+
+    &:hover {
       background-color: color(var(--bgHover) tint(20%));
     }
   }
 }
 
-.notificationsBadgeWrapper{
+.notificationsBadgeWrapper {
   position: relative;
 }
-.notificationsBadge{
+
+.notificationsBadge {
   position: absolute;
-  right: 0px;
+  right: 0;
   background: #666;
   padding: 3px;
   border-radius: 4px;

--- a/src/components/ModuleContainer/ModuleContainer.css
+++ b/src/components/ModuleContainer/ModuleContainer.css
@@ -1,5 +1,4 @@
 .moduleContainer {
-  flex-grow: 2;
   position: relative;
   outline: none;
   flex: 1 1 auto;

--- a/src/components/ModuleContainer/ModuleContainer.css
+++ b/src/components/ModuleContainer/ModuleContainer.css
@@ -1,4 +1,4 @@
-.moduleContainer{
+.moduleContainer {
   flex-grow: 2;
   position: relative;
   outline: none;

--- a/src/components/Notification/Toast.css
+++ b/src/components/Notification/Toast.css
@@ -49,9 +49,11 @@
     color: #fff;
     box-shadow: 0 4px 19px 0 rgba(153, 0, 0, 0.39);
 
+    /* stylelint-disable */
     & :global .stripes__icon {
       fill: #fff;
     }
+    /* stylelint-enable */
   }
 
   &.success {
@@ -60,9 +62,11 @@
     color: #fff;
     box-shadow: 0 4px 19px 0 rgba(0, 112, 0, 0.39);
 
+    /* stylelint-disable */
     & :global .stripes__icon {
       fill: #fff;
     }
+    /* stylelint-enable */
   }
 }
 

--- a/src/components/Notification/Toast.css
+++ b/src/components/Notification/Toast.css
@@ -1,6 +1,6 @@
 @import '../variables.css';
 
-.toastContainerRoot{
+.toastContainerRoot {
   position: fixed;
   top: 0;
   left: 0;
@@ -12,109 +12,125 @@
   flex-wrap: wrap-reverse;
   justify-content: flex-start;
   padding: 1rem;
-  &.top{
+
+  &.top {
     padding-top: 44px;
     flex-direction: column;
     flex-wrap: wrap;
   }
 }
 
-.toastNotificationRoot{
+.toastNotificationRoot {
   width: 100%;
   display: flex;
   flex-direction: row-reverse;
-  padding: .5rem 1rem;
-  transition: all .3s ease;
-  &.alignStart{
+  padding: 0.5rem 1rem;
+  transition: all 0.3s ease;
+
+  &.alignStart {
     flex-direction: row;
   }
 }
 
-.base{
+.base {
   padding: 1rem;
   border-radius: 4px;
   background-color: #fff;
   width: 35%;
   pointer-events: all;
   position: relative;
-  transition: all .2s ease;
+  transition: all 0.2s ease;
   display: flex;
-  box-shadow: 0px 4px 19px 0px rgba(0,0,0,0.39);
-  &.error{
+  box-shadow: 0 4px 19px 0 rgba(0, 0, 0, 0.39);
+
+  &.error {
     background-color: color(var(--error, #900) tint(25%));
     border-color: var(--error);
     color: #fff;
-    box-shadow: 0px 4px 19px 0px rgba(153,0,0,0.39);
-    & :global .stripes__icon{
-            fill: #fff;
-      }
+    box-shadow: 0 4px 19px 0 rgba(153, 0, 0, 0.39);
+
+    & :global .stripes__icon {
+      fill: #fff;
+    }
   }
-  &.success{
+
+  &.success {
     background-color: color(var(--success, #060) tint(25%));
     border-color: var(--success);
     color: #fff;
-    box-shadow: 0px 4px 19px 0px rgba(0,112,0,0.39);
-    & :global .stripes__icon{
-            fill: #fff;
-      }
+    box-shadow: 0 4px 19px 0 rgba(0, 112, 0, 0.39);
+
+    & :global .stripes__icon {
+      fill: #fff;
+    }
   }
 }
 
-.endOutside{
+.endOutside {
   right: -40%;
-  &.open{
+
+  &.open {
     right: 0;
   }
 }
 
-.startOutside{
+.startOutside {
   left: -40%;
-  &.open{
+
+  &.open {
     left: 0;
   }
 }
 
-.fade{
+.fade {
   opacity: 0;
-  &.open{
+
+  &.open {
     opacity: 1;
   }
 }
 
-[dir="rtl"]{
-  & .endOutside{
+[dir="rtl"] {
+  & .endOutside {
     left: -40%;
     right: auto;
-    &.open{
+
+    &.open {
       left: 0;
       right: auto;
     }
   }
-  & .startOutside{
+
+  & .startOutside {
     right: -40%;
     left: auto;
-    &.open{
+
+    &.open {
       right: 0;
       left: auto;
     }
   }
 }
 
-@media(--small){
-  .base{
+@media (--small) {
+  .base {
     width: 100%;
     border-radius: 0;
   }
-  .toastNotificationRoot{
+
+  .toastNotificationRoot {
     padding: 0;
   }
-  .endOutside{
+
+  .endOutside {
     right: -105%;
   }
-  .startOutside{
+
+  .startOutside {
     left: -105%;
   }
-  .toastContainerRoot{
+
+  .toastContainerRoot {
     padding: 0;
   }
 }

--- a/src/components/Notification/Toast.css
+++ b/src/components/Notification/Toast.css
@@ -8,15 +8,13 @@
   height: 100vh;
   display: flex;
   pointer-events: none;
-  flex-direction: column-reverse;
-  flex-wrap: wrap-reverse;
+  flex-flow: column-reverse wrap-reverse;
   justify-content: flex-start;
   padding: 1rem;
 
   &.top {
     padding-top: 44px;
-    flex-direction: column;
-    flex-wrap: wrap;
+    flex-flow: column wrap;
   }
 }
 

--- a/src/components/Root/Root.css
+++ b/src/components/Root/Root.css
@@ -1,3 +1,5 @@
+/* stylelint-disable */
 :global(#root) {
   height: 100%;
 }
+/* stylelint-enable */

--- a/src/components/Settings/NavListSection/NavListSection.css
+++ b/src/components/Settings/NavListSection/NavListSection.css
@@ -1,6 +1,6 @@
 @import '../../variables.css';
 
-.listTopLabel{
+.listTopLabel {
   display: block;
   font-weight: bold;
   margin-bottom: 4px;
@@ -8,33 +8,37 @@
   color: #666;
 }
 
-.listItem{
+.listItem {
   display: flex;
 }
 
-.listRoot{
-  & a{
+.listRoot {
+  & a {
     display: block;
     font-weight: bold;
-    font-size: .8rem;
+    font-size: 0.8rem;
     padding: 5px 8px;
     color: var(--labelColor, #333);
     border-radius: var(--radius, 6px);
-    transition: all .25s ease;
+    transition: all 0.25s ease;
     margin-bottom: 1px;
-    &.active{
+
+    &.active {
       background-color: var(--primary, #106c9e);
       color: #fff;
       text-decoration: none;
-      &:hover{
+
+      &:hover {
         background-color: color(var(--primary, #106c9e) shade(8%));
         text-decoration: none;
       }
-      &:active{
+
+      &:active {
         text-decoration: none;
       }
     }
-    &:hover{
+
+    &:hover {
       background-color: #efefef;
       text-decoration: none;
     }

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -1,4 +1,4 @@
-.paneset{
+.paneset {
   width: 100%;
   height: 100%;
   position: absolute;
@@ -6,21 +6,22 @@
   flex-direction: row;
   align-items: stretch;
   justify-content: flex-start;
-  & .paneset{
+
+  & .paneset {
     position: relative;
     flex-grow: 2;
   }
 }
 
-.navPane{
-    border-right: 2px solid #ccc;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    transition: all .25s ease;
+.navPane {
+  border-right: 2px solid #ccc;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  transition: all 0.25s ease;
 }
 
-.header{
+.header {
   width: 100%;
   display: flex;
   align-content: center;
@@ -32,10 +33,9 @@
   font-weight: bold;
 }
 
-.content{
+.content {
   width: 100%;
   height: 100%;
   overflow: auto;
   padding: 16px;
 }
-

--- a/src/components/variables.css
+++ b/src/components/variables.css
@@ -1,4 +1,4 @@
-:root{
+:root {
   --bg: #fff;
   --primary: #106c9e;
   --secondary: #999;
@@ -7,10 +7,8 @@
   --controlHeight: 28px;
   --br: 6px;
   --inputBorderColor: #acacac;
-  
   --controlHeightSmall: 44px;
 }
-
 
 @custom-media --small (max-width: 640px);
 @custom-media --mediumDown (max-width: 1024px);
@@ -20,5 +18,3 @@
 @custom-media --largeUp (min-width:1025px);
 @custom-media --xlarge (min-width: 1441px) and (max-width: 1920px);
 @custom-media --xxlarge (min-width: 1921px);
-
-


### PR DESCRIPTION
## Purpose
We'd like to treat our CSS as a first-class citizen with our JavaScript. Part of that means sticking to reasonable, consistent conventions. `stylelint` can give us the same anti-bikeshedding and bug prevention in CSS we already have with `eslint` in JS.

## Approach
`stylelint` will now run with `eslint` as part of `yarn lint`.

Developers can install a `stylelint` plugin in their editor for faster iteration: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/complementary-tools.md#editor-plugins

Several of the errors would never have been checked in if `.editorconfig` was being followed by the editor: http://editorconfig.org/#download

I started to make a `stylelint-config-stripes`, so that FOLIO Stripes apps could have a shared config like `eslint-config-stripes`. Unfortunately, `stylelint` relies too heavily on absolute paths for a shared config to be set up in the same way as `eslint`. The `stylelint-config-standard` ruleset is much simpler than the `eslint-config-airbnb` ruleset, so we should be ok just relying on `stylelint-config-standard` in all FOLIO Stripes apps. When `stylelint` gets some refactoring to support global shared configs the same way `eslint` does, we can come back and create `stylelint-config-stripes`.

In the `stripes-components` `stylelint` setup, I set up more rules than I did here for `stripes-core`: https://github.com/folio-org/stripes-components/pull/93/files#diff-ab1d354bf78d8f05312122983731ff51. For `stripes-core`, I'd rather do one-off `stylelint-disable-line`s and encourage moving of almost all the CSS to `stripes-components`.

### Frequent errors
A sampling of the most common rules found in `stylelint-config-standard` that threw errors or warnings in `stripes-core`:
- `indentation`
- `no-missing-end-of-source-newline`
- `number-leading-zero`
- `block-opening-brace-space-before`
- `rule-empty-line-before`
- `max-empty-lines`
- `no-eol-whitespace`
- `selector-list-comma-newline-after`

## Learning
[Stylelint](https://stylelint.io)
[Full list of out-of-the-box stylelint rules](https://github.com/stylelint/stylelint/blob/eec8dd4b179f2b4c0b3b55415a42189a901c01b0/lib/rules/index.js)

## Screenshot
Sample `stylelint` output:

![screen shot 2017-11-17 at 12 06 42 pm](https://user-images.githubusercontent.com/230597/32961841-cb2398d4-cb8f-11e7-8abd-adf56ffbec6b.png)