### PR TITLE
When server is absent, say so instead of displaying nothing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add Vagrant doc to [Creating a new development setup for Stripes](doc/new-development-setup.md). Fixes STCOR-160.
 * The anointed resource is correctly set from the URL. Fixes STCOR-134. Available from v2.9.1.
 * Rename bin command from `stripes` to `stripescore` to avoid conflicts with the CLI. STCOR-153
+* When the FOLIO server is absent, say so instead of displaying nothing at all. Fixes STCOR-164.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -43,7 +43,7 @@ class Root extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return !this.withOkapi || nextProps.okapiReady;
+    return !this.withOkapi || nextProps.okapiReady || nextProps.serverDown;
   }
 
   addReducer = (key, reducer) => {
@@ -72,9 +72,16 @@ class Root extends Component {
   }
 
   render() {
-    const { logger, store, epics, config, okapi, actionNames, token, disableAuth, currentUser, currentPerms, locale, plugins, bindings, discovery, translations, history } = this.props;
+    const { logger, store, epics, config, okapi, actionNames, token, disableAuth, currentUser, currentPerms, locale, plugins, bindings, discovery, translations, history, serverDown } = this.props;
 
-    if (!translations) return (<div />);
+    if (serverDown) {
+      return <div>Error: server is down.</div>;
+    }
+
+    if (!translations) {
+      // We don't know the locale, so we use English as backup
+      return <div>Loading translations...</div>;
+    }
 
     const stripes = new Stripes({
       logger,
@@ -153,6 +160,7 @@ Root.propTypes = {
     replace: PropTypes.func.isRequired,
   }),
   okapiReady: PropTypes.bool,
+  serverDown: PropTypes.bool,
 };
 
 Root.defaultProps = {
@@ -160,6 +168,7 @@ Root.defaultProps = {
   // TODO: remove after locale is accessible from a global config / public url
   locale: 'en-US',
   okapiReady: false,
+  serverDown: false,
 };
 
 function mapStateToProps(state) {
@@ -173,6 +182,7 @@ function mapStateToProps(state) {
     bindings: state.okapi.bindings,
     discovery: state.discovery,
     okapiReady: state.okapi.okapiReady,
+    serverDown: state.okapi.serverDown,
     okapi: state.okapi,
   };
 }

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -18,6 +18,7 @@ import {
   setAuthError,
   checkSSO,
   setOkapiReady,
+  setServerDown,
 } from './okapiActions';
 
 function getHeaders(tenant, token) {
@@ -150,6 +151,8 @@ function validateUser(okapiUrl, store, tenant, session) {
       getPlugins(okapiUrl, store, tenant);
       getBindings(okapiUrl, store, tenant);
     }
+  }).catch(() => {
+    store.dispatch(setServerDown());
   });
 }
 

--- a/src/okapiActions.js
+++ b/src/okapiActions.js
@@ -87,6 +87,12 @@ function setOkapiReady() {
   };
 }
 
+function setServerDown() {
+  return {
+    type: 'SERVER_DOWN',
+  };
+}
+
 export { setCurrentUser,
   clearCurrentUser,
   setCurrentPerms,
@@ -99,4 +105,5 @@ export { setCurrentUser,
   setAuthError,
   setTranslations,
   checkSSO,
-  setOkapiReady };
+  setOkapiReady,
+  setServerDown };

--- a/src/okapiReducer.js
+++ b/src/okapiReducer.js
@@ -28,6 +28,8 @@ export default function okapiReducer(state = {}, action) {
       return Object.assign({}, state, { ssoEnabled: action.ssoEnabled });
     case 'OKAPI_READY':
       return Object.assign({}, state, { okapiReady: true });
+    case 'SERVER_DOWN':
+      return Object.assign({}, state, { serverDown: true });
     default:
       return state;
   }


### PR DESCRIPTION
This turned out to be much more than the trivial fix I'd imagined, since Stripes was making no distinction between "I don't have a response to my first call _yet_" and "My first call failed". I had to add a new bit of state, `serverDown`, to the Redux store – which, as always, involved touching a whole bunch of files: `okapiActions.js` to define the `setServerDown` function that makes an action, `okapiReducer.js` to recognise that action and set the bit of state, `loginServices.js` to invoke that action when the initial call fails, and finally `Root.js` to emit the error message when this has failed. Oh, and the `CHANGELOG.md` of course.

Fixes STCOR-164.