### PR TITLE
STRIPES-528 OverlayContainer: removed enabling of pointer-events for children

### DIFF
--- a/src/components/OverlayContainer/OverlayContainer.css
+++ b/src/components/OverlayContainer/OverlayContainer.css
@@ -4,8 +4,4 @@
   z-index: 9999;
   width: 100vw;
   height: 100vh;
-
-  & > * {
-    pointer-events: all;
-  }
 }


### PR DESCRIPTION
OverlayContainer's children were stealing all pointer-events. This made us unable to interact with the page at all, giving the impression that the page had frozen.

This wasn't manifesting in (my) local builds, only on folio-testing. In local builds, `.callout`'s `pointer-events: none` rule won out while in folio-testing `overlayContainer>*`'s `pointer-events:all` rule won out. 

I can't say for certain why the rules were non-deterministic, but my best guess is that since the specificity was the same, the order that the rules were squashed together by Webpack was the deciding factor. I confirmed that the `style.{...}.css` bundle created for folio-testing _did_ have the `:all` rule later in the file so that's the explanation I'm rolling with.