### PR TITLE
STCOR-159 Render current app as h1, setup default display

### DIFF
--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -17,7 +17,7 @@
 /**
  * Badge
  */
- .badge {
+.badge {
   font-size: 10px;
   position: absolute;
   top: 0;

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -2,17 +2,41 @@
  * Current App
  */
 
-/**
- * Button
- */
-button.currentAppButton {
-  margin: 0;
-  overflow: auto;
-  padding: 2px 2px 2px 4px;
-  height: auto;
-  max-height: none;
+.currentApp {
+  padding: 0 5px;
+  height: 44px;
+  outline: 0;
+  display: flex;
+  align-items: center;
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }
 
-.currentAppButtonLabel {
-  margin: 0 6px;
+/**
+ * Badge
+ */
+ .badge {
+  font-size: 10px;
+  position: absolute;
+  top: 0;
+  right: -1px;
+  z-index: 5;
+}
+
+.icon {
+  opacity: 0.75;
+  height: 24px;
+  margin: 0 4px;
+
+  & img,
+  & svg {
+    height: 24px;
+    width: 24px;
+  }
+
+  & svg {
+    fill: #999;
+  }
 }

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -4,22 +4,47 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import NavButton from '../NavButton';
+import classNames from 'classnames';
+import Link from 'react-router-dom/Link';
+import AppIcon from '@folio/stripes-components/lib/AppIcon';
+import Badge from '@folio/stripes-components/lib/Badge';
+import Headline from '@folio/stripes-components/lib/Headline';
+import css from './CurrentApp.css';
 
 const propTypes = {
-  currentApp: PropTypes.object,
+  currentApp: PropTypes.shape(
+    {
+      displayName: PropTypes.string, 
+      description: PropTypes.string
+    }),
+  id: PropTypes.string,
+  icon: PropTypes.oneOfType([
+    PropTypes.element,
+  ]),
+  badge: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
 };
 
-const CurrentApp = ({ currentApp }) => {
-  const { displayName, description } = currentApp;
+const defaultProps = {
+  currentApp: {displayName: 'FOLIO', description: 'FOLIO platform'}
+}
+
+const CurrentApp = ({ currentApp, icon, badge, id }) => {
+
+  const displayIcon = (<div className={css.icon}>{icon || <AppIcon focusable={false} />}</div>);
+
   return (
-    <NavButton
-      label={displayName}
-      title={description}
-    />
+    <div id={id} title={currentApp.description} className={css.currentApp}>
+        { badge && (<Badge color="red" className={css.badge}>{badge}</Badge>) }
+        { displayIcon }
+        <Headline tag="h1" size="small" style={{margin: 0}} >{currentApp.displayName}</Headline>
+    </div>
   );
 };
 
 CurrentApp.propTypes = propTypes;
+CurrentApp.defaultProps = defaultProps;
 
 export default CurrentApp;

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -37,7 +37,7 @@ const CurrentApp = ({ currentApp, icon, badge, id }) => {
     <div id={id} title={currentApp.description} className={css.currentApp}>
       {badge && (<Badge color="red" className={css.badge}>{badge}</Badge>)}
       {displayIcon}
-      <Headline tag="h1" size="small" style={{ margin: 0 }} >{currentApp.displayName}</Headline>
+      <Headline tag="h1" size="small" margin="none" >{currentApp.displayName}</Headline>
     </div>
   );
 };

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -4,8 +4,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import Link from 'react-router-dom/Link';
 import AppIcon from '@folio/stripes-components/lib/AppIcon';
 import Badge from '@folio/stripes-components/lib/Badge';
 import Headline from '@folio/stripes-components/lib/Headline';
@@ -14,9 +12,10 @@ import css from './CurrentApp.css';
 const propTypes = {
   currentApp: PropTypes.shape(
     {
-      displayName: PropTypes.string, 
-      description: PropTypes.string
-    }),
+      displayName: PropTypes.string,
+      description: PropTypes.string,
+    },
+  ),
   id: PropTypes.string,
   icon: PropTypes.oneOfType([
     PropTypes.element,
@@ -28,18 +27,17 @@ const propTypes = {
 };
 
 const defaultProps = {
-  currentApp: {displayName: 'FOLIO', description: 'FOLIO platform'}
-}
+  currentApp: { displayName: 'FOLIO', description: 'FOLIO platform' },
+};
 
 const CurrentApp = ({ currentApp, icon, badge, id }) => {
-
   const displayIcon = (<div className={css.icon}>{icon || <AppIcon focusable={false} />}</div>);
 
   return (
     <div id={id} title={currentApp.description} className={css.currentApp}>
-        { badge && (<Badge color="red" className={css.badge}>{badge}</Badge>) }
-        { displayIcon }
-        <Headline tag="h1" size="small" style={{margin: 0}} >{currentApp.displayName}</Headline>
+      {badge && (<Badge color="red" className={css.badge}>{badge}</Badge>)}
+      {displayIcon}
+      <Headline tag="h1" size="small" style={{ margin: 0 }} >{currentApp.displayName}</Headline>
     </div>
   );
 };

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -171,11 +171,10 @@ class MainNav extends Component {
               <polygon style={{ fill: '#999' }} points="13 24.8 1.2 13.5 3.2 11.3 13 20.6 22.8 11.3 24.8 13.5 " />
             </svg>
           </a>
-          {selectedApp &&
-            <CurrentApp
-              currentApp={selectedApp}
-            />
-          }
+          <CurrentApp
+            id="ModuleMainHeading"
+            currentApp={selectedApp}
+          />
           {
             stripes.hasPerm('settings.enabled') && pathname.startsWith('/settings') &&
             <NavButton label="Settings" />

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -162,6 +162,11 @@ class MainNav extends Component {
     let firstNav;
     let breadcrumbArray = []; // eslint-disable-line
 
+    let settingsApp;
+    if (stripes.hasPerm('settings.enabled') && pathname.startsWith('/settings')) {
+      settingsApp = { displayName: 'Settings', description: 'FOLIO settings' };
+    }
+
     if (breadcrumbArray.length === 0) {
       firstNav = (
         <NavGroup md="hide">
@@ -173,12 +178,8 @@ class MainNav extends Component {
           </a>
           <CurrentApp
             id="ModuleMainHeading"
-            currentApp={selectedApp}
+            currentApp={selectedApp || settingsApp}
           />
-          {
-            stripes.hasPerm('settings.enabled') && pathname.startsWith('/settings') &&
-            <NavButton label="Settings" />
-          }
         </NavGroup>
       );
     } else {


### PR DESCRIPTION
As part of a continuing effort to improve the accessibility of STRIPES UI, this PR is an initial step in giving FOLIO modules a mark-up structure that outlines nicely so that assistive technologies can have a clean way to navigate the page via its heading tags.
Ideally, pages have a structure that flows in a hierarchical fashion - 
```
<h1>
  <h2>
    <!-- h2 content -->
    <h3>
      <!-- h3 content -->
  <h2>
    <!-- h2 content -->
    <h3>
      <!-- h3 content -->
      <h4>
        <!-- h4 content -->
  <h2>
  <!-- h2 content -->
```
It's best for pages to have only a single `<h1>` tag followed by `<h2-6>` tags arranged as seen in the example.
This GREATLY eases navigation for those using assistive technologies to perceive page content (and is a low-hanging fruit on the accessibility tree that sites can sometimes miss.)
There will be future PR's in other modules to set up a hierarchical flow to the headers used in an app. Much can be handled at the level of `stripes-components` with its `<Accordion>` and `<Headline>` components.

Before a module is selected in the UI, the `<CurrentApp>` displays "FOLIO" with the title "FOLIO platform"