### PR TITLE
STCOR-141 instrument build with debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fix typos in workspace-creation section of [_Creating a new development setup_ document](doc/new-development-setup.md). Fixes STCOR-186.
 * Add i18n best practices documentation. Fixes STCOR-182.
 * Upgrade react-apollo dependency to v2.1.3. Fixes STCOR-188.
+* Add diagnostic output to stripes builds, STCOR-141.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "commander": "^2.9.0",
     "connect-history-api-fallback": "^1.3.0",
     "css-loader": "^0.28.4",
+    "debug": "^3.1.0",
     "duplicate-package-checker-webpack-plugin": "^1.2.6",
     "express": "^4.14.0",
     "extract-text-webpack-plugin": "^3.0.0",

--- a/webpack/apply-webpack-overrides.js
+++ b/webpack/apply-webpack-overrides.js
@@ -1,7 +1,10 @@
+const logger = require('./logger')();
+
 // Applies overrides to the webpack configuration
 // Supports a function or an array of functions
 
 module.exports = function applyWebpackOverrides(overrides, originalConfig) {
+  logger.log('applying webpack overrides...');
   let config = originalConfig;
 
   if (overrides && typeof overrides === 'function') {

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -5,11 +5,13 @@ const StripesBrandingPlugin = require('./stripes-branding-plugin');
 const StripesTranslationsPlugin = require('./stripes-translations-plugin');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const applyWebpackOverrides = require('./apply-webpack-overrides');
+const logger = require('./logger')();
 
 const platformModulePath = path.join(path.resolve(), 'node_modules');
 
 module.exports = function build(stripesConfig, options) {
   return new Promise((resolve, reject) => {
+    logger.log('starting build...');
     let config = require('../webpack.config.cli.prod'); // eslint-disable-line
 
     config.plugins.push(new StripesConfigPlugin(stripesConfig));
@@ -35,6 +37,7 @@ module.exports = function build(stripesConfig, options) {
     // Give the caller a chance to apply their own webpack overrides
     config = applyWebpackOverrides(options.webpackOverrides, config);
 
+    logger.log('assign final webpack config', config);
     const compiler = webpack(config);
     compiler.run((err, stats) => {
       if (err) {

--- a/webpack/logger.js
+++ b/webpack/logger.js
@@ -1,0 +1,11 @@
+const debug = require('debug');
+
+// Wrapper for debug to ensure consistent use of namespace
+module.exports = function getLogger(name) {
+  const namespace = name ? `stripes-core:${name}` : 'stripes-core';
+  const logger = debug(namespace);
+
+  return {
+    log: (...args) => logger(...args),
+  };
+};

--- a/webpack/module-paths.js
+++ b/webpack/module-paths.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const logger = require('./logger')();
 
 function tryResolve(modulePath, options) {
   try {
@@ -28,6 +29,7 @@ function generateStripesAlias(moduleName) {
 
 // Common logic to locate a stripes module (pass 'package.json') or file within
 function locateStripesModule(context, moduleName, alias, ...segments) {
+  logger.log(`locating stripes module ${moduleName}...`);
   let foundPath = false;
 
   const tryPaths = [
@@ -66,6 +68,9 @@ function locateStripesModule(context, moduleName, alias, ...segments) {
     if (foundPath) {
       break;
     }
+  }
+  if (foundPath) {
+    logger.log('found', foundPath);
   }
   return foundPath;
 }

--- a/webpack/serve.js
+++ b/webpack/serve.js
@@ -10,6 +10,7 @@ const StripesConfigPlugin = require('./stripes-config-plugin');
 const StripesBrandingPlugin = require('./stripes-branding-plugin');
 const StripesTranslationsPlugin = require('./stripes-translations-plugin');
 const applyWebpackOverrides = require('./apply-webpack-overrides');
+const logger = require('./logger')();
 
 const cwd = path.resolve();
 const platformModulePath = path.join(cwd, 'node_modules');
@@ -29,6 +30,7 @@ const cachePlugin = new HardSourceWebpackPlugin({
 
 module.exports = function serve(stripesConfig, options) {
   return new Promise((resolve) => {
+    logger.log('starting serve...');
     const app = express();
     let config = require('../webpack.config.cli.dev'); // eslint-disable-line
 
@@ -49,6 +51,7 @@ module.exports = function serve(stripesConfig, options) {
     // Give the caller a chance to apply their own webpack overrides
     config = applyWebpackOverrides(options.webpackOverrides, config);
 
+    logger.log('assign final webpack config', config);
     const compiler = webpack(config);
     compiler.plugin('done', stats => resolve(stats));
 

--- a/webpack/stripes-branding-plugin.js
+++ b/webpack/stripes-branding-plugin.js
@@ -4,9 +4,11 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const defaultBranding = require('../default-assets/branding');
+const logger = require('./logger')('stripesBrandingPlugin');
 
 module.exports = class StripesBrandingPlugin {
   constructor(tenantBranding) {
+    logger.log('initializing...');
     // TODO: Validate incoming tenantBranding paths
     this.branding = Object.assign({}, defaultBranding, tenantBranding);
   }

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -10,9 +10,11 @@ const serialize = require('serialize-javascript');
 const stripesModuleParser = require('./stripes-module-parser');
 const StripesBuildError = require('./stripes-build-error');
 const stripesSerialize = require('./stripes-serialize');
+const logger = require('./logger')('stripesConfigPlugin');
 
 module.exports = class StripesConfigPlugin {
   constructor(options) {
+    logger.log('initializing...');
     if (!_.isObject(options.modules)) {
       throw new StripesBuildError('stripes-config-plugin was not provided a "modules" object for enabling stripes modules');
     }
@@ -21,6 +23,7 @@ module.exports = class StripesConfigPlugin {
 
   apply(compiler) {
     const enabledModules = this.options.modules;
+    logger.log('enabled modules:', enabledModules);
     const { config, metadata, warnings } = stripesModuleParser.parseAllModules(enabledModules, compiler.context, compiler.options.resolve.alias);
     this.mergedConfig = Object.assign({}, this.options, { modules: config });
     this.metadata = metadata;
@@ -49,6 +52,7 @@ module.exports = class StripesConfigPlugin {
       export { okapi, config, modules, branding, translations, metadata };
     `;
 
+    logger.log('writing virtual module...', stripesVirtualModule);
     this.virtualModule.writeModule('node_modules/stripes-config.js', stripesVirtualModule);
   }
 

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -2,6 +2,7 @@ const path = require('path');
 const _ = require('lodash');
 const modulePaths = require('./module-paths');
 const StripesBuildError = require('./stripes-build-error');
+const logger = require('./logger')('stripesModuleParser');
 
 function appendOrSingleton(maybeArray, newValue) {
   const singleton = [newValue];
@@ -12,6 +13,7 @@ function appendOrSingleton(maybeArray, newValue) {
 // Handles the parsing of one Stripes module's configuration and metadata
 class StripesModuleParser {
   constructor(moduleName, overrideConfig, context, aliases) {
+    logger.log(`initializing parser for ${moduleName}...`);
     this.moduleName = moduleName;
     this.modulePath = '';
     this.nameOnly = moduleName.replace(/.*\//, '');
@@ -61,6 +63,7 @@ class StripesModuleParser {
       version,
     });
     delete stripeConfig.type;
+    logger.log('config:', stripeConfig);
     return stripeConfig;
   }
 
@@ -85,7 +88,7 @@ class StripesModuleParser {
       icons,
       welcomePageEntries,
     };
-
+    logger.log('metadata:', metadata);
     return metadata;
   }
 

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const _ = require('lodash');
 const webpack = require('webpack');
 const modulePaths = require('./module-paths');
+const logger = require('./logger')('stripesTranslationsPlugin');
 
 function prefixKeys(obj, prefix) {
   const res = {};
@@ -22,6 +23,7 @@ module.exports = class StripesTranslationPlugin {
     };
     Object.assign(this.modules, options.modules);
     this.languageFilter = options.config.languages || [];
+    logger.log('language filter', this.languageFilter);
   }
 
   apply(compiler) {
@@ -45,6 +47,7 @@ module.exports = class StripesTranslationPlugin {
     // Emit merged translations to the output directory
     compiler.plugin('emit', (compilation, callback) => {
       Object.keys(allTranslations).forEach((language) => {
+        logger.log(`emitting translations for ${language} --> ${fileData[language].emitPath}`);
         const content = JSON.stringify(allTranslations[language]);
         compilation.assets[fileData[language].emitPath] = {
           source: () => content,
@@ -76,6 +79,7 @@ module.exports = class StripesTranslationPlugin {
 
   // Load translation *.json files from a single module's translation directory
   loadTranslationsDirectory(moduleName, dir) {
+    logger.log('loading translations from directory', dir);
     const moduleTranslations = {};
     for (const translationFile of fs.readdirSync(dir)) {
       const language = translationFile.replace('.json', '');
@@ -90,6 +94,7 @@ module.exports = class StripesTranslationPlugin {
 
   // Maintains backwards-compatibility with existing apps
   loadTranslationsPackageJson(moduleName, packageJsonPath) {
+    logger.log('loading translations from package.json (legacy)', packageJsonPath);
     const moduleTranslations = {};
     const packageJson = StripesTranslationPlugin.loadFile(packageJsonPath);
     if (packageJson.stripes && packageJson.stripes.translations) {


### PR DESCRIPTION
This adds the "debug" package, also used in the CLI, to provide better visibility into Stripes builds.  By default no additional output is given.  Output is enabled by setting the `DEBUG` environment variable and specifying a wildcard on the "stripes" namespace to get both stripes-cli and stripes-core logs.  

For example: `DEBUG=stripes* stripes build stripes.config.js`

STCOR-141