### PR TITLE
Updated MainNav to be more responsive (UX-153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add -l to stripes-pull to iterate through local directories instead of through a hard-coded list. Fixes STCOR-166. Available from v2.9.2.
 * Update react-cookie dependency, eliminating a duplicate-package warning from WebPack. Fixes part of STCOR-167.
 * Do not emit "no icons defined in stripes.icons" warning for non-app modules. Fixes STCOR-171.
+* Updated MainNav to be more responsive. UX-153.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -515,7 +515,10 @@ In JavaScript, the Stripes object furnishes an internationalization object as it
 
 In addition to the translations that it provides itself, a module may use translations provided by stripes-core. In particular, it provides translations for a set of common labels, which modules therefore need not translate for themselves. The keys for these labels all begin with `common.`. The translations provided by stripes-core are provided in [language-specific translation files](https://github.com/folio-org/stripes-core/tree/master/translations).
 
-For example, if the `stripes-core/translations/*.json` files define a property as `"common.search": "Search"`, then search buttons may use `<Button label={stripes.intl.formatMessage({ id: 'stripes-core.common.search' })} />`.
+For example, if the `stripes-core/translations/*.json` files define a property as `"common.search": "Search"`, then the translation can be done like so: 
+```
+<Button label={stripes.intl.formatMessage({ id: 'stripes-core.common.search' })} />
+```
 
 #### Filtering translations at build time
 

--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -1,0 +1,106 @@
+/**
+ * App Switcher
+ */
+
+@import '@folio/stripes-components/lib/variables.css';
+
+.appList {
+  display: flex;
+}
+
+/**
+ * Nav List
+ */
+.navItemsList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: none;
+}
+
+/**
+ * Nav Dropdown
+ */
+
+.navListDropdownWrap,
+.navListDropdown {
+  display: block;
+}
+
+.navListDropdown {
+  z-index: 200;
+}
+
+.dropdownBody {
+  width: 100%;
+}
+
+.dropdownList {
+  padding: 5px 15px;
+}
+
+.dropdownListItem {
+  display: flex;
+  align-items: center;
+}
+
+.dropdownListItemLabel {
+  padding: 0 4px;
+  min-width: 200px;
+  font-weight: 600;
+}
+
+.dropdownListItemDescription {
+  color: var(--labelColor);
+  display: none;
+}
+
+.dropdownHeader {
+  padding: 10px 10px 5px;
+}
+
+/**
+ * Focus trap
+ */
+.focusTrap {
+  position: absolute;
+  height: 0;
+  width: 0;
+  left: -99999px;
+  opacity: 0;
+}
+
+/**
+ * Responsive
+ */
+
+/* A bit of a hack to force tether to 100% width on mobile.. */
+@media (--small) {
+  .navListDropdown,
+  .navListDropdown > div {
+    left: 0 !important;
+    right: 0 !important;
+    width: 100% !important;
+  }
+}
+
+@media (--mediumUp) {
+  .dropdownListItemDescription {
+    display: block;
+  }
+
+  .dropdownBody {
+    width: 600px;
+  }
+}
+
+@media (--largeUp) {
+  .navItemsList {
+    display: flex;
+  }
+
+  .navListDropdownWrap,
+  .navListDropdown {
+    display: none;
+  }
+}

--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -37,6 +37,8 @@
 
 .dropdownList {
   padding: 5px 15px;
+  max-height: 225px;
+  overflow-y: auto;
 }
 
 .dropdownListItem {

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -1,0 +1,140 @@
+/**
+ * App Switcher
+ */
+
+import React, { Component } from 'react';
+import { uniqueId } from 'lodash';
+import PropTypes from 'prop-types';
+import { Dropdown } from '@folio/stripes-components/lib/Dropdown';
+import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
+import AppListDropdown from './AppListDropdown';
+import NavButton from '../NavButton';
+import css from './AppList.css';
+
+const defaultProps = {
+  searchfieldId: uniqueId('app-list-searchfield-'),
+};
+
+const propTypes = {
+  dropdownId: PropTypes.string,
+  searchfieldId: PropTypes.string,
+  apps: PropTypes.arrayOf(
+    PropTypes.shape({
+      displayName: PropTypes.string,
+      description: PropTypes.string,
+      id: PropTypes.string,
+      href: PropTypes.string,
+      active: PropTypes.bool,
+      name: PropTypes.string,
+      icon: PropTypes.string,
+      iconData: PropTypes.object, // Only need because "Settings" isn't a standalone app yet
+    }),
+  ),
+};
+
+class AppList extends Component {
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      open: false,
+    };
+  }
+
+  // componentDidUpdate(prevProps, prevState) {
+  //   const { open } = this.state;
+  //   const { searchfieldId } = this.props;
+  //
+  //   // Focus SearchField when dropdown opens
+  //   if (open && !prevState.open) {
+  //     setTimeout(() => document.getElementById(searchfieldId).focus(), 50);
+  //   }
+  // }
+
+  /**
+   * Get the nav buttons that is displayed
+   * in the app header on desktop
+   */
+  getNavButtons = () => {
+    const { apps } = this.props;
+
+    return apps.map(app => (
+      <li className={css.navItem} key={app.id}>
+        <NavButton
+          label={app.displayName}
+          id={app.id}
+          selected={app.active}
+          href={app.active ? null : app.href}
+          title={app.displayName}
+          iconKey={app.name}
+          iconData={app.iconData}
+        />
+      </li>
+    ));
+  }
+
+  /**
+   * When dropdown is getting toggled
+   */
+  toggleDropdown = () => {
+    this.setState({
+      open: !this.state.open,
+    });
+  }
+
+  /**
+   * The button that toggles the dropdown
+   */
+  getDropdownToggleButton = () => {
+    const icon = (<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.9 2.2H2.7c-.4 0-.7.4-.7.7v4.2c0 .4.3.7.7.7h4.2c.4 0 .7-.3.7-.7V2.9c0-.3-.3-.7-.7-.7zM14 2.2H9.8c-.4 0-.8.4-.8.7v4.2c0 .4.3.7.7.7H14c.4 0 .7-.3.7-.7V2.9c0-.3-.3-.7-.7-.7zM21 2.2h-4.2c-.4 0-.7.3-.7.7v4.2c0 .4.3.7.7.7H21c.4 0 .7-.3.7-.7V2.9c0-.3-.3-.7-.7-.7zM6.9 9.3H2.7c-.4 0-.7.3-.7.7v4.2c0 .4.3.7.7.7h4.2c.4 0 .7-.3.7-.7V10c0-.4-.3-.7-.7-.7zM14 9.3H9.8c-.4 0-.8.3-.8.7v4.2c0 .4.3.7.7.7H14c.4 0 .7-.3.7-.7V10c0-.4-.3-.7-.7-.7zM21 9.3h-4.2c-.4 0-.7.3-.7.7v4.2c0 .4.3.7.7.7H21c.4 0 .7-.3.7-.7V10c0-.4-.3-.7-.7-.7zM6.9 16.3H2.7c-.4 0-.7.3-.7.7v4.2c0 .4.3.8.7.8h4.2c.4 0 .7-.3.7-.7V17c0-.4-.3-.7-.7-.7zM14 16.3H9.8c-.4 0-.8.3-.8.7v4.2c0 .4.4.8.8.8H14c.4 0 .7-.3.7-.7V17c0-.4-.3-.7-.7-.7zM21 16.3h-4.2c-.4 0-.7.3-.7.7v4.2c0 .4.3.7.7.7H21c.4 0 .7-.3.7-.7V17c0-.4-.3-.7-.7-.7z" /></svg>);
+
+    return [
+      // TO-DO!
+      // Here we are going to place a button for desktop as well
+      // once that's ready to get imlemented (re-ordering is needed for this to be relevant)
+      <NavButton
+        key="mobile-dropdown-toggle"
+        title="Show applications"
+        data-role="toggle"
+        className={css.navMobileToggle}
+        onClick={this.toggleDropdown}
+        selected={this.state.open}
+        icon={icon}
+        noSelectedBar
+      />,
+    ];
+  }
+
+  render() {
+    const { getNavButtons, getDropdownToggleButton } = this;
+    const { dropdownId, apps, searchfieldId } = this.props;
+
+    return (
+      <nav className={css.appList}>
+        <ul className={css.navItemsList}>
+          { getNavButtons() }
+        </ul>
+        <div className={css.navListDropdownWrap}>
+          <Dropdown dropdownClass={css.navListDropdown} open={this.state.open} id={dropdownId} onToggle={this.toggleDropdown}>
+            { getDropdownToggleButton() }
+            <DropdownMenu data-role="menu" onToggle={this.toggleDropdown}>
+              <AppListDropdown
+                apps={apps}
+                searchfieldId={searchfieldId}
+              />
+            </DropdownMenu>
+          </Dropdown>
+        </div>
+      </nav>
+    );
+  }
+}
+
+AppList.defaultProps = defaultProps;
+AppList.propTypes = propTypes;
+
+export default AppList;

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -45,16 +45,6 @@ class AppList extends Component {
     };
   }
 
-  // componentDidUpdate(prevProps, prevState) {
-  //   const { open } = this.state;
-  //   const { searchfieldId } = this.props;
-  //
-  //   // Focus SearchField when dropdown opens
-  //   if (open && !prevState.open) {
-  //     setTimeout(() => document.getElementById(searchfieldId).focus(), 50);
-  //   }
-  // }
-
   /**
    * Get the nav buttons that is displayed
    * in the app header on desktop
@@ -110,7 +100,7 @@ class AppList extends Component {
   }
 
   render() {
-    const { getNavButtons, getDropdownToggleButton } = this;
+    const { getNavButtons, getDropdownToggleButton, toggleDropdown } = this;
     const { dropdownId, apps, searchfieldId } = this.props;
 
     return (
@@ -119,12 +109,13 @@ class AppList extends Component {
           { getNavButtons() }
         </ul>
         <div className={css.navListDropdownWrap}>
-          <Dropdown dropdownClass={css.navListDropdown} open={this.state.open} id={dropdownId} onToggle={this.toggleDropdown}>
+          <Dropdown dropdownClass={css.navListDropdown} open={this.state.open} id={dropdownId} onToggle={toggleDropdown}>
             { getDropdownToggleButton() }
-            <DropdownMenu data-role="menu" onToggle={this.toggleDropdown}>
+            <DropdownMenu data-role="menu" onToggle={toggleDropdown}>
               <AppListDropdown
                 apps={apps}
                 searchfieldId={searchfieldId}
+                toggleDropdown={toggleDropdown}
               />
             </DropdownMenu>
           </Dropdown>

--- a/src/components/MainNav/AppList/AppListDropdown.js
+++ b/src/components/MainNav/AppList/AppListDropdown.js
@@ -14,6 +14,7 @@ import css from './AppList.css';
 const propTypes = {
   apps: PropTypes.arrayOf(PropTypes.object).isRequired,
   searchfieldId: PropTypes.string.isRequired,
+  toggleDropdown: PropTypes.func.isRequired,
 };
 
 class AppListDropdown extends Component {
@@ -25,12 +26,15 @@ class AppListDropdown extends Component {
     };
   }
 
+  /**
+   * Focus search field on mount
+   */
   componentDidMount() {
     document.getElementById(this.props.searchfieldId).focus();
   }
 
   render() {
-    const { apps, searchfieldId } = this.props;
+    const { apps, searchfieldId, toggleDropdown } = this.props;
     const { query } = this.state;
     let list = apps;
     let activeLink = null;
@@ -47,7 +51,7 @@ class AppListDropdown extends Component {
 
       return (
         <Link
-          onClick={this.toggleDropdown}
+          onClick={toggleDropdown}
           key={index}
           to={app.href}
           className={css.dropdownListItem}

--- a/src/components/MainNav/AppList/AppListDropdown.js
+++ b/src/components/MainNav/AppList/AppListDropdown.js
@@ -1,0 +1,106 @@
+/**
+ * App List Dropdown
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import AppIcon from '@folio/stripes-components/lib/AppIcon';
+import NavList from '@folio/stripes-components/lib/NavList';
+import NavListSection from '@folio/stripes-components/lib/NavListSection';
+import SearchField from '@folio/stripes-components/lib/structures/SearchField';
+import Link from 'react-router-dom/Link';
+import css from './AppList.css';
+
+const propTypes = {
+  apps: PropTypes.arrayOf(PropTypes.object).isRequired,
+  searchfieldId: PropTypes.string.isRequired,
+};
+
+class AppListDropdown extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      query: '',
+    };
+  }
+
+  componentDidMount() {
+    document.getElementById(this.props.searchfieldId).focus();
+  }
+
+  render() {
+    const { apps, searchfieldId } = this.props;
+    const { query } = this.state;
+    let list = apps;
+    let activeLink = null;
+
+    // If we are filtering by searching
+    if (query) {
+      list = apps.filter(app => app.displayName.toLowerCase().indexOf(query.toLowerCase()) >= 0);
+    }
+
+    const items = list.map((app, index) => {
+      if (app.active) {
+        activeLink = app.href;
+      }
+
+      return (
+        <Link
+          onClick={this.toggleDropdown}
+          key={index}
+          to={app.href}
+          className={css.dropdownListItem}
+        >
+          <AppIcon app={app.name} size="small" icon={app.iconData} />
+          <span className={css.dropdownListItemLabel}>{ app.displayName }</span>
+          { app.description && <span className={css.dropdownListItemDescription}>{ app.description }</span>}
+        </Link>
+      );
+    });
+
+
+    // If we have any items in the list (filtered by search or not)
+    // we want to continue to the first app in the list
+    // when a user presses enter in the search field
+
+    // TO-DO: This needs to be activated once the user
+    // can use arrow keys to scroll through the list
+
+    // let onSearchEnter = null;
+    // const firstItem = list.length && list[0];
+    // if (firstItem && activeLink !== firstItem.href) {
+    //   onSearchEnter = (e) => {
+    //     if (e.key === 'Enter') {
+    //       this.context.router.history.push(firstItem.href);
+    //       this.toggleDropdown();
+    //     }
+    //   };
+    // }
+
+    return (
+      <div className={css.dropdownBody}>
+        <header className={css.dropdownHeader}>
+          <SearchField
+            value={this.state.query}
+            onChange={e => this.setState({ query: e.target.value })}
+            onClear={() => this.setState({ query: '' })}
+            id={searchfieldId}
+            marginBottom0
+          />
+        </header>
+        <NavList className={css.dropdownList}>
+          { (query && !list.length) && <div>No apps with the name &quot;{query}&quot; was found.</div> }
+          <NavListSection stripped activeLink={activeLink}>
+            {items}
+          </NavListSection>
+        </NavList>
+        <input className={css.focusTrap} onFocus={() => document.getElementById(searchfieldId).focus()} />
+      </div>
+    );
+  }
+}
+
+AppListDropdown.propTypes = propTypes;
+
+export default AppListDropdown;

--- a/src/components/MainNav/AppList/index.js
+++ b/src/components/MainNav/AppList/index.js
@@ -1,0 +1,1 @@
+export { default } from './AppList';

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -28,14 +28,13 @@ const defaultProps = {
   currentApp: { displayName: 'FOLIO', description: 'FOLIO platform' },
 };
 
-const CurrentApp = ({ currentApp, iconData, id, badge }) => {
-  const { displayName, description, module } = currentApp;
-  const iconKey = module && module.replace(/^@[a-z0-9_]+\//, '');
+const CurrentApp = ({ currentApp, id, badge }) => {
+  const { description, iconData, name, displayName } = currentApp;
 
   return (
     <div id={id} title={description} className={css.currentApp}>
       {badge && (<Badge color="red" className={css.badge}>{badge}</Badge>)}
-      <AppIcon icon={iconData} app={iconKey} className={css.icon} />
+      <AppIcon icon={iconData} app={name} className={css.icon} />
       <Headline tag="h1" size="small" margin="none">{displayName}</Headline>
     </div>
   );

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -17,7 +17,6 @@ const propTypes = {
     },
   ),
   id: PropTypes.string,
-  iconData: PropTypes.object,
   badge: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -13,21 +13,13 @@ import { resetStore } from '../../mainActions';
 import { updateQueryResource, updateLocation } from '../../locationService';
 
 import css from './MainNav.css';
-import NavButton from './NavButton';
 import NavDivider from './NavDivider';
 import NavGroup from './NavGroup';
-import Breadcrumbs from './Breadcrumbs';
 import CurrentApp from './CurrentApp';
 import MyProfile from './MyProfile';
+import AppList from './AppList';
 import NotificationsDropdown from './Notifications/NotificationsDropdown';
 import settingsIcon from './settings.svg';
-
-// Temporary until settings becomes an app
-const settingsIconData = {
-  src: settingsIcon,
-  alt: 'Tenant Settings',
-  title: 'Settings',
-};
 
 if (!Array.isArray(modules.app) || modules.app.length < 1) {
   throw new Error('At least one module of type "app" must be enabled.');
@@ -131,9 +123,8 @@ class MainNav extends Component {
 
   render() {
     const { stripes, location: { pathname } } = this.props;
-    const selectedApp = modules.app.find(entry => pathname.startsWith(entry.route));
 
-    const menuLinks = modules.app.map((entry) => {
+    const apps = modules.app.map((entry) => {
       const name = entry.module.replace(/^@[a-z0-9_]+\//, '');
       const perm = `module.${name}.enabled`;
 
@@ -141,34 +132,44 @@ class MainNav extends Component {
         return null;
       }
 
-      const navId = `clickable-${name}-module`;
-      const isActive = pathname.startsWith(entry.route);
-      const href = !isActive ? (this.lastVisited[name] || entry.home || entry.route) : null;
+      const id = `clickable-${name}-module`;
+      const active = pathname.startsWith(entry.route);
+      const href = (this.lastVisited[name] || entry.home || entry.route);
 
-      return (
-        <NavButton
-          label={entry.displayName}
-          id={navId}
-          selected={isActive}
-          href={href}
-          title={entry.displayName}
-          key={entry.route}
-          iconKey={name}
-        />);
-    });
+      return {
+        id,
+        href,
+        active,
+        name,
+        ...entry,
+      };
+    }).filter(app => app);
 
-    let firstNav;
-    let breadcrumbArray = []; // eslint-disable-line
+    /**
+     * Add Settings to apps array manually
+     * until Settings becomes a standalone app
+     */
 
-    // Temporary solution until Settings becomes a standalone app
-    let settingsApp;
-    if (stripes.hasPerm('settings.enabled') && pathname.startsWith('/settings')) {
-      settingsApp = { displayName: 'Settings', description: 'FOLIO settings' };
+    if (stripes.hasPerm('settings.enabled')) {
+      apps.push({
+        displayName: 'Settings',
+        id: 'clickable-settings',
+        href: this.lastVisited.x_settings || '/settings',
+        active: pathname.startsWith('/settings'),
+        description: 'FOLIO settings',
+        iconData: {
+          src: settingsIcon,
+          alt: 'Tenant Settings',
+          title: 'Settings',
+        },
+      });
     }
 
-    if (breadcrumbArray.length === 0) {
-      firstNav = (
-        <NavGroup md="hide">
+    const selectedApp = apps.find(app => app.active);
+
+    return (
+      <header className={css.navRoot}>
+        <NavGroup>
           <a className={css.skipLink} href="#ModuleContainer" aria-label="Skip Main Navigation" title="Skip Main Navigation">
             <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 26 26">
               <polygon style={{ fill: '#999' }} points="13 16.5 1.2 5.3 3.2 3.1 13 12.4 22.8 3.1 24.8 5.3 " />
@@ -177,46 +178,23 @@ class MainNav extends Component {
           </a>
           <CurrentApp
             id="ModuleMainHeading"
-            currentApp={selectedApp || settingsApp}
-            iconData={settingsApp && settingsIconData}
+            currentApp={selectedApp}
           />
         </NavGroup>
-      );
-    } else {
-      firstNav = (
-        <NavGroup>
-          <NavButton md="hide" />
-          <Breadcrumbs linkArray={breadcrumbArray} />
-        </NavGroup>
-      );
-    }
-
-    return (
-      <header className={css.navRoot}>
-        {firstNav}
         <nav>
           <Headline tag="h2" className="sr-only">Main Navigation</Headline>
           <NavGroup>
-            <NavGroup>
-              {menuLinks}
-              {
-                !stripes.hasPerm('settings.enabled') ? '' : (
-                  <NavButton
-                    label="Settings"
-                    id="clickable-settings"
-                    title="Settings"
-                    iconData={settingsIconData}
-                    selected={pathname.startsWith('/settings')}
-                    href={pathname.startsWith('/settings') ? null : (this.lastVisited.x_settings || '/settings')}
-                  />
-                )
-              }
-            </NavGroup>
             <NavGroup className={css.smallAlignRight}>
+              <AppList
+                apps={apps}
+              />
               <NavDivider md="hide" />
-              {this.props.stripes.withOkapi && this.props.stripes.hasPerm('notify.item.get,notify.item.put,notify.collection.get') && <NotificationsDropdown stripes={stripes} {...this.props} />}
-              { /* temporary divider solution.. */}
-              {this.props.stripes.hasPerm('notify.item.get,notify.item.put,notify.collection.get') && (<NavDivider md="hide" />)}
+              { this.props.stripes.withOkapi && this.props.stripes.hasPerm('notify.item.get,notify.item.put,notify.collection.get') &&
+                <NavGroup>
+                  <NotificationsDropdown stripes={stripes} {...this.props} />
+                  <NavDivider md="hide" />
+                </NavGroup>
+              }
               <MyProfile
                 onLogout={this.logout}
                 stripes={stripes}


### PR DESCRIPTION
## **Issue** 
https://issues.folio.org/browse/UX-153

## **Updates**
- Added AppList component that contains a list of apps. For now it's just for the regular apps but later on we can re-use this component for popover-apps. Resizing, re-ordering etc. would be added to this component later on as well. (Features demonstrated here: http://ux.folio.org/prototype)
- Turned 'menuLinks' array into 'apps' array which can be passed to AppList. This array is also used to find the currently active app which is then passed to CurrentApp. Pushed 'Settings' manually to this array for now (just until 'Settings' becomes a standalone app)
- Made a bit of clean up in MainNav
- Now showing `<CurrentApp />` on mobile (changes are coming to this one as well)

## **Notes**
These changes is just a start for a more responsive MainNav. More changes will come later but the base functionality is here.

I'm using the predefined breakpoints in stripes-components with a mobile-first approach. This means that apps can still be a bit squeezed on some screen widths:

![image](https://user-images.githubusercontent.com/640976/37775226-b311157c-2de2-11e8-8a51-c6084252749d.png)

This will be fixed once we add re-sizing to AppList (and re-ordering so users can decide which apps to show in the MainNav)

## **Before**
![image](https://user-images.githubusercontent.com/640976/37774953-e1e961d4-2de1-11e8-8ec8-383c69f3f10a.png)

## **After**
![image](https://user-images.githubusercontent.com/640976/37774975-ef47b6b4-2de1-11e8-9d0a-f18c1fe3213d.png)

![image](https://user-images.githubusercontent.com/640976/37775037-1659dfb6-2de2-11e8-9488-04e7f67951e4.png)
