### PR TITLE
UIEH-130 Create z-index management solution

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "stylelint-config-standard"
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "function-name-case": null
+  }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "stylelint-config-standard": "^17.0.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.0",
+    "@folio/stripes-components": "git+https://git@github.com/thefrontside/stripes-components.git#jc/stripeszindex",
     "@folio/stripes-connect": "^3.1.0",
     "@folio/stripes-logger": "^0.0.2",
     "apollo-cache-inmemory": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "postcss-color-function": "^4.0.0",
     "postcss-custom-media": "^6.0.0",
     "postcss-custom-properties": "^6.1.0",
+    "postcss-functions": "^3.0.0",
     "postcss-import": "^10.0.0",
     "postcss-loader": "^2.0.6",
     "postcss-media-minmax": "^3.0.0",

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -23,7 +23,7 @@
   position: absolute;
   top: 0;
   right: -1px;
-  z-index: 5;
+  z-index: stripesZIndex('currentAppBadge');
 }
 
 .icon {

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -61,7 +61,7 @@ button.navButton {
 .icon,
 .label {
   position: relative;
-  z-index: 2;
+  z-index: stripesZIndex('navButtonIcon');
 }
 
 .navButton,
@@ -90,7 +90,7 @@ button.navButton {
   position: absolute;
   top: 0;
   right: -1px;
-  z-index: 5;
+  z-index: stripesZIndex('navButtonBadge');
 }
 
 /**
@@ -106,7 +106,7 @@ button.navButton {
   right: 0;
   background: transparent;
   border-radius: calc(var(--radius) * 1.2);
-  z-index: 1;
+  z-index: stripesZIndex('navButtonInteractableIcon');
 }
 
 .navButton.isInteractable:hover .inner::before {

--- a/src/components/MainNav/NavDropdownMenu/NavDropdownMenu.css
+++ b/src/components/MainNav/NavDropdownMenu/NavDropdownMenu.css
@@ -4,7 +4,7 @@
   position: absolute;
   top: 105%;
   right: 0;
-  z-index: 1002;
+  z-index: stripesZIndex('navDropdownMenu');
   display: none;
   float: left;
   padding: 5px 8px;

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -2,6 +2,7 @@
 // from the command line via devServer.js
 
 const webpack = require('webpack');
+const path = require('path');
 const postCssImport = require('postcss-import');
 const autoprefixer = require('autoprefixer');
 const postCssCustomProperties = require('postcss-custom-properties');
@@ -10,6 +11,7 @@ const postCssNesting = require('postcss-nesting');
 const postCssCustomMedia = require('postcss-custom-media');
 const postCssMediaMinMax = require('postcss-media-minmax');
 const postCssColorFunction = require('postcss-color-function');
+const postCssFunctions = require('postcss-functions');
 
 const base = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
@@ -54,6 +56,9 @@ devConfig.module.rules.push({
           postCssCustomMedia(),
           postCssMediaMinMax(),
           postCssColorFunction(),
+          postCssFunctions({
+            glob: path.join(path.resolve(), 'node_modules/@folio/stripes-components/lib/sharedStyles/functions', '*.js'),
+          }),
         ],
         sourceMap: true,
       },

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -1,6 +1,7 @@
 // Top level Webpack configuration for building static files for
 // production deployment from the command line
 
+const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const postCssImport = require('postcss-import');
@@ -11,6 +12,7 @@ const postCssNesting = require('postcss-nesting');
 const postCssCustomMedia = require('postcss-custom-media');
 const postCssMediaMinMax = require('postcss-media-minmax');
 const postCssColorFunction = require('postcss-color-function');
+const postCssFunctions = require('postcss-functions');
 
 const base = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
@@ -48,6 +50,9 @@ prodConfig.module.rules.push({
             postCssCustomMedia(),
             postCssMediaMinMax(),
             postCssColorFunction(),
+            postCssFunctions({
+              glob: path.join(path.resolve(), 'node_modules/@folio/stripes-components/lib/sharedStyles/functions', '*.js'),
+            }),
           ],
         },
       },


### PR DESCRIPTION
## Purpose
`ui-eholdings` uses `z-index` to manage layering of its search layout. The dropdown menu from the header avatar ends up underneath the third pane: https://issues.folio.org/browse/UIEH-130

Handling `z-index` can be notoriously finicky. The solution to a problem is frequently "set it to a very high number," but with many layers happening, that can get messy real quick.

## Approach
https://github.com/folio-org/stripes-components/pull/314

## TODO
- [ ] Merge `stripes-components` PR first.
- [ ] Remove commit pointing to fork.