### PR TITLE
include ui-vendors in pull-stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Retrieve tenant module details in one swell foop. Fixes STCOR-200. Available from v2.9.6.
 * Add build option to disable JS minification, STCOR-197
 * Upgrade required version of hard-source-webpack-plugin, and thereby of leveldown. Fixes STCOR-210.
+* Include ui-vendors in pull-stripes.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/util/pull-stripes
+++ b/util/pull-stripes
@@ -28,6 +28,7 @@ dirs=`echo '
     ui-search
     ui-testing
     ui-trivial
+    ui-vendors
     eslint-config-stripes
 '`
 


### PR DESCRIPTION
Is `ui-vendors` enough of a core repository that we should include it in `pull-stripes`? Seems like "yes" to me. 