### PR TITLE
remove ui-okapi-console from pull-stripes; it's deprecated. Fixes STCOR-156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * New document, [Depending on unreleased features](doc/depending-on-unreleased-features.md). Fixes STCOR-152.
 * Reorganize [Creating a new development setup for Stripes](doc/new-development-setup.md) and add `configure` script. Refs STCOR-140.
 * Update docs to reflect that "stripescli" is now "stripes". Refs STCLI-11. 
+* Remove ui-okapi-console from pull-stripes; it's deprecated. Fixes STCOR-156.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/util/pull-stripes
+++ b/util/pull-stripes
@@ -29,7 +29,6 @@ dirs=`echo '
     stripes-sample-platform
     stripes-demo-platform
     folio-testing-platform
-    ui-okapi-console
     ui-users
     ui-inventory
     ui-eholdings


### PR DESCRIPTION
Fixes [STCOR-156](https://issues.folio.org/browse/STCOR-156).