### PR TITLE
Minor tweak to hide NavButton labels on mobile

### DIFF
--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -8,7 +8,7 @@
   outline: 0;
   display: flex;
   align-items: center;
-  color: rgba(0, 0, 0, 0.62);
+  color: rgba(0, 0, 0, 1);
 
   &::-moz-focus-inner {
     border: 0;

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -77,6 +77,7 @@ button.navButton {
 .label {
   margin: 0 4px;
   font-weight: 600;
+  display: none;
 }
 
 .inner {
@@ -131,4 +132,13 @@ button.navButton {
 .navButton.isInteractable:active .inner::before {
   background: rgb(37, 118, 195);
   border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+/**
+ * Responsive
+ */
+@media (--largeUp) {
+  .label {
+    display: block;
+  }
 }


### PR DESCRIPTION
This minor update removes the NavButton labels on smaller screens. This isn't a perfect solution but it will do for now. 