### PR TITLE
Allow use of Stripes without Okapi

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -33,7 +33,7 @@ const RootWithIntl = (props, context) => {
           { token || disableAuth ?
             <MainContainer>
               <MainNav stripes={stripes} />
-              { stripes.discovery.isFinished && (
+              { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
                 <ModuleContainer id="content">
                   <Switch>
                     <Route exact path="/" component={() => <Front stripes={stripes} />} key="root" />

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -40,6 +40,7 @@ class MainNav extends Component {
         dispatch: PropTypes.func.isRequired,
       }),
       hasPerm: PropTypes.func.isRequired,
+      withOkapi: PropTypes.bool,
     }),
     history: PropTypes.shape({
       listen: PropTypes.func.isRequired,
@@ -242,7 +243,7 @@ class MainNav extends Component {
               )
             }
             <NavDivider md="hide" />
-            { this.props.stripes.hasPerm('notify.item.get,notify.item.put,notify.collection.get') && <NotificationsDropdown stripes={stripes} {...this.props} /> }
+            { this.props.stripes.withOkapi && this.props.stripes.hasPerm('notify.item.get,notify.item.put,notify.collection.get') && <NotificationsDropdown stripes={stripes} {...this.props} /> }
           </NavGroup>
           <NavGroup className={css.smallAlignRight}>
             <Dropdown open={this.state.userMenuOpen} id="UserMenuDropDown" onToggle={this.toggleUserMenu} pullRight >

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -23,6 +23,7 @@ class Root extends Component {
     super(...args);
     this.reducers = { ...initialReducers };
     this.epics = {};
+    this.withOkapi = this.props.okapi.withoutOkapi !== true;
 
     for (const app of modules.app) {
       if (window.location.pathname.startsWith(app.route) && app.queryResource) {
@@ -40,13 +41,13 @@ class Root extends Component {
 
   componentWillMount() {
     const { okapi, store, locale } = this.props;
-    checkOkapiSession(okapi.url, store, okapi.tenant);
+    if (this.withOkapi) checkOkapiSession(okapi.url, store, okapi.tenant);
     // TODO: remove this after we load locale and translations at start from a public endpoint
     loadTranslations(store, locale);
   }
 
   shouldComponentUpdate(nextProps) {
-    return nextProps.okapiReady;
+    return !this.withOkapi || nextProps.okapiReady;
   }
 
   addReducer = (key, reducer) => {
@@ -77,7 +78,7 @@ class Root extends Component {
   render() {
     const { logger, store, epics, config, okapi, actionNames, token, disableAuth, currentUser, currentPerms, locale, plugins, bindings, discovery, translations, history } = this.props;
 
-    if (!translations) return (<div />);
+    if (false && !translations) return (<div />);
 
     const stripes = new Stripes({
       logger,
@@ -85,6 +86,7 @@ class Root extends Component {
       epics,
       config,
       okapi,
+      withOkapi: this.withOkapi,
       setToken: (val) => { store.dispatch(setOkapiToken(val)); },
       actionNames,
       locale,
@@ -133,9 +135,9 @@ Root.propTypes = {
   bindings: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   config: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   okapi: PropTypes.shape({
-    url: PropTypes.string.isRequired,
-    tenant: PropTypes.string.isRequired,
-  }).isRequired,
+    url: PropTypes.string,
+    tenant: PropTypes.string,
+  }),
   actionNames: PropTypes.arrayOf(
     PropTypes.string,
   ).isRequired,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
-import { okapi, config } from 'stripes-config'; // eslint-disable-line
+import { okapi as okapiConfig, config } from 'stripes-config'; // eslint-disable-line
 
 import connectErrorEpic from './connectErrorEpic';
 import configureEpics from './configureEpics';
@@ -12,12 +12,13 @@ import gatherActions from './gatherActions';
 
 import Root from './components/Root';
 
+const okapi = (typeof okapiConfig === 'object') ? okapiConfig : { withoutOkapi: true };
 const initialState = { okapi };
 const epics = configureEpics(connectErrorEpic);
 const logger = configureLogger(config);
 logger.log('core', 'Starting Stripes ...');
 const store = configureStore(initialState, logger, epics);
-discoverServices(store);
+if (!okapi.withoutOkapi) discoverServices(store);
 const actionNames = gatherActions();
 
 render(


### PR DESCRIPTION
If you don't provide an Okapi section in your Stripes configuration this allows Stripes to continue building. Useful for demoing with the trivial app or building a fully FOLIO front-end that can also work standalone with the same code base. 

Currently requires hasAllPerms and disableAuth in config as we haven't made auth modular yet.