### PR TITLE
update Okapi deps WRT proxy.meta deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Include ui-vendors in pull-stripes.
 * Added system skeleton loading
 * I18n-ify login page. Fixes STCOR-213.
+* Update Okapi dependencies corresponding with UIU-495.
 
 ## [2.9.0](https://github.com/folio-org/stripes-core/tree/v2.9.0) (2018-02-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.8.0...v2.9.0)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "stripes": {
     "okapiInterfaces": {
-      "users-bl": "2.0",
+      "users-bl": "3.0",
       "authtoken": "1.0",
       "configuration": "2.0"
     },


### PR DESCRIPTION
This is merely follow through for work done in [UIU-495](https://issues.folio.org/browse/UIU-495), which allowed a deprecated field to be removed.