### PR TITLE
STCOR-207 Set document lang attribute for assistive technology

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>FOLIO</title>

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -54,7 +54,11 @@ export function getLocale(okapiUrl, store, tenant) {
           if (json.configs.length) {
             const localeValues = JSON.parse(json.configs[0].value);
             const { locale, timezone } = localeValues;
-            if (locale) loadTranslations(store, locale);
+            if (locale) {
+              loadTranslations(store, locale);
+              // set title of document using first 2 characters of locale.
+              document.documentElement.setAttribute('lang', locale.substr(0, 2));
+            }
             if (timezone) store.dispatch(setTimezone(timezone));
           }
         });


### PR DESCRIPTION
# Purpose
So that assistive technology can pick up on which language the document should be read in, the language code should be indicated in the html as a `lang` attribute on the `<html>` tag.

https://www.w3.org/International/questions/qa-html-language-declarations

# Approach
This is set to "en" as default in the base index.html of stripes-core, which is updated later once the locale information loads from okapi. 

Corresponds with another PR on `ui-org` for when the locale is changed. https://github.com/folio-org/ui-organization/pull/72