### PR TITLE
`link-stripes -i` skips platform packages, quietly re-links already-linked packages, and exits when done. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add new document, [Stripes application metadata bundles](doc/app-metadata.md). Fixes STCOR-117 and STCOR-129.
 * Extend babel-loader test condition to exclude specific folio-scoped modules. Fixes STRIPES-499
 * Add `-c` (clone git repositories) mode to `pull-stripes`. Fixes STCOR-135.
+* `link-stripes -i` skips platform packages, quietly re-links already-linked packages, and exits when done. Fixes STCOR-136.
 
 ## [2.8.0](https://github.com/folio-org/stripes-core/tree/v2.8.0) (2017-11-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.7.0...v2.8.0)

--- a/util/link-stripes
+++ b/util/link-stripes
@@ -27,9 +27,18 @@ if (@ARGV == 1) {
 
 if ($initialise) {
     foreach my $dir (<stripes-*>) {
-	print "* Initialising linkability for '$dir'\n";
-	system "cd $dir && yarn link"
+	if ($dir =~ /-platform$/) {
+	    print "* Skipping linkability for platform '$dir'\n";
+	} else {
+	    print "* Initialising linkability for '$dir'\n";
+	    # Stupidly, there is no way to ask yarn whether there is
+	    # already a link in place, so the best we can do is try to
+	    # unlink and discard whatever error it emits.
+	    system "cd $dir && yarn unlink > /dev/null 2>&1 || true";
+	    system "cd $dir && yarn link"
+	}
     }
+    exit;
 }
 
 foreach my $dir (<stripes-* ui-*>) {

--- a/util/link-stripes
+++ b/util/link-stripes
@@ -26,8 +26,10 @@ if (@ARGV == 1) {
 }
 
 if ($initialise) {
-    foreach my $dir (<stripes-*>) {
+    foreach my $dir (<stripes-* ui-* ui-plugin-example/plugin-*>) {
 	if ($dir =~ /-platform$/) {
+	    print "* Skipping linkability for platform '$dir'\n";
+	} elsif ($dir eq 'ui-plugin-example') {
 	    print "* Skipping linkability for platform '$dir'\n";
 	} else {
 	    print "* Initialising linkability for '$dir'\n";

--- a/util/pull-stripes
+++ b/util/pull-stripes
@@ -43,6 +43,7 @@ dirs=`echo '
     ui-search
     ui-testing
     ui-trivial
+    ui-items
     eslint-config-stripes
 '`
 


### PR DESCRIPTION
Fixes STCOR-136.