### PR TITLE
translate module types on About page

### DIFF
--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -63,7 +63,20 @@ const About = (props) => {
 
   function listModules(caption, list, interfaces) {
     const itemFormatter = m => (<li key={m.module}>{renderDependencies(m, interfaces)}</li>);
-    const headlineMsg = <FormattedMessage id="stripes-core.about.moduleTypeCount" values={{ count: list.length, type: caption }} />;
+    var headlineMsg;
+    switch (caption) {
+      case 'app':
+        headlineMsg = <FormattedMessage id="stripes-core.about.appModuleCount" values={{ count: list.length }} />;
+        break;
+      case 'settings':
+        headlineMsg = <FormattedMessage id="stripes-core.about.settingsModuleCount" values={{ count: list.length }} />;
+        break;
+      case 'plugin':
+        headlineMsg = <FormattedMessage id="stripes-core.about.pluginModuleCount" values={{ count: list.length }} />;
+        break;
+      default:
+        headlineMsg = <FormattedMessage id="stripes-core.about.moduleTypeCount" values={{ count: list.length, type: caption }} />;
+    }
     return (
       <div key={caption}>
         <Headline>{headlineMsg}</Headline>

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -63,7 +63,7 @@ const About = (props) => {
 
   function listModules(caption, list, interfaces) {
     const itemFormatter = m => (<li key={m.module}>{renderDependencies(m, interfaces)}</li>);
-    var headlineMsg;
+    let headlineMsg;
     switch (caption) {
       case 'app':
         headlineMsg = <FormattedMessage id="stripes-core.about.appModuleCount" values={{ count: list.length }} />;

--- a/translations/de.json
+++ b/translations/de.json
@@ -38,6 +38,10 @@
   "about.key.compatible": "Interfaces, die in kompatibler Version bereitstehen, erscheinen in normaler Schrift.",
   "about.moduleTypeCount": "{count, number} {type}-{count, plural, one {Modul} other {Module}}",
 
+  "about.appModuleCount": "{count, number} {count, plural, one {Appmodul} other {Appmodule}}",
+  "about.settingsModuleCount": "{count, number} {count, plural, one {Modul} other {Module}} für Einstellungen",
+  "about.pluginModuleCount": "{count, number} {count, plural, one {Pluginmodul} other {Pluginmodule}}",
+
   "loggedInAs": "Als {firstName} {lastName} eingeloggt",
   "logout": "Ausloggen",
   "settings": "Einstellungen",

--- a/translations/en.json
+++ b/translations/en.json
@@ -39,6 +39,10 @@
   "about.key.compatible": "Interfaces that are present in a compatible version are shown in regular font.",
   "about.moduleTypeCount": "{count, number} {type} {count, plural, one {module} other {modules}}",
 
+  "about.appModuleCount": "{count, number} app {count, plural, one {module} other {modules}}",
+  "about.settingsModuleCount": "{count, number} settings {count, plural, one {module} other {modules}}",
+  "about.pluginModuleCount": "{count, number} plugin {count, plural, one {module} other {modules}}",
+
   "loggedInAs": "Logged in as {firstName} {lastName}",
   "logout": "Log out",
   "settings": "Settings",


### PR DESCRIPTION
Addressing Julian's [comment](https://issues.folio.org/browse/STCOR-196?focusedCommentId=30143&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-30143) to translate the module types (_app_, _settings_, and _plugin_)