### PR TITLE
Removed href from active menu button when on settings.

### DIFF
--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -178,7 +178,7 @@ class MainNav extends Component {
           }
           {
             stripes.hasPerm('settings.enabled') && pathname.startsWith('/settings') &&
-            <NavButton label="Settings" href={this.lastVisited.x_settings || '/settings'} />
+            <NavButton label="Settings" />
           }
         </NavGroup>
       );


### PR DESCRIPTION
 This is the default behaviour until the active menu item to the left becomes a dropdown in the future.