### PR TITLE
doc: intl from context

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -5,6 +5,7 @@
 * [TL;DR](#tldr)
 * [Details](#details)
     * [Dates and times](#dates-and-times)
+* [intl object](#intl-object)
 * [Examples](#examples)
 
 
@@ -82,6 +83,24 @@ All date and time data exchanged with the backend is expressed in UTC. The forma
 
 For date and time values, use `import { FormattedDate } from 'react-intl'; ... const message = <FormattedDate value={item.metadata.updatedDate} />` or the methods on `this.props.stripes`: `formatDate(loan.dueDate)`, `formatTime(loan.dueDate)`, or `formatDateTime(loan.dueDate)`.
 
+### intl object
+
+The `<IntlProvider>` is at the root level of the Stripes UI, so all components can retrieve the `intl` object via context:
+
+```
+import { intlShape } from 'react-intl';
+
+class MyComponent extends React.Component {
+   render() {
+      return (<div>this.context.intl.formatMessage({ id: 'hello.world' })</div>)
+   }
+}
+
+MyComponent.contextTypes = {
+  intl: intlShape
+};
+export default MyComponent;
+```
 
 ## Examples
 


### PR DESCRIPTION
For most of the project, we use `this.props.stripes.intl`. It's much more versatile to retrieve `intl` from context, which is what `react-intl` components do (like [`<FormattedMessage>`](https://github.com/yahoo/react-intl/blob/f82383e02cb0d38dfd28649dc2442a2ea2796a44/src/components/message.js#L19)).