### PR TITLE
STCOR-139 metadata

### DIFF
--- a/test/webpack/stripes-branding-plugin.spec.js
+++ b/test/webpack/stripes-branding-plugin.spec.js
@@ -41,13 +41,12 @@ describe('The stripes-branding-plugin', function () {
   });
 
   describe('apply method', function () {
-    it('registers a virtual module', function () {
-      this.sandbox.spy(compilerStub, 'apply');
+    it('assigns serialized branding to this.serializedBranding', function () {
       const sut = new StripesBrandingPlugin();
       sut.apply(compilerStub);
-
-      const applyArg = compilerStub.apply.getCall(0).args[0];
-      expect(applyArg).to.be.an.instanceOf(VirtualModulesPlugin);
+      console.log(sut.serializedBranding);
+      expect(sut.serializedBranding).to.be.a('string')
+        .which.includes(`"${defaultBranding.logo.alt}"`);
     });
 
     it('registers the "after-plugins" hook', function () {

--- a/test/webpack/stripes-branding-plugin.spec.js
+++ b/test/webpack/stripes-branding-plugin.spec.js
@@ -44,7 +44,6 @@ describe('The stripes-branding-plugin', function () {
     it('assigns serialized branding to this.serializedBranding', function () {
       const sut = new StripesBrandingPlugin();
       sut.apply(compilerStub);
-      console.log(sut.serializedBranding);
       expect(sut.serializedBranding).to.be.a('string')
         .which.includes(`"${defaultBranding.logo.alt}"`);
     });

--- a/test/webpack/stripes-branding-plugin.spec.js
+++ b/test/webpack/stripes-branding-plugin.spec.js
@@ -40,43 +40,11 @@ describe('The stripes-branding-plugin', function () {
   });
 
   describe('apply method', function () {
-    it('assigns serialized branding to this.serializedBranding', function () {
-      const sut = new StripesBrandingPlugin();
-      sut.apply(compilerStub);
-      expect(sut.serializedBranding).to.be.a('string')
-        .which.includes(`"${defaultBranding.logo.alt}"`);
-    });
-
     it('registers the "after-plugins" hook', function () {
       this.sandbox.spy(compilerStub, 'plugin');
       const sut = new StripesBrandingPlugin();
       sut.apply(compilerStub);
       expect(compilerStub.plugin).to.be.calledWith('after-plugins');
-    });
-  });
-
-  describe('_serializeBranding method', function () {
-    it('maintains absolute src paths', function () {
-      const result = StripesBrandingPlugin._serializeBranding(defaultBranding);
-      expect(result).to.be.a('string')
-        .which.includes(`'${defaultBranding.logo.src}'`);
-    });
-
-    it('updates custom src paths', function () {
-      const result = StripesBrandingPlugin._serializeBranding(tenantBranding);
-      expect(result).to.be.a('string')
-        .which.includes(`'.${tenantBranding.logo.src}'`)
-        .and.not.include(`'${tenantBranding.logo.src}'`);
-    });
-
-    it('wraps src values in require()', function () {
-      const result = StripesBrandingPlugin._serializeBranding(tenantBranding);
-      expect(result).to.include('"src": require(');
-    });
-
-    it('does not wrap non-src values in require()', function () {
-      const result = StripesBrandingPlugin._serializeBranding(tenantBranding);
-      expect(result).to.not.include('"alt": require(');
     });
   });
 

--- a/test/webpack/stripes-branding-plugin.spec.js
+++ b/test/webpack/stripes-branding-plugin.spec.js
@@ -1,7 +1,6 @@
 const expect = require('chai').expect;
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const VirtualModulesPlugin = require('webpack-virtual-modules');
 const defaultBranding = require('../../default-assets/branding');
 const StripesBrandingPlugin = require('../../webpack/stripes-branding-plugin');
 

--- a/test/webpack/stripes-config-plugin.spec.js
+++ b/test/webpack/stripes-config-plugin.spec.js
@@ -5,7 +5,7 @@ const StripesConfigPlugin = require('../../webpack/stripes-config-plugin');
 const StripesTranslationsPlugin = require('../../webpack/stripes-translations-plugin');
 const StripesBrandingPlugin = require('../../webpack/stripes-branding-plugin');
 const StripesModuleParser = require('../../webpack/stripes-module-parser');
-
+const stripesSerialize = require('../../webpack/stripes-serialize');
 
 const compilerStub = {
   apply: () => {},
@@ -78,6 +78,7 @@ describe('The stripes-config-plugin', function () {
     beforeEach(function () {
       this.sandbox.stub(StripesModuleParser.prototype, 'parseEnabledModules').returns({ app: ['something'] });
       this.sandbox.stub(VirtualModulesPlugin.prototype, 'writeModule').returns({});
+      this.sandbox.stub(stripesSerialize, 'serializeWithRequire').returns({});
       this.sut = new StripesConfigPlugin(mockConfig);
 
       compilerStub.plugins = [];
@@ -104,7 +105,7 @@ describe('The stripes-config-plugin', function () {
       expect(writeModuleArgs[0]).to.be.a('string').that.equals('node_modules/stripes-config.js');
 
       // TODO: More thorough analysis of the generated virtual module
-      expect(writeModuleArgs[1]).to.be.a('string').with.match(/export { okapi, config, modules, branding, translations }/);
+      expect(writeModuleArgs[1]).to.be.a('string').with.match(/export { okapi, config, modules, branding, translations, metadata }/);
     });
   });
 });

--- a/test/webpack/stripes-config-plugin.spec.js
+++ b/test/webpack/stripes-config-plugin.spec.js
@@ -19,6 +19,7 @@ const compilerStub = {
     plugins: [],
   },
   context: '/context/path',
+  warnings: [],
 };
 
 const mockConfig = {
@@ -70,7 +71,7 @@ describe('The stripes-config-plugin', function () {
     it('registers the "after-plugins" hook', function () {
       this.sandbox.spy(compilerStub, 'plugin');
       this.sut.apply(compilerStub);
-      expect(compilerStub.plugin).to.have.been.calledOnce;
+      expect(compilerStub.plugin).to.have.been.calledWith('after-plugins');
     });
   });
 
@@ -106,6 +107,27 @@ describe('The stripes-config-plugin', function () {
 
       // TODO: More thorough analysis of the generated virtual module
       expect(writeModuleArgs[1]).to.be.a('string').with.match(/export { okapi, config, modules, branding, translations, metadata }/);
+    });
+  });
+
+  describe('processWarnings method', function () {
+    beforeEach(function () {
+      compilerStub.warnings = [];
+      this.sut = new StripesConfigPlugin(mockConfig);
+    });
+
+    it('assigns warnings to the Webpack compilation', function () {
+      this.sut.warnings = ['uh-oh', 'something happened'];
+      this.sut.processWarnings(compilerStub, () => {});
+      expect(compilerStub.warnings).to.be.an('array').with.length(1);
+      expect(compilerStub.warnings[0]).to.match(/uh-oh/);
+      expect(compilerStub.warnings[0]).to.match(/something happened/);
+    });
+
+    it('does not assign warnings when not present', function () {
+      this.sut.warnings = [];
+      this.sut.processWarnings(compilerStub, () => {});
+      expect(compilerStub.warnings).to.be.an('array').with.length(0);
     });
   });
 });

--- a/test/webpack/stripes-config-plugin.spec.js
+++ b/test/webpack/stripes-config-plugin.spec.js
@@ -1,0 +1,110 @@
+const expect = require('chai').expect;
+
+const VirtualModulesPlugin = require('webpack-virtual-modules');
+const StripesConfigPlugin = require('../../webpack/stripes-config-plugin');
+const StripesTranslationsPlugin = require('../../webpack/stripes-translations-plugin');
+const StripesBrandingPlugin = require('../../webpack/stripes-branding-plugin');
+const StripesModuleParser = require('../../webpack/stripes-module-parser');
+
+
+const compilerStub = {
+  apply: () => {},
+  plugin: () => {},
+  options: {
+    resolve: {
+      alias: {
+        'my-alias': '/path/to/some-module',
+      },
+    },
+    plugins: [],
+  },
+  context: '/context/path',
+};
+
+const mockConfig = {
+  modules: {
+    '@folio/users': {},
+    '@folio/search': {},
+    '@folio/developer': {},
+  },
+};
+
+describe('The stripes-config-plugin', function () {
+  describe('constructor', function () {
+    it('throws StripesBuildError when missing modules config', function () {
+      const config = {};
+      try {
+        const sut = new StripesConfigPlugin(config);
+        expect('should not get here').to.equal(false);
+      } catch (err) {
+        expect(err.message).match(/was not provided a "modules" object/);
+      }
+    });
+
+    it('omits branding config (handled by its own plugin)', function () {
+      const config = {
+        modules: {},
+        branding: {},
+      };
+      const sut = new StripesConfigPlugin(config);
+      expect(sut.options).to.have.property('modules');
+      expect(sut.options).to.not.have.property('branding');
+    });
+  });
+
+  describe('apply method', function () {
+    beforeEach(function () {
+      this.sandbox.stub(StripesModuleParser.prototype, 'parseEnabledModules').returns({ app: ['something'] });
+      this.sut = new StripesConfigPlugin(mockConfig);
+    });
+
+    it('applies a virtual module', function () {
+      this.sandbox.spy(compilerStub, 'apply');
+      this.sut.apply(compilerStub);
+
+      expect(compilerStub.apply).to.have.been.calledOnce;
+      const applyCall = compilerStub.apply.getCall(0);
+      expect(applyCall.args[0]).to.be.an.instanceOf(VirtualModulesPlugin);
+    });
+
+    it('registers the "after-plugins" hook', function () {
+      this.sandbox.spy(compilerStub, 'plugin');
+      this.sut.apply(compilerStub);
+      expect(compilerStub.plugin).to.have.been.calledOnce;
+    });
+  });
+
+  describe('afterPlugins method', function () {
+    beforeEach(function () {
+      this.sandbox.stub(StripesModuleParser.prototype, 'parseEnabledModules').returns({ app: ['something'] });
+      this.sandbox.stub(VirtualModulesPlugin.prototype, 'writeModule').returns({});
+      this.sut = new StripesConfigPlugin(mockConfig);
+
+      compilerStub.plugins = [];
+
+      const translationPlugin = new StripesTranslationsPlugin({ config: {} });
+      translationPlugin.allFiles = { en: '/translations/en.json' };
+      compilerStub.options.plugins.push(translationPlugin);
+
+      const brandingPlugin = new StripesBrandingPlugin({});
+      brandingPlugin.serializedBranding = JSON.stringify({ logo: { alt: 'Future Of Libraries Is Open' } });
+      compilerStub.options.plugins.push(brandingPlugin);
+
+      this.sut.apply(compilerStub);
+    });
+
+    it('calls virtualModule.writeModule()', function () {
+      this.sut.afterPlugins(compilerStub);
+      expect(this.sut.virtualModule.writeModule).to.have.been.calledOnce;
+    });
+
+    it('writes serialized config to virtual module', function () {
+      this.sut.afterPlugins(compilerStub);
+      const writeModuleArgs = this.sut.virtualModule.writeModule.getCall(0).args;
+      expect(writeModuleArgs[0]).to.be.a('string').that.equals('node_modules/stripes-config.js');
+
+      // TODO: More thorough analysis of the generated virtual module
+      expect(writeModuleArgs[1]).to.be.a('string').with.match(/export { okapi, config, modules, branding, translations }/);
+    });
+  });
+});

--- a/test/webpack/stripes-config-plugin.spec.js
+++ b/test/webpack/stripes-config-plugin.spec.js
@@ -34,7 +34,7 @@ describe('The stripes-config-plugin', function () {
     it('throws StripesBuildError when missing modules config', function () {
       const config = {};
       try {
-        const sut = new StripesConfigPlugin(config);
+        const sut = new StripesConfigPlugin(config); // eslint-disable-line no-unused-vars
         expect('should not get here').to.equal(false);
       } catch (err) {
         expect(err.message).match(/was not provided a "modules" object/);

--- a/test/webpack/stripes-config-plugin.spec.js
+++ b/test/webpack/stripes-config-plugin.spec.js
@@ -4,7 +4,7 @@ const VirtualModulesPlugin = require('webpack-virtual-modules');
 const StripesConfigPlugin = require('../../webpack/stripes-config-plugin');
 const StripesTranslationsPlugin = require('../../webpack/stripes-translations-plugin');
 const StripesBrandingPlugin = require('../../webpack/stripes-branding-plugin');
-const StripesModuleParser = require('../../webpack/stripes-module-parser');
+const stripesModuleParser = require('../../webpack/stripes-module-parser');
 const stripesSerialize = require('../../webpack/stripes-serialize');
 
 const compilerStub = {
@@ -54,7 +54,7 @@ describe('The stripes-config-plugin', function () {
 
   describe('apply method', function () {
     beforeEach(function () {
-      this.sandbox.stub(StripesModuleParser.prototype, 'parseEnabledModules').returns({ app: ['something'] });
+      this.sandbox.stub(stripesModuleParser, 'parseAllModules').returns({ app: ['something'] });
       this.sut = new StripesConfigPlugin(mockConfig);
     });
 
@@ -76,7 +76,7 @@ describe('The stripes-config-plugin', function () {
 
   describe('afterPlugins method', function () {
     beforeEach(function () {
-      this.sandbox.stub(StripesModuleParser.prototype, 'parseEnabledModules').returns({ app: ['something'] });
+      this.sandbox.stub(stripesModuleParser, 'parseAllModules').returns({ config: 'something', metadata: 'something' });
       this.sandbox.stub(VirtualModulesPlugin.prototype, 'writeModule').returns({});
       this.sandbox.stub(stripesSerialize, 'serializeWithRequire').returns({});
       this.sut = new StripesConfigPlugin(mockConfig);

--- a/test/webpack/stripes-module-parser.spec.js
+++ b/test/webpack/stripes-module-parser.spec.js
@@ -132,12 +132,18 @@ describe('The stripes-module-parser', function () {
     });
 
     describe('buildIconFilePaths', function () {
-      it('returns all file variations (high/low)', function () {
+      it('returns all file variants (high/low)', function () {
         const result = this.sut.buildIconFilePaths('one');
-        expect(result).to.be.an('object').with.keys('high', 'low');
-        expect(result).to.deep.equal({
+        expect(result).to.deep.include({
           high: { src: '/path/to/module/icons/one.svg' },
           low: { src: '/path/to/module/icons/one.png' },
+        });
+      });
+
+      it('returns default icon src', function () {
+        const result = this.sut.buildIconFilePaths('one');
+        expect(result).to.deep.include({
+          src: '/path/to/module/icons/one.svg',
         });
       });
 
@@ -145,7 +151,7 @@ describe('The stripes-module-parser', function () {
         modulePaths.tryResolve.restore();
         this.sandbox.stub(modulePaths, 'tryResolve').returns(false);
         const result = this.sut.buildIconFilePaths('one');
-        expect(result).to.deep.equal({
+        expect(result).to.deep.include({
           high: { src: '' },
           low: { src: '' },
         });

--- a/test/webpack/stripes-module-parser.spec.js
+++ b/test/webpack/stripes-module-parser.spec.js
@@ -4,7 +4,7 @@ const StripesModuleParser = require('../../webpack/stripes-module-parser');
 
 function mockPackageJson(mod) {
   return {
-    name: mod.replace('@folio/', 'ui-'),
+    name: mod,
     description: `description for ${mod}`,
     version: '1.0.0',
     stripes: {
@@ -98,8 +98,8 @@ describe('The stripes-module-parser', function () {
     it('returns config grouped by stripes type', function () {
       this.sandbox.stub(this.sut, 'loadModulePackageJson').callsFake(mockPackageJson);
       const result = this.sut.parseEnabledModules();
-      expect(result).to.be.an('object').with.property('app').that.is.an('array');
-      expect(result.app[0]).to.be.an('object').with.all.keys(
+      expect(result.moduleConfigs).to.be.an('object').with.property('app').that.is.an('array');
+      expect(result.moduleConfigs.app[0]).to.be.an('object').with.all.keys(
         'module', 'getModule', 'description', 'version', 'displayName', 'route', 'permissionSets',
       );
     });

--- a/test/webpack/stripes-module-parser.spec.js
+++ b/test/webpack/stripes-module-parser.spec.js
@@ -1,0 +1,107 @@
+const expect = require('chai').expect;
+const modulePaths = require('../../webpack/module-paths');
+const StripesModuleParser = require('../../webpack/stripes-module-parser');
+
+function mockPackageJson(mod) {
+  return {
+    name: mod.replace('@folio/', 'ui-'),
+    description: `description for ${mod}`,
+    version: '1.0.0',
+    stripes: {
+      type: 'app',
+      displayName: `display name for ${mod}`,
+      route: `/${mod}`,
+      permissionSets: [],
+    },
+  };
+}
+
+describe('The stripes-module-parser', function () {
+  beforeEach(function () {
+    const enabledModules = {
+      '@folio/users': {},
+      '@folio/search': {},
+      '@folio/developer': {},
+    };
+    const context = '/path/to/folio-testing-platform';
+    const aliases = {
+      react: '/path/to/node_modules/react',
+    };
+
+    this.sut = new StripesModuleParser(enabledModules, context, aliases);
+  });
+
+  describe('loadPackageJson method', function () {
+    it('throws StripesBuildError when package.json is missing', function () {
+      this.sandbox.stub(modulePaths, 'locateStripesModule').returns(false);
+      try {
+        this.sut.loadModulePackageJson('test');
+        expect('never to be called').to.equal(true);
+      } catch (err) {
+        expect(err.message).to.match(/Unable to locate/);
+      }
+    });
+  });
+
+  describe('parseStripesConfig method', function () {
+    beforeEach(function () {
+      this.packageJson = mockPackageJson('@folio/users');
+    });
+
+    it('throws StripesBuildError when stripes is missing', function () {
+      delete this.packageJson.stripes;
+      try {
+        this.sut.parseStripesConfig('@folio/users', this.packageJson);
+        expect('never to be called').to.equal(true);
+      } catch (err) {
+        expect(err.message).to.match(/does not have a "stripes" key/);
+      }
+    });
+
+    it('throws StripesBuildError when stripes.type is missing', function () {
+      delete this.packageJson.stripes.type;
+      try {
+        this.sut.parseStripesConfig('@folio/users', this.packageJson);
+        expect('never to be called').to.equal(true);
+      } catch (err) {
+        expect(err.message).to.match(/does not specify stripes\.type/);
+      }
+    });
+
+    it('returns a parsed config', function () {
+      const result = this.sut.parseStripesConfig('@folio/users', this.packageJson);
+      expect(result).to.be.an('object').with.all.keys(
+        'module', 'getModule', 'description', 'version', 'displayName', 'route', 'permissionSets',
+      );
+    });
+
+    it('applies overrides from tenant config', function () {
+      this.sut.enabledModules['@folio/users'] = { displayName: 'something else' };
+      const result = this.sut.parseStripesConfig('@folio/users', this.packageJson);
+      expect(result.displayName).to.equal('something else');
+    });
+
+    it('assigns getModule function', function () {
+      const result = this.sut.parseStripesConfig('@folio/users', this.packageJson);
+      expect(result.getModule).to.be.a('function');
+    });
+  });
+
+  describe('parseAllModules method', function () {
+    it('calls parseStripesConfig for each module', function () {
+      this.sandbox.stub(this.sut, 'loadModulePackageJson').callsFake(mockPackageJson);
+      this.sandbox.spy(this.sut, 'parseStripesConfig');
+      this.sut.parseEnabledModules();
+      expect(this.sut.parseStripesConfig).to.have.callCount(3);
+    });
+
+    it('returns config grouped by stripes type', function () {
+      this.sandbox.stub(this.sut, 'loadModulePackageJson').callsFake(mockPackageJson);
+      const result = this.sut.parseEnabledModules();
+      expect(result).to.be.an('object').with.property('app').that.is.an('array');
+      expect(result.app[0]).to.be.an('object').with.all.keys(
+        'module', 'getModule', 'description', 'version', 'displayName', 'route', 'permissionSets',
+      );
+    });
+  });
+});

--- a/test/webpack/stripes-serialize.spec.js
+++ b/test/webpack/stripes-serialize.spec.js
@@ -1,0 +1,42 @@
+const expect = require('chai').expect;
+
+const defaultBranding = require('../../default-assets/branding');
+const { serializeWithRequire } = require('../../webpack/stripes-serialize');
+
+// Sample data for test
+const tenantBranding = {
+  logo: {
+    src: './path/to/my-logo.png',
+    alt: 'my alt',
+  },
+  favicon: {
+    src: './path/to/my-favicon.ico',
+  },
+};
+
+describe('The stripes-serialize module', function () {
+  describe('serializeWithRequire function', function () {
+    it('maintains absolute src paths', function () {
+      const result = serializeWithRequire(defaultBranding);
+      expect(result).to.be.a('string')
+        .which.includes(`'${defaultBranding.logo.src}'`);
+    });
+
+    it('updates custom src paths', function () {
+      const result = serializeWithRequire(tenantBranding);
+      expect(result).to.be.a('string')
+        .which.includes(`'.${tenantBranding.logo.src}'`)
+        .and.not.include(`'${tenantBranding.logo.src}'`);
+    });
+
+    it('wraps src values in require()', function () {
+      const result = serializeWithRequire(tenantBranding);
+      expect(result).to.include('"src": require(');
+    });
+
+    it('does not wrap non-src values in require()', function () {
+      const result = serializeWithRequire(tenantBranding);
+      expect(result).to.not.include('"alt": require(');
+    });
+  });
+});

--- a/webpack/module-paths.js
+++ b/webpack/module-paths.js
@@ -58,6 +58,7 @@ function locateStripesModule(context, moduleName, alias, ...segments) {
 }
 
 module.exports = {
+  tryResolve,
   generateStripesAlias,
   locateStripesModule,
 };

--- a/webpack/stripes-branding-plugin.js
+++ b/webpack/stripes-branding-plugin.js
@@ -12,38 +12,8 @@ module.exports = class StripesBrandingPlugin {
   }
 
   apply(compiler) {
-    // The serialized output will be picked up by stripes-config-plugin
-    this.serializedBranding = StripesBrandingPlugin._serializeBranding(this.branding);
-
     // Locate the HtmlWebpackPlugin and apply the favicon.
     compiler.plugin('after-plugins', theCompiler => this._replaceFavicon(theCompiler));
-  }
-
-  // Serialize the branding config.
-  static _serializeBranding(branding) {
-    const assetPath = (thePath) => {
-      if (path.isAbsolute(thePath)) {
-        return thePath;
-      }
-
-      return path.join('..', thePath); // Look outside the node_modules directory
-    };
-
-    // Wraps image paths with require()'s for webpack to process via its file loaders
-    // The require()'s are just strings here so we don't attempt to invoke them right now
-    const injectRequire = (key, value) => {
-      if (key === 'src') {
-        return `require('${assetPath(value)}')`;
-      }
-
-      return value;
-    };
-    // Serialize whole branding configuration, adding require()'s as needed
-    const brandingString = JSON.stringify(branding, injectRequire, 2);
-
-    // Now that the branding object has been serialized, this regex omits the wrapping quotes
-    // surrounding the require()'s so they are invoked when Webpack loads stripes-config
-    return brandingString.replace(/"(require\([^)]+\))"/g, (match, $1) => $1);
   }
 
   // Prep favicon path for use with HtmlWebpackPlugin

--- a/webpack/stripes-branding-plugin.js
+++ b/webpack/stripes-branding-plugin.js
@@ -2,7 +2,6 @@
 // The virtual module contains require()'s needed for webpack to pull images into the bundle.
 
 const path = require('path');
-const VirtualModulesPlugin = require('webpack-virtual-modules');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const defaultBranding = require('../default-assets/branding');
 
@@ -13,11 +12,8 @@ module.exports = class StripesBrandingPlugin {
   }
 
   apply(compiler) {
-    const brandingVirtualModule = `module.exports = ${StripesBrandingPlugin._serializeBranding(this.branding)};`;
-
-    compiler.apply(new VirtualModulesPlugin({
-      'node_modules/stripes-branding.js': brandingVirtualModule,
-    }));
+    // The serialized output will be picked up by stripes-config-plugin
+    this.serializedBranding = StripesBrandingPlugin._serializeBranding(this.branding);
 
     // Locate the HtmlWebpackPlugin and apply the favicon.
     compiler.plugin('after-plugins', theCompiler => this._replaceFavicon(theCompiler));

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -9,6 +9,7 @@ const StripesTranslationPlugin = require('./stripes-translations-plugin');
 const serialize = require('serialize-javascript');
 const StripesModuleParser = require('./stripes-module-parser');
 const StripesBuildError = require('./stripes-build-error');
+const stripesSerialize = require('./stripes-serialize');
 
 module.exports = class StripesConfigPlugin {
   constructor(options) {
@@ -41,9 +42,10 @@ module.exports = class StripesConfigPlugin {
     // Create a virtual module for Webpack to include in the build
     const stripesVirtualModule = `
       const { okapi, config, modules } = ${serialize(this.mergedConfig, { space: 2 })};
-      const branding = ${brandingPlugin.serializedBranding};
+      const branding = ${stripesSerialize.serializeWithRequire(brandingPlugin.branding)};
       const translations = ${serialize(translationPlugin.allFiles, { space: 2 })};
-      export { okapi, config, modules, branding, translations };
+      const metadata = ${stripesSerialize.serializeWithRequire(this.metadata)};
+      export { okapi, config, modules, branding, translations, metadata };
     `;
 
     this.virtualModule.writeModule('node_modules/stripes-config.js', stripesVirtualModule);

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -2,64 +2,13 @@
 // To access this configuration simply import 'stripes-config' within your JavaScript:
 //   import { okapi, config, modules } from 'stripes-config';
 
-const path = require('path');
 const assert = require('assert');
 const _ = require('lodash');
 const VirtualModulesPlugin = require('webpack-virtual-modules');
 const StripesBrandingPlugin = require('./stripes-branding-plugin');
 const StripesTranslationPlugin = require('./stripes-translations-plugin');
 const serialize = require('serialize-javascript');
-
-// Loads description, version, and stripes configuration from a module's package.json
-function loadDefaults(context, moduleName, alias) {
-  // TODO: Replace with common locateStripesModule() logic
-  let aPath;
-  if (alias[moduleName]) {
-    aPath = require.resolve(path.join(alias[moduleName], 'package.json'));
-  } else {
-    try {
-      aPath = require.resolve(path.join(context, 'node_modules', moduleName, '/package.json'));
-    } catch (e) {
-      try {
-        // The above resolution is overspecific and prevents some use cases eg. yarn workspaces
-        aPath = require.resolve(path.join(moduleName, '/package.json'));
-      } catch (e2) {
-        try {
-          // This better incorporates the context path but requires nodejs 9+
-          aPath = require.resolve(path.join(moduleName, '/package.json'), { paths: [context] });
-        } catch (e3) { throw e3; }
-      }
-    }
-  }
-
-  const { stripes, description, version } = require(aPath); // eslint-disable-line
-  assert(_.isObject(stripes, `included module ${moduleName} does not have a "stripes" key in package.json`));
-  assert(_.isString(stripes.type, `included module ${moduleName} does not specify stripes.type in package.json`));
-  return { stripes, description, version };
-}
-
-function appendOrSingleton(maybeArray, newValue) {
-  const singleton = [newValue];
-  if (Array.isArray(maybeArray)) return maybeArray.concat(singleton);
-  return singleton;
-}
-
-// Generates stripes configuration for the tenant's enabled modules
-function parseStripesModules(enabledModules, context, alias) {
-  const moduleConfigs = {};
-  _.forOwn(enabledModules, (moduleConfig, moduleName) => {
-    const { stripes, description, version } = loadDefaults(context, moduleName, alias);
-    const stripeConfig = Object.assign({}, stripes, moduleConfig, {
-      module: moduleName,
-      getModule: new Function([], `return require('${moduleName}').default;`), // eslint-disable-line no-new-func
-      description,
-      version,
-    });
-    delete stripeConfig.type;
-    moduleConfigs[stripes.type] = appendOrSingleton(moduleConfigs[stripes.type], stripeConfig);
-  });
-  return moduleConfigs;
-}
+const StripesModuleParser = require('./stripes-module-parser');
 
 module.exports = class StripesConfigPlugin {
   constructor(options) {
@@ -69,7 +18,8 @@ module.exports = class StripesConfigPlugin {
 
   apply(compiler) {
     const enabledModules = this.options.modules;
-    const moduleConfigs = parseStripesModules(enabledModules, compiler.context, compiler.options.resolve.alias);
+    const stripesModuleParser = new StripesModuleParser(enabledModules, compiler.context, compiler.options.resolve.alias);
+    const moduleConfigs = stripesModuleParser.parseEnabledModules();
     const mergedConfig = Object.assign({}, this.options, { modules: moduleConfigs });
 
     // Prep the virtual module now, we will write to it when ready

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -9,10 +9,13 @@ const StripesBrandingPlugin = require('./stripes-branding-plugin');
 const StripesTranslationPlugin = require('./stripes-translations-plugin');
 const serialize = require('serialize-javascript');
 const StripesModuleParser = require('./stripes-module-parser');
+const StripesBuildError = require('./stripes-build-error');
 
 module.exports = class StripesConfigPlugin {
   constructor(options) {
-    assert(_.isObject(options.modules), 'stripes-config-plugin was not provided a "modules" object for enabling stripes modules');
+    if (!_.isObject(options.modules)) {
+      throw new StripesBuildError('stripes-config-plugin was not provided a "modules" object for enabling stripes modules');
+    }
     this.options = _.omit(options, 'branding');
   }
 
@@ -20,27 +23,29 @@ module.exports = class StripesConfigPlugin {
     const enabledModules = this.options.modules;
     const stripesModuleParser = new StripesModuleParser(enabledModules, compiler.context, compiler.options.resolve.alias);
     const moduleConfigs = stripesModuleParser.parseEnabledModules();
-    const mergedConfig = Object.assign({}, this.options, { modules: moduleConfigs });
+    this.mergedConfig = Object.assign({}, this.options, { modules: moduleConfigs });
 
     // Prep the virtual module now, we will write to it when ready
-    const virtualModule = new VirtualModulesPlugin();
-    compiler.apply(virtualModule);
+    this.virtualModule = new VirtualModulesPlugin();
+    compiler.apply(this.virtualModule);
 
     // Wait until after other plugins to generate virtual stripes-config
-    compiler.plugin('after-plugins', (theCompiler) => {
-      // Locate the StripesTranslationPlugin to grab its translation file list
-      const translationPlugin = theCompiler.options.plugins.find(plugin => plugin instanceof StripesTranslationPlugin);
-      const brandingPlugin = theCompiler.options.plugins.find(plugin => plugin instanceof StripesBrandingPlugin);
+    compiler.plugin('after-plugins', theCompiler => this.afterPlugins(theCompiler));
+  }
 
-      // Create a virtual module for Webpack to include in the build
-      const stripesVirtualModule = `
-        const { okapi, config, modules } = ${serialize(mergedConfig, { space: 2 })};
-        const branding = ${brandingPlugin.serializedBranding};
-        const translations = ${serialize(translationPlugin.allFiles, { space: 2 })};
-        export { okapi, config, modules, branding, translations };
-      `;
+  afterPlugins(compiler) {
+    // Locate the StripesTranslationPlugin to grab its translation file list
+    const translationPlugin = compiler.options.plugins.find(plugin => plugin instanceof StripesTranslationPlugin);
+    const brandingPlugin = compiler.options.plugins.find(plugin => plugin instanceof StripesBrandingPlugin);
 
-      virtualModule.writeModule('node_modules/stripes-config.js', stripesVirtualModule);
-    });
+    // Create a virtual module for Webpack to include in the build
+    const stripesVirtualModule = `
+      const { okapi, config, modules } = ${serialize(this.mergedConfig, { space: 2 })};
+      const branding = ${brandingPlugin.serializedBranding};
+      const translations = ${serialize(translationPlugin.allFiles, { space: 2 })};
+      export { okapi, config, modules, branding, translations };
+    `;
+
+    this.virtualModule.writeModule('node_modules/stripes-config.js', stripesVirtualModule);
   }
 };

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -2,7 +2,6 @@
 // To access this configuration simply import 'stripes-config' within your JavaScript:
 //   import { okapi, config, modules } from 'stripes-config';
 
-const assert = require('assert');
 const _ = require('lodash');
 const VirtualModulesPlugin = require('webpack-virtual-modules');
 const StripesBrandingPlugin = require('./stripes-branding-plugin');
@@ -22,8 +21,9 @@ module.exports = class StripesConfigPlugin {
   apply(compiler) {
     const enabledModules = this.options.modules;
     const stripesModuleParser = new StripesModuleParser(enabledModules, compiler.context, compiler.options.resolve.alias);
-    const moduleConfigs = stripesModuleParser.parseEnabledModules();
+    const { moduleConfigs, metadata } = stripesModuleParser.parseEnabledModules();
     this.mergedConfig = Object.assign({}, this.options, { modules: moduleConfigs });
+    this.metadata = metadata;
 
     // Prep the virtual module now, we will write to it when ready
     this.virtualModule = new VirtualModulesPlugin();

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -6,6 +6,7 @@ const path = require('path');
 const assert = require('assert');
 const _ = require('lodash');
 const VirtualModulesPlugin = require('webpack-virtual-modules');
+const StripesBrandingPlugin = require('./stripes-branding-plugin');
 const StripesTranslationPlugin = require('./stripes-translations-plugin');
 const serialize = require('serialize-javascript');
 
@@ -71,22 +72,25 @@ module.exports = class StripesConfigPlugin {
     const moduleConfigs = parseStripesModules(enabledModules, compiler.context, compiler.options.resolve.alias);
     const mergedConfig = Object.assign({}, this.options, { modules: moduleConfigs });
 
+    // Prep the virtual module now, we will write to it when ready
+    const virtualModule = new VirtualModulesPlugin();
+    compiler.apply(virtualModule);
+
     // Wait until after other plugins to generate virtual stripes-config
     compiler.plugin('after-plugins', (theCompiler) => {
       // Locate the StripesTranslationPlugin to grab its translation file list
       const translationPlugin = theCompiler.options.plugins.find(plugin => plugin instanceof StripesTranslationPlugin);
+      const brandingPlugin = theCompiler.options.plugins.find(plugin => plugin instanceof StripesBrandingPlugin);
 
       // Create a virtual module for Webpack to include in the build
       const stripesVirtualModule = `
-        import branding from 'stripes-branding';
         const { okapi, config, modules } = ${serialize(mergedConfig, { space: 2 })};
+        const branding = ${brandingPlugin.serializedBranding};
         const translations = ${serialize(translationPlugin.allFiles, { space: 2 })};
         export { okapi, config, modules, branding, translations };
       `;
 
-      compiler.apply(new VirtualModulesPlugin({
-        'node_modules/stripes-config.js': stripesVirtualModule,
-      }));
+      virtualModule.writeModule('node_modules/stripes-config.js', stripesVirtualModule);
     });
   }
 };

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -7,7 +7,7 @@ const VirtualModulesPlugin = require('webpack-virtual-modules');
 const StripesBrandingPlugin = require('./stripes-branding-plugin');
 const StripesTranslationPlugin = require('./stripes-translations-plugin');
 const serialize = require('serialize-javascript');
-const StripesModuleParser = require('./stripes-module-parser');
+const stripesModuleParser = require('./stripes-module-parser');
 const StripesBuildError = require('./stripes-build-error');
 const stripesSerialize = require('./stripes-serialize');
 
@@ -21,9 +21,8 @@ module.exports = class StripesConfigPlugin {
 
   apply(compiler) {
     const enabledModules = this.options.modules;
-    const stripesModuleParser = new StripesModuleParser(enabledModules, compiler.context, compiler.options.resolve.alias);
-    const { moduleConfigs, metadata } = stripesModuleParser.parseEnabledModules();
-    this.mergedConfig = Object.assign({}, this.options, { modules: moduleConfigs });
+    const { config, metadata } = stripesModuleParser.parseAllModules(enabledModules, compiler.context, compiler.options.resolve.alias);
+    this.mergedConfig = Object.assign({}, this.options, { modules: config });
     this.metadata = metadata;
 
     // Prep the virtual module now, we will write to it when ready

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -1,0 +1,74 @@
+const _ = require('lodash');
+const modulePaths = require('./module-paths');
+const StripesBuildError = require('./stripes-build-error');
+
+function appendOrSingleton(maybeArray, newValue) {
+  const singleton = [newValue];
+  if (Array.isArray(maybeArray)) return maybeArray.concat(singleton);
+  return singleton;
+}
+
+module.exports = class StripesModuleParser {
+  constructor(enabledModules, context, aliases) {
+    this.enabledModules = enabledModules;
+    this.context = context;
+    this.aliases = aliases;
+  }
+
+  loadModulePackageJson(moduleName) {
+    const packageJson = modulePaths.locateStripesModule(this.context, moduleName, this.aliases, 'package.json');
+    if (!packageJson) {
+      throw new StripesBuildError(`Unable to locate ${moduleName}'s package.json`);
+    }
+    return require(packageJson); // eslint-disable-line
+  }
+
+  parseModule(moduleName) {
+    const packageJson = this.loadModulePackageJson(moduleName);
+    const config = this.parseStripesConfig(moduleName, packageJson);
+    // const metadata = this.parseStripesMetadata(packageJson);
+
+    const parsedModule = {
+      name: moduleName,
+      type: packageJson.stripes.type,
+      config,
+      // metadata,
+    };
+    return parsedModule;
+  }
+
+  parseStripesConfig(moduleName, packageJson) {
+    const { stripes, description, version } = packageJson;
+    const tenantModuleConfig = this.enabledModules[moduleName];
+
+    if (!_.isObject(stripes)) {
+      throw new StripesBuildError(`Included module ${moduleName} does not have a "stripes" key in package.json`);
+    }
+    if (!_.isString(stripes.type)) {
+      throw new StripesBuildError(`Included module ${moduleName} does not specify stripes.type in package.json`);
+    }
+
+    const stripeConfig = Object.assign({}, stripes, tenantModuleConfig, {
+      module: moduleName,
+      getModule: new Function([], `return require('${moduleName}').default;`), // eslint-disable-line no-new-func
+      description,
+      version,
+    });
+    delete stripeConfig.type;
+    return stripeConfig;
+  }
+
+  // parseStripesMetadata(packageJson) {
+  //   const metadata = {};
+  //   return metadata;
+  // }
+
+  parseEnabledModules() {
+    const moduleConfigs = {};
+    _.forOwn(this.enabledModules, (moduleConfig, moduleName) => {
+      const parsedModule = this.parseModule(moduleName);
+      moduleConfigs[parsedModule.type] = appendOrSingleton(moduleConfigs[parsedModule.type], parsedModule.config);
+    });
+    return moduleConfigs;
+  }
+};

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -8,6 +8,10 @@ function appendOrSingleton(maybeArray, newValue) {
   return singleton;
 }
 
+function nameOnly(moduleName) {
+  return moduleName.replace(/.*\//, '');
+}
+
 module.exports = class StripesModuleParser {
   constructor(enabledModules, context, aliases) {
     this.enabledModules = enabledModules;
@@ -15,6 +19,8 @@ module.exports = class StripesModuleParser {
     this.aliases = aliases;
   }
 
+  // Loads a given module's package.json and errors when it fails
+  // By using require, the JSON will already be parsed
   loadModulePackageJson(moduleName) {
     const packageJson = modulePaths.locateStripesModule(this.context, moduleName, this.aliases, 'package.json');
     if (!packageJson) {
@@ -23,20 +29,24 @@ module.exports = class StripesModuleParser {
     return require(packageJson); // eslint-disable-line
   }
 
+  // Wrapper to source data and transform into collections (config and metadata)
   parseModule(moduleName) {
     const packageJson = this.loadModulePackageJson(moduleName);
     const config = this.parseStripesConfig(moduleName, packageJson);
-    // const metadata = this.parseStripesMetadata(packageJson);
+    const metadata = StripesModuleParser.parseStripesMetadata(packageJson);
 
     const parsedModule = {
-      name: moduleName,
+      name: nameOnly(moduleName),
       type: packageJson.stripes.type,
       config,
-      // metadata,
+      metadata,
     };
     return parsedModule;
   }
 
+  // Validates and parses a module's stripes data
+  // One critical aspect of this operation is value of getModule, which is the entry point into each app
+  // This will be modified to a webpack-compatible dynamic import when we implement code-splitting.
   parseStripesConfig(moduleName, packageJson) {
     const { stripes, description, version } = packageJson;
     const tenantModuleConfig = this.enabledModules[moduleName];
@@ -58,17 +68,81 @@ module.exports = class StripesModuleParser {
     return stripeConfig;
   }
 
-  // parseStripesMetadata(packageJson) {
-  //   const metadata = {};
-  //   return metadata;
-  // }
+  // Extract metadata defined here:
+  // https://github.com/folio-org/stripes-core/blob/master/doc/app-metadata.md
+  static parseStripesMetadata(packageJson) {
+    // Name without @folio/ scope
+    const icons = StripesModuleParser.getIconMetadata(packageJson.stripes.icons);
+    const welcomePageEntries = StripesModuleParser.getWelcomePageEntries(packageJson.stripes.welcomePageEntries, icons, nameOnly);
 
+    const metadata = {
+      name: nameOnly(packageJson.name),
+      version: packageJson.version,
+      description: packageJson.description,
+      license: packageJson.license,
+      feedback: {
+        url: packageJson.bugs ? packageJson.bugs.url : undefined,
+        email: packageJson.bugs ? packageJson.bugs.email : undefined,
+      },
+      type: packageJson.stripes.type,
+      shortTitle: packageJson.stripes.displayName,
+      fullTitle: packageJson.stripes.fullName,
+      defaultPopoverSize: packageJson.stripes.defaultPopoverSize,
+      defaultPreviewWidth: packageJson.stripes.defaultPreviewWidth,
+      helpPage: packageJson.stripes.helpPage,
+      icons,
+      welcomePageEntries,
+    };
+
+    return metadata;
+  }
+
+  static getIconMetadata(icons) {
+    if (!icons || !Array.isArray(icons)) {
+      return {};
+    }
+    return _.reduce(icons, (iconMetadata, icon) => {
+      iconMetadata[icon.name] = {
+        filename: icon.filename,
+        alt: icon.alt,
+        title: icon.title,
+      };
+      return iconMetadata;
+    }, {});
+  }
+
+  static getWelcomePageEntries(entries, icons, name) {
+    if (!entries || !Array.isArray(entries)) {
+      return [];
+    }
+    return _.map(entries, (entry) => {
+      if (!icons[entry.iconName]) {
+        console.warn(`Welcome page entry icon "${entry.iconName}" has no icon defined in stripes.icons for module ${name}`);
+        // throw new StripesBuildError(`Welcome page entry icon "${entry.iconName}" has no icon defined in stripes.icons for module ${name}`);
+      }
+      return {
+        iconName: entry.iconName,
+        headline: entry.headline,
+        description: entry.description,
+      };
+    });
+  }
+
+  // Loops over all the tenant's module configs and parses each
+  // The resulting config is grouped by stripes module type (app, settings, plugin, etc.)
   parseEnabledModules() {
     const moduleConfigs = {};
+    const metadata = {};
+
     _.forOwn(this.enabledModules, (moduleConfig, moduleName) => {
       const parsedModule = this.parseModule(moduleName);
       moduleConfigs[parsedModule.type] = appendOrSingleton(moduleConfigs[parsedModule.type], parsedModule.config);
+      metadata[parsedModule.name] = parsedModule.metadata;
     });
-    return moduleConfigs;
+
+    return {
+      moduleConfigs,
+      metadata,
+    };
   }
 };

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -106,24 +106,24 @@ class StripesModuleParser {
   // Construct and validate expected icon file paths
   buildIconFilePaths(name) {
     const iconDir = 'icons';
-    const iconNames = {
+    const defaultKey = 'high';
+    const iconVariants = {
       high: `${name}.svg`,
       low: `${name}.png`,
       // bw: `${name}-bw.png`, example
     };
 
-    return _.reduce(iconNames, (iconPaths, file, key) => {
+    return _.reduce(iconVariants, (iconPaths, file, key) => {
       const iconFilePath = path.join(this.modulePath, iconDir, file);
       const isFound = modulePaths.tryResolve(iconFilePath);
-      if (isFound) {
-        iconPaths[key] = {
-          src: iconFilePath,
-        };
-      } else {
+      if (!isFound) {
         console.warn(`  Warning: Module ${this.moduleName} defines icon "${name}" but is missing file "${iconDir}/${file}"`);
-        iconPaths[key] = {
-          src: '',
-        };
+      }
+      iconPaths[key] = {
+        src: isFound ? iconFilePath : '',
+      };
+      if (key === defaultKey) {
+        iconPaths.src = isFound ? iconFilePath : '';
       }
       return iconPaths;
     }, {});

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -73,7 +73,7 @@ module.exports = class StripesModuleParser {
   static parseStripesMetadata(packageJson) {
     // Name without @folio/ scope
     const icons = StripesModuleParser.getIconMetadata(packageJson.stripes.icons);
-    const welcomePageEntries = StripesModuleParser.getWelcomePageEntries(packageJson.stripes.welcomePageEntries, icons, nameOnly);
+    const welcomePageEntries = StripesModuleParser.getWelcomePageEntries(packageJson.stripes.welcomePageEntries, icons, packageJson.name);
 
     const metadata = {
       name: nameOnly(packageJson.name),

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -91,7 +91,7 @@ class StripesModuleParser {
     }
     return _.reduce(icons, (iconMetadata, icon) => {
       iconMetadata[icon.name] = {
-        filename: icon.fileName,
+        src: icon.src,
         alt: icon.alt,
         title: icon.title,
       };

--- a/webpack/stripes-serialize.js
+++ b/webpack/stripes-serialize.js
@@ -14,7 +14,7 @@ function serializeWithRequire(theObject) {
   // Wraps image paths with require()'s for webpack to process via its file loaders
   // The require()'s are just strings here so we don't attempt to invoke them right now
   const injectRequire = (key, value) => {
-    if (key === 'src') {
+    if (key === 'src' && typeof value === 'string') {
       return `require('${assetPath(value)}')`;
     }
 

--- a/webpack/stripes-serialize.js
+++ b/webpack/stripes-serialize.js
@@ -14,7 +14,7 @@ function serializeWithRequire(theObject) {
   // Wraps image paths with require()'s for webpack to process via its file loaders
   // The require()'s are just strings here so we don't attempt to invoke them right now
   const injectRequire = (key, value) => {
-    if (key === 'src' && typeof value === 'string') {
+    if (key === 'src' && typeof value === 'string' && value !== '') {
       return `require('${assetPath(value)}')`;
     }
 

--- a/webpack/stripes-serialize.js
+++ b/webpack/stripes-serialize.js
@@ -1,0 +1,33 @@
+const path = require('path');
+
+// Serialize an object
+// In the process, it wraps "src" properties with requires for loading files
+function serializeWithRequire(theObject) {
+  const assetPath = (thePath) => {
+    if (path.isAbsolute(thePath)) {
+      return thePath;
+    }
+
+    return path.join('..', thePath); // Look outside the node_modules directory
+  };
+
+  // Wraps image paths with require()'s for webpack to process via its file loaders
+  // The require()'s are just strings here so we don't attempt to invoke them right now
+  const injectRequire = (key, value) => {
+    if (key === 'src') {
+      return `require('${assetPath(value)}')`;
+    }
+
+    return value;
+  };
+  // Serialize whole configuration, adding require()'s as needed
+  const theString = JSON.stringify(theObject, injectRequire, 2);
+
+  // Now that the object has been serialized, this regex omits the wrapping quotes
+  // surrounding the require()'s so they are invoked when Webpack loads stripes-config
+  return theString.replace(/"(require\([^)]+\))"/g, (match, $1) => $1);
+}
+
+module.exports = {
+  serializeWithRequire,
+};


### PR DESCRIPTION
There is a bit going on here. Much of the change results from a refactor to better share and test existing stripes-config logic. A quick summary:

**Changes to existing:**
* Move module parsing out of `stripes-config-plugin` and into new `stripes-module-parser` to make it more extensible
* Move serialization logic out of `stripes-branding-plugin` and into new `stripes-serialization` to reuse it with new icon metadata
* Consolidate on try/parse logic for locating modules from `module-paths`
* Add tests for `stripes-config-plugin` and new modules

**New functionality:**
* Add module's metadata as an export of `stripes-config` based on spec
* Icons are pulled in via require during serialization process like branding icons
* Build-time validation and warnings for icon metadata

**Example icon usage:**
Given the following example icon data for `ui-users`:
```
"stripes": {
  "icons": [
    {
      "name": "example",
      "alt": "example alt",
      "title": "example title"
    },
    // ...
```
Reference the icon in client code:
```
import { metadata } from 'stripes-config';
// ...
// Use the default:
<img alt={metadata.users.icons.example.alt} src={metadata.users.icons.example.src} />
// Or use a variant (low-resolution, for example):
<img alt={metadata.users.icons.example.alt} src={metadata.users.icons.example.low.src} />
```
Remaining to do: 
Review and finalize a few things re: usage and defaults, and then update docs.  Details added to STCOR-139.