### PR TITLE
Passing missing id prop to NavButton

### DIFF
--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -3,7 +3,6 @@
 .navButton {
   margin: 0 5px;
   height: 44px;
-  color: rgba(0, 0, 0, 0.61);
   outline: 0;
 
   &::-moz-focus-inner {
@@ -12,8 +11,6 @@
 
   /* Is selected */
   &.selected {
-    color: rgba(0, 0, 0, 1);
-
     &::before {
       content: '';
       position: absolute;
@@ -33,6 +30,16 @@
         fill: var(--primary);
       }
     }
+  }
+}
+
+/* To make sure we overwrite default link colors */
+a.navButton,
+button.navButton {
+  color: rgba(0, 0, 0, 0.61);
+
+  &.selected {
+    color: rgba(0, 0, 0, 1);
   }
 }
 

--- a/src/components/MainNav/NavButton/NavButton.js
+++ b/src/components/MainNav/NavButton/NavButton.js
@@ -11,6 +11,7 @@ const propTypes = {
   label: PropTypes.string,
   title: PropTypes.string,
   className: PropTypes.string,
+  id: PropTypes.string,
   icon: PropTypes.oneOfType([
     PropTypes.element,
   ]),
@@ -27,7 +28,7 @@ const defaultProps = {
   noSelectedBar: false,
 };
 
-const NavButton = withRouter(({ history, label, title, selected, onClick, href, icon, noSelectedBar, className, badge }) => {
+const NavButton = withRouter(({ history, label, title, selected, onClick, href, icon, noSelectedBar, className, badge, id }) => {
   /**
    * Root classes
    */
@@ -57,7 +58,7 @@ const NavButton = withRouter(({ history, label, title, selected, onClick, href, 
   const Element = typeof onClick === 'function' || href ? 'button' : 'span';
 
   return (
-    <Element title={title} className={rootClasses} onClick={clickEvent} role="button">
+    <Element id={id} title={title} className={rootClasses} onClick={clickEvent} role="button">
       <div className={css.inner}>
         { badge && (<Badge color="red" className={css.badge}>{badge}</Badge>) }
         { displayIcon }

--- a/src/components/MainNav/NavButton/NavButton.js
+++ b/src/components/MainNav/NavButton/NavButton.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Link from 'react-router-dom/Link';
 import AppIcon from '@folio/stripes-components/lib/AppIcon';
 import Badge from '@folio/stripes-components/lib/Badge';
-import { withRouter } from 'react-router-dom';
 import css from './NavButton.css';
 
 const propTypes = {
@@ -28,7 +28,7 @@ const defaultProps = {
   noSelectedBar: false,
 };
 
-const NavButton = withRouter(({ history, label, title, selected, onClick, href, icon, noSelectedBar, className, badge, id }) => {
+const NavButton = ({ label, title, selected, onClick, href, icon, noSelectedBar, className, badge, id }) => {
   /**
    * Root classes
    */
@@ -44,21 +44,31 @@ const NavButton = withRouter(({ history, label, title, selected, onClick, href, 
    */
   const displayIcon = (<span className={css.icon}>{icon || <AppIcon focusable={false} />}</span>);
 
-  /**
-   * On click
-   */
-  const clickEvent = () => {
-    if (onClick) {
-      onClick();
-    } else if (href) {
-      history.push(href);
-    }
-  };
+  let Element = 'span';
+  let clickableProps = {};
 
-  const Element = typeof onClick === 'function' || href ? 'button' : 'span';
+  /**
+   * Is link (use react-router link)
+   */
+  if (href) {
+    Element = Link;
+    clickableProps = {
+      to: href,
+    };
+  }
+
+  /**
+   * Is button (with onClick handler)
+   */
+  if (typeof onClick === 'function') {
+    Element = 'button';
+    clickableProps = {
+      onClick,
+    };
+  }
 
   return (
-    <Element id={id} title={title} className={rootClasses} onClick={clickEvent} role="button">
+    <Element id={id} title={title} className={rootClasses} role="button" {...clickableProps}>
       <div className={css.inner}>
         { badge && (<Badge color="red" className={css.badge}>{badge}</Badge>) }
         { displayIcon }
@@ -66,7 +76,7 @@ const NavButton = withRouter(({ history, label, title, selected, onClick, href, 
       </div>
     </Element>
   );
-});
+};
 
 NavButton.propTypes = propTypes;
 NavButton.defaultProps = defaultProps;


### PR DESCRIPTION
The id's were missing on nav buttons as mentioned here: https://issues.folio.org/browse/STCOR-132

This fixes that issue by padding the prop down to the button element.

I also added so that the element is changed to an anchor tag if a href-prop is provided. This enables right-click to open in new tab/window.