### PR TITLE
Create TimeZone and Locale contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.10.0 (IN PROGRESS)
 
+* Create `Locale` and `TimeZone` contexts. Fixes STCOM-259.
 * Update [Creating a new development setup for Stripes](doc/new-development-setup.md) for `stripes-cli`-based workflow. Fixes STCOR-140.
 * New document, [Depending on unreleased features](doc/depending-on-unreleased-features.md). Fixes STCOR-152.
 * Reorganize [Creating a new development setup for Stripes](doc/new-development-setup.md) and add `configure` script. Refs STCOR-140.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "stylelint-config-standard": "^17.0.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.12",
+    "@folio/stripes-components": "git+https://git@github.com/thefrontside/stripes-components.git#jc/timezone-locale-contexts",
     "@folio/stripes-connect": "^3.1.2",
     "@folio/stripes-logger": "^0.0.2",
     "apollo-cache-inmemory": "^1.1.1",

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -7,6 +7,8 @@ import { IntlProvider } from 'react-intl';
 import queryString from 'query-string';
 import { ApolloProvider } from 'react-apollo';
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
+import { LocaleContext } from '@folio/stripes-components/lib/Locale';
+import { TimeZoneContext } from '@folio/stripes-components/lib/TimeZone';
 import initialReducers from '../../initialReducers';
 import enhanceReducer from '../../enhanceReducer';
 import createApolloClient from '../../createApolloClient';
@@ -107,7 +109,7 @@ class Root extends Component {
       formatDate: (dateStr, zone) => formatDate(dateStr, zone || timezone),
       formatTime: (dateStr, zone) => formatTime(dateStr, zone || timezone),
       formatDateTime: (dateStr, zone) => formatDateTime(dateStr, zone || timezone),
-      formatAbsoluteDate: (dateStr) => formatDate(dateStr, 'UTC'),
+      formatAbsoluteDate: dateStr => formatDate(dateStr, 'UTC'),
       bindings,
       setBindings: (val) => { store.dispatch(setBindings(val)); },
       discovery,
@@ -120,11 +122,15 @@ class Root extends Component {
 
     return (
       <ErrorBoundary>
-        <ApolloProvider client={createApolloClient(okapi)}>
-          <IntlProvider locale={locale} key={locale} messages={translations}>
-            <RootWithIntl stripes={stripes} token={token} disableAuth={disableAuth} history={history} />
-          </IntlProvider>
-        </ApolloProvider>
+        <LocaleContext.Provider value={locale}>
+          <TimeZoneContext.Provider value={timezone}>
+            <ApolloProvider client={createApolloClient(okapi)}>
+              <IntlProvider locale={locale} key={locale} messages={translations}>
+                <RootWithIntl stripes={stripes} token={token} disableAuth={disableAuth} history={history} />
+              </IntlProvider>
+            </ApolloProvider>
+          </TimeZoneContext.Provider>
+        </LocaleContext.Provider>
       </ErrorBoundary>
     );
   }


### PR DESCRIPTION
## Purpose
Work for https://issues.folio.org/browse/UIORG-55 changed the behavior of `Datepicker`. Instead of emitting an ISO-8601 datetime string in the user's local time zone, it now emits the datetime at UTC.

That needs tests. We should be able to more easily identify breaking changes.

## Approach
Adds context providers for `locale` and `timeZone`.

Much more detail at: https://github.com/folio-org/stripes-components/pull/349

## Risk
Accessing `this.context.stripes.locale` and `this.context.stripes.timezone` should continue to work as previously, but we should find a way to deprecate those in favor of using `withLocale` and `withTimeZone`.

## TODO
- [ ] Merge https://github.com/folio-org/stripes-components/pull/349 first.
- [ ] Remove fork from `package.json`.