### PR TITLE
DRY out notification text parsing. Fixes STCOR-104

### DIFF
--- a/src/components/MainNav/Notifications/NotificationsMenu.js
+++ b/src/components/MainNav/Notifications/NotificationsMenu.js
@@ -11,6 +11,8 @@ import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import Button from '@folio/stripes-components/lib/Button';
 import css from '@folio/stripes-components/lib/DropdownMenu/DropdownLayout.css';
 import menuStyles from './NotificationMenu.css';
+import mapDomainToPath from '../../../mapDomains';
+import uuidRe from '../../../uuidRe';
 
 class NotificationsMenu extends React.Component {
   static propTypes = {
@@ -86,13 +88,16 @@ class NotificationsMenu extends React.Component {
   notificationListFormatter(notification) {
     const formattedDate = moment(notification.metadata.createdDate).format(this.props.dateFormat);
 
-    const noteId = notification.text.match(/ ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}) /);
+    const noteId = notification.text.match(new RegExp(` (${uuidRe}) `, 'i'));
     const [domain, id] = notification.link.split('/');
-    const link = <Link to={`/${domain}/view/${id}?notes=${noteId.length === 2 ? noteId[1] : ''}`}>link</Link>;
+    const uiPath = mapDomainToPath(domain);
+    const link = <Link to={`/${uiPath}/view/${id}?notes=${noteId && noteId.length === 2 ? noteId[1] : ''}`}>link</Link>;
 
-    const re = new RegExp(` about ${domain}/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`);
-    const text = notification.text.replace(/ [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} /g, '')
-      .replace(re, '');
+    // pull the UUIDs out of the text. they're ugly and not meant for
+    // human consumption.
+    const text = notification.text
+      .replace(new RegExp(` ${uuidRe} `, 'ig'), '')
+      .replace(new RegExp(` about ${domain}/${uuidRe}`, 'i'), '');
 
     return (
       <Row key={notification.id} onClick={() => { this.onClickNotification(notification); }} className={this.getNotificationClass(notification.date)}>

--- a/src/mapDomains.js
+++ b/src/mapDomains.js
@@ -1,0 +1,17 @@
+const domainToPath = {
+  items: 'inventory',
+  instances: 'inventory',
+};
+
+/**
+ * Given the domain portion of a link from a notification, map it to the
+ * path the corresponding application is deployed to. Under most circumstances
+ * this is the same as the domain, but it may be overridden by an entry in
+ * the domainToPath table, which should eventually be replaced with a value
+ * pulled from an app registry, but we haven't built an app registry yet.
+ *
+ * @param {string} domain string
+ */
+export default function mapDomainToPath(domain) {
+  return (domainToPath[domain] ? domainToPath[domain] : domain);
+}

--- a/src/uuidRe.js
+++ b/src/uuidRe.js
@@ -1,0 +1,2 @@
+/** match a v4 UUID; https://tools.ietf.org/html/rfc4122#section-4.1.3 */
+export default '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';


### PR DESCRIPTION
Use a single constant for the regular expression responsible for finding
UUIDs in the text, and import a function to handle the mapping from a
note's link's domain attribute to a URL so that it can easily be
replaced with something that reads from an application registry once we
finally write an application registry.

You may note that there are many UUID regular expression packages out
there in NPM land. All of them return an actual RegEx object, but in
this case we need the string that we can construct our own RegEx object
around.