### PR TITLE
in discovery, retrieve modules per-tenant. Fixes STCOR-114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Move about under settings. Fixes STCOR-123.
 * Support loading SVG images via WebPack. Fixes STCOR-124.
 * Add support for basic tenant branding of logo and favicon via stripes config. FOLIO-988.
+* In discovery, retrieve modules installed per-tenant instead of globally. STCOR-114.
 
 ## [2.8.0](https://github.com/folio-org/stripes-core/tree/v2.8.0) (2017-11-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.7.0...v2.8.0)

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -22,9 +22,10 @@ function discoverInterfaces(okapiUrl, store, entry) {
     });
 }
 
-export function discoverServices(okapiUrl, store) {
+export function discoverServices(store) {
+  const okapi = store.getState().okapi;
   return Promise.all([
-    fetch(`${okapiUrl}/_/version`)
+    fetch(`${okapi.url}/_/version`)
       .then((response) => { // eslint-disable-line consistent-return
         if (response.status >= 400) {
           store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
@@ -36,14 +37,14 @@ export function discoverServices(okapiUrl, store) {
       }).catch((reason) => {
         store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
       }),
-    fetch(`${okapiUrl}/_/proxy/modules`)
+    fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules`)
       .then((response) => { // eslint-disable-line consistent-return
         if (response.status >= 400) {
           store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
         } else {
           return response.json().then((json) => {
             store.dispatch({ type: 'DISCOVERY_SUCCESS', data: json });
-            return Promise.all(json.map(entry => discoverInterfaces(okapiUrl, store, entry)));
+            return Promise.all(json.map(entry => discoverInterfaces(okapi.url, store, entry)));
           });
         }
       }).catch((reason) => {

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const epics = configureEpics(connectErrorEpic);
 const logger = configureLogger(config);
 logger.log('core', 'Starting Stripes ...');
 const store = configureStore(initialState, logger, epics);
-discoverServices(okapi.url, store);
+discoverServices(store);
 const actionNames = gatherActions();
 
 render(


### PR DESCRIPTION
Previously, `discoverServices()` retrieved the list of globally-available modules rather than those enabled only for the current tenant. On a system with a large number of modules, or with many versions of modules, this led to horrible performance on login while waiting for 1000+ requests to complete as each module was inspected. 