### PR TITLE
Extend the stripes object with a function used to calculate timezone …

### DIFF
--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -106,6 +106,7 @@ class Root extends Component {
       formatDate: (dateStr, zone) => formatDate(dateStr, zone || timezone),
       formatTime: (dateStr, zone) => formatTime(dateStr, zone || timezone),
       formatDateTime: (dateStr, zone) => formatDateTime(dateStr, zone || timezone),
+      formatAbsoluteDate: (dateStr) => formatDate(dateStr, 'UTC'),
       bindings,
       setBindings: (val) => { store.dispatch(setBindings(val)); },
       discovery,


### PR DESCRIPTION
…agnostic dates, refs UIORG-55

- Added in the formatAbsoluteDate function that takes in a date string as an argument and calls the formatDate function woth datestring and UTC as the arguments. This helps us in displaying the
dates that are sent from the server ( in UTC ), and that needs to be the same irrespective of the timezone.