### PR TITLE
STCON-67 && STCOM-150 Error Boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Modified z-index of MainNav, ModuleContainer, OverlayContainer so that components within these containers can apply their own z-indexes without collision or unwanted overlap. Also Implements STCOR-187.
 * Add diagnostic output to stripes builds, STCOR-141.
 * Set @folio's NPM registry before using it. Duh. Fixes STCOR-193. Available from v2.9.5.
+* Added React Error Boundary to catch errors thrown during render(), implementing STCOR-150.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@folio/stripes-components": "^2.0.0",
-    "@folio/stripes-connect": "^3.1.0",
+    "@folio/stripes-connect": "^3.1.2",
     "@folio/stripes-logger": "^0.0.2",
     "apollo-cache-inmemory": "^1.1.1",
     "apollo-client": "^2.0.3",

--- a/src/components/GlobalErrorBoundary/GlobalErrorBoundary.js
+++ b/src/components/GlobalErrorBoundary/GlobalErrorBoundary.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class GlobalErrorBoundary extends React.Component {
+  static propTypes = {
+    children: PropTypes.object,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      error: false,
+    };
+  }
+
+  componentDidCatch(error) {
+    this.setState({ error });
+  }
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      return <h1>{error.message}</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default GlobalErrorBoundary;

--- a/src/components/GlobalErrorBoundary/GlobalErrorBoundary.js
+++ b/src/components/GlobalErrorBoundary/GlobalErrorBoundary.js
@@ -10,18 +10,25 @@ class GlobalErrorBoundary extends React.Component {
     super(props);
 
     this.state = {
-      error: false,
+      error: undefined,
+      info: undefined,
     };
   }
 
-  componentDidCatch(error) {
-    this.setState({ error });
+  componentDidCatch(error, info) {
+    this.setState({ error, info });
   }
 
   render() {
-    const { error } = this.state;
+    const { error, info } = this.state;
     if (error) {
-      return <h1>{error.message}</h1>;
+      return (
+        <div>
+          <h1>The following error has occurred:</h1>
+          <h3>{error.message}</h3>
+          <p>{info}</p>
+        </div>
+      );
     }
 
     return this.props.children;

--- a/src/components/GlobalErrorBoundary/index.js
+++ b/src/components/GlobalErrorBoundary/index.js
@@ -1,0 +1,2 @@
+export { default } from './GlobalErrorBoundary';
+

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -15,6 +15,7 @@ import { loadTranslations, checkOkapiSession } from '../../loginServices';
 import { getQueryResourceKey } from '../../locationService';
 import Stripes from '../../Stripes';
 import RootWithIntl from '../../RootWithIntl';
+import GlobalErrorBoundary from '../GlobalErrorBoundary';
 
 import './Root.css';
 
@@ -118,11 +119,13 @@ class Root extends Component {
     });
 
     return (
-      <ApolloProvider client={createApolloClient(okapi)}>
-        <IntlProvider locale={locale} key={locale} messages={translations}>
-          <RootWithIntl stripes={stripes} token={token} disableAuth={disableAuth} history={history} />
-        </IntlProvider>
-      </ApolloProvider>
+      <GlobalErrorBoundary>
+        <ApolloProvider client={createApolloClient(okapi)}>
+          <IntlProvider locale={locale} key={locale} messages={translations}>
+            <RootWithIntl stripes={stripes} token={token} disableAuth={disableAuth} history={history} />
+          </IntlProvider>
+        </ApolloProvider>
+      </GlobalErrorBoundary>
     );
   }
 }

--- a/src/connectErrorEpic.js
+++ b/src/connectErrorEpic.js
@@ -3,6 +3,9 @@ const connectErrorEpic = action$ => action$
   .map((action) => {
     const { meta, payload: e } = action;
     const op = action.type === '@@stripes-connect/FETCH_ERROR' ? 'GET' : e.type;
+
+    if (!meta.throwErrors) return undefined;
+
     // eslint-disable-next-line prefer-template,no-alert
     window.alert(`ERROR: in module ${meta.module}, operation ${op}`
       + ` on resource '${meta.resource}' failed`
@@ -13,6 +16,7 @@ const connectErrorEpic = action$ => action$
     // through it this will better follow the redux-observable pattern of emitting
     // another action.
     return { type: '@@stripes-core/CREATE_NOTIFICATION' };
-  });
+  })
+  .filter(action => action !== undefined);
 
 export default connectErrorEpic;


### PR DESCRIPTION
STCON-67 turns off the `alert()` box when [using the `throwErrors` prop implemented here](https://github.com/folio-org/stripes-connect/pull/44). 

STCOM-150 adds [an Error Boundary at the top-level of the application.](https://reactjs.org/docs/error-boundaries.html). Error boundaries let us catch errors thrown _only_ in render() or lifecycle methods. 

React 16 unmounts the component tree when errors are thrown rather than operating in an unstable state, so error boundaries give us the opportunity to introduce a fallback UI. Contrary to what I initially thought, they are not intended to be used as a mechanism to trap errors and return to a stable state. That's why `GlobalErrorBoundary` is fairly dumb and just reports the error and doesn't do anything interesting.