### PR TITLE
UIEH-107 ie11

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,4 @@
     <div id="root">
     </div>
   </body>
-</body>
 </html>

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -36,7 +36,7 @@ function parseStripesModules(enabledModules, context, alias) {
     const { stripes, description, version } = loadDefaults(context, moduleName, alias);
     const stripeConfig = Object.assign({}, stripes, moduleConfig, {
       module: moduleName,
-      getModule: eval(`() => require('${moduleName}').default`), // eslint-disable-line no-eval
+      getModule: eval(`new Function([], "return require('${moduleName}').default;")`), // eslint-disable-line no-eval
       description,
       version,
     });

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -36,7 +36,7 @@ function parseStripesModules(enabledModules, context, alias) {
     const { stripes, description, version } = loadDefaults(context, moduleName, alias);
     const stripeConfig = Object.assign({}, stripes, moduleConfig, {
       module: moduleName,
-      getModule: eval(`new Function([], "return require('${moduleName}').default;")`), // eslint-disable-line no-eval
+      getModule: new Function([], `return require('${moduleName}').default;`), // eslint-disable-line no-new-func
       description,
       version,
     });


### PR DESCRIPTION
The virtual module, `stripes-config`, created by stripes-config-plugin does not appear to pass through Babel and therefore the arrow functions for each `getModule()` are left in the code which IE cannot deal with. 

The solution using `new Function()` appears to negate the need for `eval()` due to the similar nature in parsing.   For reference, `eval()` did not want to accept a function expression without the arrow syntax, thus the use of `new Function()` constructor.  Such parsing is needed with `getModule` for feeding app entry points to webpack via require.  This approach may change when we introduce code-splitting.

This issue could also be solved by determining how to pass the `stripes-config` virtual module through the Babel loader.  However, adjusting the one line in stripes-config-plugin was quick to verify and the remainder of `stripes-config` has nothing to transpile at the moment.  Still, transpilation is perhaps the better long term solution and should eventually be addressed particularly if we ever find a need for creating multiple virtual modules.