### PR TITLE
translate login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Add build option to disable JS minification, STCOR-197
 * Upgrade required version of hard-source-webpack-plugin, and thereby of leveldown. Fixes STCOR-210.
 * Include ui-vendors in pull-stripes.
+* I18n-ify login page. Fixes STCOR-213.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -60,7 +60,7 @@ const RootWithIntl = (props, context) => {
             </MainContainer> :
             <Switch>
               <Route exact path="/sso-landing" component={() => wrapInErrorBoundary(<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>)} key="sso-landing" />
-              <Route component={() => wrapInErrorBoundary(<LoginCtrl autoLogin={stripes.config.autoLogin} />)} />
+              <Route component={() => wrapInErrorBoundary(<LoginCtrl autoLogin={stripes.config.autoLogin} stripes={stripes} />)} />
             </Switch>
           }
         </Router>

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -12,6 +12,11 @@ import { branding } from 'stripes-config'; //eslint-disable-line
 
 class Login extends Component {
   static propTypes = {
+    stripes: PropTypes.shape({
+      intl: PropTypes.shape({
+        formatMessage: PropTypes.func.isRequired,
+      }),
+    }).isRequired,
     handleSubmit: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     submitting: PropTypes.bool,
@@ -50,11 +55,12 @@ class Login extends Component {
       onSubmit,
       formValues,
       submitSucceeded,
+      stripes: { intl: { formatMessage: translate } },
     } = this.props;
 
     const { username } = formValues;
     const buttonDisabled = submitting || submitSucceeded || !(username);
-    const buttonLabel = (submitting || (submitSucceeded)) ? 'Logging in...' : 'Log in';
+    const buttonLabel = translate({ id: (submitting || (submitSucceeded)) ? 'stripes-core.loggingIn' : 'stripes-core.login' });
     return (
       <div className={authFormStyles.wrap}>
         <div className={authFormStyles.centered}>
@@ -66,7 +72,7 @@ class Login extends Component {
                 component={TextField}
                 name="username"
                 type="text"
-                placeholder="Username"
+                placeholder={translate({ id: 'stripes-core.username' })}
                 marginBottom0
                 fullWidth
                 inputClass={authFormStyles.input}
@@ -81,7 +87,7 @@ class Login extends Component {
                 component={TextField}
                 name="password"
                 type="password"
-                placeholder="Password"
+                placeholder={translate({ id: 'stripes-core.password' })}
                 marginBottom0
                 fullWidth
                 inputClass={authFormStyles.input}

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -18,6 +18,11 @@ class LoginCtrl extends Component {
       username: PropTypes.string.isRequired,
       password: PropTypes.string.isRequired,
     }),
+    stripes: PropTypes.shape({
+      intl: PropTypes.shape({
+        formatMessage: PropTypes.func.isRequired,
+      }),
+    }).isRequired,
   }
 
   constructor(props, context) {
@@ -55,6 +60,7 @@ class LoginCtrl extends Component {
         authError={authFailure}
         handleSSOLogin={this.handleSSOLogin}
         ssoActive={ssoEnabled}
+        stripes={this.props.stripes}
       />
     );
   }

--- a/translations/en.json
+++ b/translations/en.json
@@ -41,6 +41,10 @@
 
   "loggedInAs": "Logged in as {firstName} {lastName}",
   "logout": "Log out",
+  "login": "Log in",
+  "username": "Username",
+  "password": "Password",
+  "loggingIn": "Logging in...",
   "settings": "Settings",
   "folioSettings": "FOLIO settings",
   "mainNavigation": "Main Navigation",


### PR DESCRIPTION
Thread the `stripes` object through to the login page so we can
translate its embedded strings.

Fixes [STCOR-213](https://issues.folio.org/browse/STCOR-213).