### PR TITLE
set importLoaders property in webpack config

### DIFF
--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -39,6 +39,7 @@ devConfig.module.rules.push({
         localIdentName: '[local]---[hash:base64:5]',
         modules: true,
         sourceMap: true,
+        importLoaders: 1,
       },
     },
     {

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -32,6 +32,7 @@ prodConfig.module.rules.push({
         options: {
           localIdentName: '[local]---[hash:base64:5]',
           modules: true,
+          importLoaders: 1,
         },
       },
       {


### PR DESCRIPTION
The `importLoaders` property makes css-loader use the previous loaders in the webpack config's build chain when handling css files that are brought in within css files (via `@import` or use of the `compose` functionality between files)
This will allow for greater style re-use among components, since centralized style sheets can use some of the nice features (nesting, css-variables, etc) that `postcss` gives us. Component styles can use the `composes` command for cross-file style composition as follows.
```
.newTextFieldClass {
  composes: sharedTextFieldClass from "../sharedStyles/centralizedStyles.css";
  color: #fff;
}
```
This will automatically stack classes in the DOM so that `<tag class="newTextField---h^$# sharedTextFieldClass---h^$2 ">` affectively combining styles from both classes when only `className={css.newTextFieldClass}` was supplied as a prop.
It is possible to compose of multiple class names using multiple `composes` properties.
More info here in CSS-loader's documentation: https://github.com/webpack-contrib/css-loader#composing