### PR TITLE
Update babel loader test condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 * In discovery, retrieve modules installed per-tenant instead of globally. STCOR-114.
 * Push new URLs onto history instead of replacing old one. Fixes STCOR-128.
 * Add "Home" link to user menu, but only when "showHomeLink" developer option is on. Fixes STCOR-130 and STCOR-131.
+* Extend babel-loader test condition to exclude specific folio-scoped modules. Fixes STRIPES-499
 
-Fixes STCOR-131.
 
 ## [2.8.0](https://github.com/folio-org/stripes-core/tree/v2.8.0) (2017-11-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.7.0...v2.8.0)

--- a/test/webpack/babel-loader-rule.spec.js
+++ b/test/webpack/babel-loader-rule.spec.js
@@ -7,25 +7,13 @@ describe('The babel-loader-rule', function () {
       this.sut = babelLoaderRule.test;
     });
 
-    it('selects files for @folio scoped modules', function () {
+    it('selects files for @folio scoped node_modules', function () {
       const fileName = '/projects/folio/folio-testing-platform/node_modules/@folio/inventory/index.js';
       const result = this.sut(fileName);
       expect(result).to.equal(true);
     });
 
-    it('does not select node_modules files', function () {
-      const fileName = '/projects/folio/folio-testing-platform/node_modules/lodash/lodash.js';
-      const result = this.sut(fileName);
-      expect(result).to.equal(false);
-    });
-
-    it('select @folio scoped files within node_modules', function () {
-      const fileName = '/projects/folio/folio-testing-platform/node_modules/@folio/users/settings/index.js';
-      const result = this.sut(fileName);
-      expect(result).to.equal(true);
-    });
-
-    it('does not select node_modules files of @folio scoped modules', function () {
+    it('does not select node_modules files outside of @folio scope', function () {
       const fileName = '/projects/folio/folio-testing-platform/node_modules/lodash/lodash.js';
       const result = this.sut(fileName);
       expect(result).to.equal(false);
@@ -37,7 +25,7 @@ describe('The babel-loader-rule', function () {
       expect(result).to.equal(false);
     });
 
-    it('selects files outside of @folio scope and node_modules', function () {
+    it('selects files outside of both @folio scope and node_modules', function () {
       // This test case would hold true for yarn-linked modules, @folio scoped or otherwise
       // Therefore this implies that we are not yarn-linking any non-@folio scoped modules
       const fileName = '/projects/folio/stripes-core/src/configureLogger.js';

--- a/test/webpack/babel-loader-rule.spec.js
+++ b/test/webpack/babel-loader-rule.spec.js
@@ -44,5 +44,11 @@ describe('The babel-loader-rule', function () {
       const result = this.sut(fileName);
       expect(result).to.equal(true);
     });
+
+    it('does not select excluded modules', function () {
+      const fileName = '/projects/folio/stripes-smart-components/node_modules/@folio/react-githubish-mentions/lib/MentionMenu.js';
+      const result = this.sut(fileName);
+      expect(result).to.equal(false);
+    });
   });
 });

--- a/test/webpack/babel-loader-rule.spec.js
+++ b/test/webpack/babel-loader-rule.spec.js
@@ -1,0 +1,48 @@
+const expect = require('chai').expect;
+const babelLoaderRule = require('../../webpack/babel-loader-rule');
+
+describe('The babel-loader-rule', function () {
+  describe('test condition function', function () {
+    beforeEach(function () {
+      this.sut = babelLoaderRule.test;
+    });
+
+    it('selects files for @folio scoped modules', function () {
+      const fileName = '/projects/folio/folio-testing-platform/node_modules/@folio/inventory/index.js';
+      const result = this.sut(fileName);
+      expect(result).to.equal(true);
+    });
+
+    it('does not select node_modules files', function () {
+      const fileName = '/projects/folio/folio-testing-platform/node_modules/lodash/lodash.js';
+      const result = this.sut(fileName);
+      expect(result).to.equal(false);
+    });
+
+    it('select @folio scoped files within node_modules', function () {
+      const fileName = '/projects/folio/folio-testing-platform/node_modules/@folio/users/settings/index.js';
+      const result = this.sut(fileName);
+      expect(result).to.equal(true);
+    });
+
+    it('does not select node_modules files of @folio scoped modules', function () {
+      const fileName = '/projects/folio/folio-testing-platform/node_modules/lodash/lodash.js';
+      const result = this.sut(fileName);
+      expect(result).to.equal(false);
+    });
+
+    it('only selects .js file extensions', function () {
+      const fileName = '/project/folio/folio-testing-platform/node_modules/@folio/search/package.json';
+      const result = this.sut(fileName);
+      expect(result).to.equal(false);
+    });
+
+    it('selects files outside of @folio scope and node_modules', function () {
+      // This test case would hold true for yarn-linked modules, @folio scoped or otherwise
+      // Therefore this implies that we are not yarn-linking any non-@folio scoped modules
+      const fileName = '/projects/folio/stripes-core/src/configureLogger.js';
+      const result = this.sut(fileName);
+      expect(result).to.equal(true);
+    });
+  });
+});

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const generateStripesAlias = require('./webpack/generate-stripes-alias');
+const babelLoaderRule = require('./webpack/babel-loader-rule');
 
 // React doesn't like being included multiple times as can happen when using
 // yarn link. Here we find a more specific path to it by first looking in
@@ -29,29 +30,7 @@ module.exports = {
   ],
   module: {
     rules: [
-      {
-        test(fn) {
-          // We want to transpile files inside node_modules/@folio or outside
-          // any node_modules directory. And definitely not files in
-          // node_modules outside the @folio namespace even if some parent
-          // directory happens to be in @folio.
-          //
-          // fn is the path after all symlinks are resolved so we need to be
-          // wary of all the edge cases yarn link will find for us.
-          const nmidx = fn.lastIndexOf('node_modules');
-          if (fn.endsWith('.js') && (nmidx === -1 || fn.lastIndexOf('@folio') > nmidx)) return true;
-          return false;
-        },
-        loader: 'babel-loader',
-        options: {
-          cacheDirectory: true,
-          presets: [
-            [require.resolve('babel-preset-env'), { modules: false }],
-            [require.resolve('babel-preset-stage-2')],
-            [require.resolve('babel-preset-react')],
-          ],
-        },
-      },
+      babelLoaderRule,
       {
         test: /\.json$/,
         loader: 'json-loader',

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -1,16 +1,29 @@
+const path = require('path');
+
+// These modules are already transpiled and should be excluded
+const folioScopeBlacklist = [
+  'react-githubish-mentions',
+].map(segment => path.join('@folio', segment));
+
+// We want to transpile files inside node_modules/@folio or outside
+// any node_modules directory. And definitely not files in
+// node_modules outside the @folio namespace even if some parent
+// directory happens to be in @folio.
+//
+// fn is the path after all symlinks are resolved so we need to be
+// wary of all the edge cases yarn link will find for us.
+function babelLoaderTest(fileName) {
+  const nodeModIdx = fileName.lastIndexOf('node_modules');
+  if (fileName.endsWith('.js')
+    && (nodeModIdx === -1 || fileName.lastIndexOf('@folio') > nodeModIdx)
+    && (folioScopeBlacklist.findIndex(ignore => fileName.includes(ignore)) === -1)) {
+    return true;
+  }
+  return false;
+}
+
 module.exports = {
-  test(fn) {
-    // We want to transpile files inside node_modules/@folio or outside
-    // any node_modules directory. And definitely not files in
-    // node_modules outside the @folio namespace even if some parent
-    // directory happens to be in @folio.
-    //
-    // fn is the path after all symlinks are resolved so we need to be
-    // wary of all the edge cases yarn link will find for us.
-    const nmidx = fn.lastIndexOf('node_modules');
-    if (fn.endsWith('.js') && (nmidx === -1 || fn.lastIndexOf('@folio') > nmidx)) return true;
-    return false;
-  },
+  test: babelLoaderTest,
   loader: 'babel-loader',
   options: {
     cacheDirectory: true,

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -1,0 +1,23 @@
+module.exports = {
+  test(fn) {
+    // We want to transpile files inside node_modules/@folio or outside
+    // any node_modules directory. And definitely not files in
+    // node_modules outside the @folio namespace even if some parent
+    // directory happens to be in @folio.
+    //
+    // fn is the path after all symlinks are resolved so we need to be
+    // wary of all the edge cases yarn link will find for us.
+    const nmidx = fn.lastIndexOf('node_modules');
+    if (fn.endsWith('.js') && (nmidx === -1 || fn.lastIndexOf('@folio') > nmidx)) return true;
+    return false;
+  },
+  loader: 'babel-loader',
+  options: {
+    cacheDirectory: true,
+    presets: [
+      [require.resolve('babel-preset-env'), { modules: false }],
+      [require.resolve('babel-preset-stage-2')],
+      [require.resolve('babel-preset-react')],
+    ],
+  },
+};


### PR DESCRIPTION
Our fork of `react-githubish-mentions` is under the `@folio` scope and therefore stripes-core attempts to transpile it based on the current babel-loader test condition.  This results in a build error for a missing es2015 preset which Stripes does not use.  

This fix updates the current babel loader test condition to exclude specific folio-scoped modules from selection.  Tests were added before this change to ensure we continue to capture the various desired use cases.

Fixes STRIPES-499.