### PR TITLE
Add proper path for stripes-core when looking for "@folio/stripe-core"

### DIFF
--- a/webpack/module-paths.js
+++ b/webpack/module-paths.js
@@ -37,7 +37,12 @@ function locateStripesModule(context, moduleName, alias, ...segments) {
     path.join(moduleName, ...segments), { paths: [context] }, // This better incorporates the context path but requires nodejs 9+
   ];
 
-  // When available, ty for the alias first
+  // If we are looking for anything in stripes-core, then we are already there!
+  if (moduleName === '@folio/stripes-core') {
+    tryPaths.unshift(path.join(__dirname, '..', ...segments));
+  }
+
+  // When available, try for the alias first
   if (alias[moduleName]) {
     tryPaths.unshift(path.join(alias[moduleName], ...segments));
   }

--- a/webpack/stripes-build-error.js
+++ b/webpack/stripes-build-error.js
@@ -1,0 +1,7 @@
+module.exports = class StripesBuildError extends Error {
+  constructor(...args) {
+    super(...args);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, StripesBuildError);
+  }
+};

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -59,6 +59,9 @@ module.exports = class StripesTranslationPlugin {
     const allTranslations = {};
     for (const mod of Object.keys(this.modules)) {
       const modPackageJsonPath = modulePaths.locateStripesModule(this.context, mod, this.aliases, 'package.json');
+      if (!modPackageJsonPath) {
+        throw new StripesBuildError(`Unable to locate ${mod} while looking for translations.`);
+      }
       const modTranslationDir = modPackageJsonPath.replace('package.json', 'translations');
 
       if (fs.existsSync(modTranslationDir)) {

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const _ = require('lodash');
 const webpack = require('webpack');
 const modulePaths = require('./module-paths');
+const StripesBuildError = require('./stripes-build-error');
 
 function prefixKeys(obj, prefix) {
   const res = {};


### PR DESCRIPTION
This is necessary because stripes-core (where the code is current running) will not be a folio-scoped dependency path.

This was an issue in some environments when looking for /translations within stripes-core.

Fixes STCOR-143 and related to STCOR-49.