### PR TITLE
Improve button style consistency 

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -91,7 +91,7 @@ class Login extends Component {
               />
             </div>
             <div className={authFormStyles.formGroup}>
-              <Button id="clickable-login" type="submit" buttonClass={authFormStyles.submitButton} disabled={buttonDisabled} fullWidth marginBottom0>
+              <Button buttonStyle="primary" id="clickable-login" type="submit" buttonClass={authFormStyles.submitButton} disabled={buttonDisabled} fullWidth marginBottom0>
                 {buttonLabel}
               </Button>
             </div>

--- a/src/components/Notification/ToastNotification.js
+++ b/src/components/Notification/ToastNotification.js
@@ -113,7 +113,7 @@ class ToastNotification extends React.Component {
       <Layout className="flex full justified centerItems">
         {this.props.message}
         <Button
-          buttonStyle="transparent"
+          buttonStyle="link"
           title="Dismiss this message"
           onClick={this.handleHide}
         >
@@ -124,7 +124,7 @@ class ToastNotification extends React.Component {
       <Layout className="flex full justified centerItems">
         {this.props.message}
         <Button
-          buttonStyle="transparent"
+          buttonStyle="link"
           title="Dismiss this message"
           onClick={this.handleHide}
         >

--- a/src/components/SSOLogin/SSOLogin.js
+++ b/src/components/SSOLogin/SSOLogin.js
@@ -14,7 +14,7 @@ function SSOLogin(props) {
 
   return (
     <div className={authFormStyles.formGroup}>
-      <Button type="button" buttonClass={authFormStyles.submitButton} onClick={handleSSOLogin} fullWidth>Login via SSO</Button>
+      <Button buttonStyle="primary" type="button" buttonClass={authFormStyles.submitButton} onClick={handleSSOLogin} fullWidth>Login via SSO</Button>
       <form id="ssoForm" />
     </div>
   );


### PR DESCRIPTION
Follow-up to https://github.com/folio-org/stripes-components/pull/209.

1. `transparent` is no longer an available button style; replaced with `link`
2. Now that `primary` is no longer the default button style (now `default` is), the primary action buttons on login pages needed that style applied.