### PR TITLE
mandatory back-end services for stripes-core

### DIFF
--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -684,3 +684,6 @@ class Users extends React.Component {
 
 Note that this code does _not_ access the stripes-connect data within the Redux store: so far, no situation has been found where that is necessary or desirable. Instead, it accesses internal data about the present session. (Arguably, that data should be made available in the Stripes object; but really, module code should not need to use this at all.)
 
+## Appendix B: mandatory back-end services for stripes-core
+
+Stripes-core currently requires certain server side modules to be enabled, i.e. /notify endpoint


### PR DESCRIPTION
To help future developers to avoid my mistake. I tried to test connection between a back-end module in development and relative ui module without run all others back-end services up.