### PR TITLE
Added a utility function to handle formatting dates that are timezone…Refs UIORG-55

### DIFF
--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -10,7 +10,7 @@ import initialReducers from '../../initialReducers';
 import enhanceReducer from '../../enhanceReducer';
 import createApolloClient from '../../createApolloClient';
 import { setSinglePlugin, setBindings, setOkapiToken, setTimezone } from '../../okapiActions';
-import { formatDate, formatTime, formatDateTime } from '../../../util/dateUtil';
+import { formatDate, formatTime, formatDateTime, formatAbsoluteDate } from '../../../util/dateUtil';
 import { loadTranslations, checkOkapiSession } from '../../loginServices';
 import { getQueryResourceKey } from '../../locationService';
 import Stripes from '../../Stripes';
@@ -106,6 +106,7 @@ class Root extends Component {
       formatDate: (dateStr, zone) => formatDate(dateStr, zone || timezone),
       formatTime: (dateStr, zone) => formatTime(dateStr, zone || timezone),
       formatDateTime: (dateStr, zone) => formatDateTime(dateStr, zone || timezone),
+      formatAbsoluteDate: (dateStr) => formatAbsoluteDate(dateStr),
       bindings,
       setBindings: (val) => { store.dispatch(setBindings(val)); },
       discovery,

--- a/util/dateUtil.js
+++ b/util/dateUtil.js
@@ -8,6 +8,14 @@ export function formatDate(dateStr, timezone) {
   return (<FormattedDate value={dateTime} timeZone={timezone} />);
 }
 
+// This function helps in formatting dates that are timezone agnostic (eg: birthdays)
+export function formatAbsoluteDate(dateStr) {
+  if (!dateStr) return dateStr;
+  // Consider only the date part of the ISO string ('yyyy-mm-dd'T'hh:mm:ss') for formatting Date
+  const date = moment(dateStr.split('T')[0]).format('MM-DD-YYYY');
+  return (<FormattedDate value={date}/>);
+}
+
 export function formatTime(dateStr, timezone) {
   if (!dateStr) return dateStr;
   const dateTime = moment.tz(dateStr, timezone);
@@ -17,5 +25,5 @@ export function formatTime(dateStr, timezone) {
 export function formatDateTime(dateStr, timezone) {
   if (!dateStr) return dateStr;
   const dateTime = moment.tz(dateStr, timezone);
-  return (<span><FormattedDate value={dateTime} timeZone={timezone} /> <FormattedTime value={dateStr} timeZone={timezone} /></span>);
+  return (<span><FormattedDate value={dateTime} timeZone={timezone} /> <FormattedTime value={dateTime} timeZone={timezone} /></span>);
 }

--- a/util/dateUtil.js
+++ b/util/dateUtil.js
@@ -8,7 +8,7 @@ export function formatDate(dateStr, timezone) {
   return (<FormattedDate value={dateTime} timeZone={timezone} />);
 }
 
-// This function helps in formatting dates that are timezone agnostic (eg: birthdays)
+// This function helps in formatting dates that are timezone agnostic (eg: birthdays, expiration days, etc)
 export function formatAbsoluteDate(dateStr) {
   if (!dateStr) return dateStr;
   // Consider only the date part of the ISO string ('yyyy-mm-dd'T'hh:mm:ss') for formatting Date

--- a/util/dateUtil.js
+++ b/util/dateUtil.js
@@ -13,7 +13,7 @@ export function formatAbsoluteDate(dateStr) {
   if (!dateStr) return dateStr;
   // Consider only the date part of the ISO string ('yyyy-mm-dd'T'hh:mm:ss') for formatting Date
   const date = moment(dateStr.split('T')[0]).format('MM-DD-YYYY');
-  return (<FormattedDate value={date}/>);
+  return (<FormattedDate value={date} />);
 }
 
 export function formatTime(dateStr, timezone) {


### PR DESCRIPTION
… agnostic.

- For cases like birthdays, user expiraion days, enrollment days, etc we need to make sure that these days shouldn't be changing with the timezone. This new function takes in an ISO string
that comes from the server, and just passes in the date part of that string to the `FormattedDate` for formatting and avoids considering the time part of the string. Inout ISO string - `yyyy-mm-dd'T'hh:mm:ss`, we extract the date part(`yyyy-mm-dd`)  for formatting the date.