### PR TITLE
STCOR-170 StripesBuildError with Yarn workspaces

### DIFF
--- a/webpack/module-paths.js
+++ b/webpack/module-paths.js
@@ -41,6 +41,9 @@ function locateStripesModule(context, moduleName, alias, ...segments) {
       // This better incorporates the context path but requires nodejs 9+
       request: path.join(moduleName, ...segments),
       options: { paths: [context] },
+    }, {
+      // Yarn workspaces fallback: Try node_modules of the parent directory
+      request: path.join(context, '..', 'node_modules', moduleName, ...segments),
     },
   ];
 


### PR DESCRIPTION
Add another entry to the tryPath list to help locate modules in a yarn workspace
Fixes STCOR-170