### PR TITLE
retrieve module info in a single request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Add diagnostic output to stripes builds, STCOR-141.
 * Set @folio's NPM registry before using it. Duh. Fixes STCOR-193. Available from v2.9.5.
 * Added React Error Boundary to catch errors thrown during render(), implementing STCOR-150.
+* Retrieve tenant module details in one swell foop. Fixes STCOR-200. Available from v2.9.6.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -7,21 +7,6 @@
  */
 import 'isomorphic-fetch';
 
-function discoverInterfaces(okapiUrl, store, entry) {
-  return fetch(`${okapiUrl}/_/proxy/modules/${entry.id}`)
-    .then((response) => { // eslint-disable-line consistent-return
-      if (response.status >= 400) {
-        store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
-      } else {
-        return response.json().then((json) => {
-          store.dispatch({ type: 'DISCOVERY_INTERFACES', data: json });
-        });
-      }
-    }).catch((reason) => {
-      store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
-    });
-}
-
 export function discoverServices(store) {
   const okapi = store.getState().okapi;
   return Promise.all([
@@ -37,14 +22,14 @@ export function discoverServices(store) {
       }).catch((reason) => {
         store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
       }),
-    fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules`)
+    fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules?full=true`)
       .then((response) => { // eslint-disable-line consistent-return
         if (response.status >= 400) {
           store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
         } else {
           return response.json().then((json) => {
             store.dispatch({ type: 'DISCOVERY_SUCCESS', data: json });
-            return Promise.all(json.map(entry => discoverInterfaces(okapi.url, store, entry)));
+            return Promise.all(json.map(entry => store.dispatch({ type: 'DISCOVERY_INTERFACES', data: entry })));
           });
         }
       }).catch((reason) => {


### PR DESCRIPTION
Retrieve module info in one request, instead of one request per module.
This is vastly more performant.

Fixes [STCOR-200](https://issues.folio.org/browse/STCOR-200).