### PR TITLE
Always set EnvironmentPlugin for NODE_ENV

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -1,5 +1,5 @@
 // Common Webpack configuration for building Stripes
-
+const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const generateStripesAlias = require('./webpack/generate-stripes-alias');
@@ -25,6 +25,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: `${__dirname}/index.html`,
     }),
+    new webpack.EnvironmentPlugin(['NODE_ENV']),
   ],
   module: {
     rules: [

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -1,7 +1,6 @@
 // Top level Webpack configuration for building static files for
 // production deployment from the command line
 
-const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const postCssImport = require('postcss-import');
@@ -24,7 +23,6 @@ prodConfig.plugins = prodConfig.plugins.concat([
   new ExtractTextPlugin({ filename: 'style.[contenthash].css', allChunks: true }),
   new OptimizeCssAssetsPlugin(),
   new StripesDuplicatesPlugin(),
-  new webpack.EnvironmentPlugin(['NODE_ENV']),
 ]);
 
 prodConfig.module.rules.push({


### PR DESCRIPTION
This moves the webpack EnvironmentPlugin to the base config so NODE_ENV is available in both dev and prod builds.