### PR TITLE
Specify 'minimal' preset and upgrade webpack-dev-middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "uglifyjs-webpack-plugin": "^1.1.8",
     "uuid": "^3.0.0",
     "webpack": "^3.4.1",
-    "webpack-dev-middleware": "^1.10.0",
+    "webpack-dev-middleware": "^2.0.4",
     "webpack-hot-middleware": "^2.16.1",
     "webpack-virtual-modules": "^0.1.8"
   }

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -62,7 +62,8 @@ module.exports = function serve(stripesConfig, options) {
     app.use(connectHistoryApiFallback({}));
 
     app.use(webpackDevMiddleware(compiler, {
-      noInfo: true,
+      logLevel: 'warn',
+      stats: 'minimal',
       publicPath: config.output.publicPath,
     }));
 


### PR DESCRIPTION
The main cause of the noise is that when any one warning is present, webpack-dev-server will [output all stats as a warning](https://github.com/webpack/webpack-dev-middleware/blob/236afb1c28e443e4fd9cddff9973e8edfe9e5f0b/lib/reporter.js#L10-L16), rather than output only the warnings themselves.  The same is true for errors.

As a quick solution, the `minimal` stats preset is sufficient to quiet the output.  Warnings and errors will still show.  We always can opt for more [fine-grained control](https://webpack.js.org/configuration/stats/#stats) of stats options or [write our own reporter](https://github.com/webpack/webpack-dev-middleware#reporter) if so desired.

Builds will continue to receive the default output.

Fixes STCOR-144