### PR TITLE
Consider empty okapi config as no okapi

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,10 @@ import gatherActions from './gatherActions';
 
 import Root from './components/Root';
 
-const okapi = (typeof okapiConfig === 'object') ? okapiConfig : { withoutOkapi: true };
+const okapi = (typeof okapiConfig === 'object' && Object.keys(okapiConfig) > 0)
+  ? okapiConfig
+  : { withoutOkapi: true };
+console.log("REDIOUS", okapi);
 const initialState = { okapi };
 const epics = configureEpics(connectErrorEpic);
 const logger = configureLogger(config);


### PR DESCRIPTION
stripes-cli will create an okapi key in the config with an empty object even if it was omitted from the configuration passed to it.