### PR TITLE
Avoid module name for local files and allow absolute paths for branding

### DIFF
--- a/default-assets/branding.js
+++ b/default-assets/branding.js
@@ -3,10 +3,10 @@
 // and processed through the webpack loaders from the stripes-core in use.
 module.exports = {
   logo: {
-    src: '@folio/stripes-core/default-assets/folio-logo.svg',
+    src: `${__dirname}/folio-logo.svg`,
     alt: 'Future Of Libraries Is Open',
   },
   favicon: {
-    src: '@folio/stripes-core/default-assets/favicon.ico',
+    src: `${__dirname}/favicon.ico`,
   },
 };

--- a/test/webpack/stripes-branding-plugin.spec.js
+++ b/test/webpack/stripes-branding-plugin.spec.js
@@ -59,11 +59,10 @@ describe('The stripes-branding-plugin', function () {
   });
 
   describe('_serializeBranding method', function () {
-    it('maintains default @folio/stripes-core src paths', function () {
+    it('maintains absolute src paths', function () {
       const result = StripesBrandingPlugin._serializeBranding(defaultBranding);
       expect(result).to.be.a('string')
-        .which.includes(`'${defaultBranding.logo.src}'`)
-        .and.includes('@folio/stripes-core');
+        .which.includes(`'${defaultBranding.logo.src}'`);
     });
 
     it('updates custom src paths', function () {

--- a/webpack/stripes-branding-plugin.js
+++ b/webpack/stripes-branding-plugin.js
@@ -26,7 +26,7 @@ module.exports = class StripesBrandingPlugin {
   // Serialize the branding config.
   static _serializeBranding(branding) {
     const assetPath = (thePath) => {
-      if (thePath.startsWith('/')) {
+      if (path.isAbsolute(thePath)) {
         return thePath;
       }
 
@@ -52,7 +52,7 @@ module.exports = class StripesBrandingPlugin {
 
   // Prep favicon path for use with HtmlWebpackPlugin
   static _initFavicon(favicon) {
-    if (favicon.startsWith('/')) {
+    if (path.isAbsolute(favicon)) {
       return favicon;
     }
     return path.join(path.resolve(), favicon);

--- a/webpack/stripes-branding-plugin.js
+++ b/webpack/stripes-branding-plugin.js
@@ -26,8 +26,8 @@ module.exports = class StripesBrandingPlugin {
   // Serialize the branding config.
   static _serializeBranding(branding) {
     const assetPath = (thePath) => {
-      if (thePath.startsWith('@folio/stripes-core')) {
-        return thePath; // leave as-is and import defaults from stripes-core
+      if (thePath.startsWith('/')) {
+        return thePath;
       }
 
       return path.join('..', thePath); // Look outside the node_modules directory
@@ -52,9 +52,8 @@ module.exports = class StripesBrandingPlugin {
 
   // Prep favicon path for use with HtmlWebpackPlugin
   static _initFavicon(favicon) {
-    if (favicon.startsWith('@folio/stripes-core')) {
-      // The plugin wants a file path for this
-      return path.join(__dirname, '..', favicon.replace('@folio/stripes-core', ''));
+    if (favicon.startsWith('/')) {
+      return favicon;
     }
     return path.join(path.resolve(), favicon);
   }


### PR DESCRIPTION
This enables us to once again list a relative path for a module in a Stripes config and launch stripes.js from within core. Very helpful for integration testing of stripes-core as we can just check in some mocked modules and refer to them with little fuss.