### PR TITLE
Fix okapiConfig logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import gatherActions from './gatherActions';
 
 import Root from './components/Root';
 
-const okapi = (typeof okapiConfig === 'object' && Object.keys(okapiConfig) > 0)
+const okapi = (typeof okapiConfig === 'object' && Object.keys(okapiConfig).length > 0)
   ? okapiConfig
   : { withoutOkapi: true };
 const initialState = { okapi };


### PR DESCRIPTION
## Purpose
`ui-eholdings` is broken on the latest `stripes-core`. Before starting up, `ui-eholdings` GETs `/eholdings/status` to verify it has an appropriate back-module in the Okapi cluster. Instead, it now GETs `/undefined/eholdings/status`.

## Diagnosis
The Okapi config was being blown away by https://github.com/folio-org/stripes-core/pull/239.

`Object.keys()` returns an array, so `Object.keys(anyObject) > 0` should always evaluate to `false`. Instead we want to be checking the length of `Object.keys()`.