### PR TITLE
STRIPES-505: Settings Pane Should List Items Alphabetically

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -24,7 +24,7 @@ const settingsModules = [].concat(
 const Settings = (props) => {
   const stripes = props.stripes;
   const navLinks = settingsModules.sort(
-    (x, y) => x.displayName > y.displayName,
+    (x, y) => x.displayName.toLowerCase() > y.displayName.toLowerCase(),
   ).filter(
     x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`),
   ).map(m => (


### PR DESCRIPTION
https://issues.folio.org/browse/STRIPES-505

The bug is that _eHoldings_ is the last item, after _Users_.

With this PR, _eHoldings_ is after _Developer_ and before _Organization_