### PR TITLE
Lock in uglify-es version because of bug on 3.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "serialize-javascript": "^1.4.0",
     "style-loader": "^0.18.2",
     "typeface-source-sans-pro": "0.0.43",
+    "uglify-es": "3.3.9",
     "uglifyjs-webpack-plugin": "^1.1.8",
     "uuid": "^3.0.0",
     "webpack": "^3.4.1",


### PR DESCRIPTION
`@folio/ui-eholdings` is failing to create a production build in CI:

![screen shot 2018-02-14 at 11 07 12 am](https://user-images.githubusercontent.com/230597/36217569-700aad1a-1177-11e8-8eba-20107abd9a74.png)

There's a bug in `uglify-es` causing the failure (https://github.com/mishoo/UglifyJS2/issues/2896), and a new version hasn't been cut yet. This will lock in `uglify-es` (needed by `uglify-webpack-plugin`) to 3.3.9, before the bug was introduced.