### PR TITLE
Upgrade babel-eslint to 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "apollo-link-http": "^1.2.0",
     "autoprefixer": "^7.1.1",
     "babel-core": "^6.23.1",
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^8.2.2",
     "babel-loader": "^7.0.0",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-polyfill": "^6.16.0",


### PR DESCRIPTION
I was running into a very strange ESLint error:

```
import {
  page
} from '@bigtest/interaction';
```

was throwing `Error while running ESLint: Cannot read property 'type' of undefined.`.

Upgrading `babel-eslint` fixed it, so there's no longer an error being improperly thrown.