### PR TITLE
Fix prefix when retrieving query resource key. Fixes STCOR-220

### DIFF
--- a/src/locationService.js
+++ b/src/locationService.js
@@ -7,7 +7,8 @@ function getLocationQuery(location) {
 }
 
 export function getQueryResourceKey({ dataKey, module, queryResource }) {
-  return `${dataKey || ''}${snakeCase(module)}_${queryResource}`;
+  const prefix = dataKey ? `${dataKey}#` : '';
+  return `${prefix}${snakeCase(module)}_${queryResource}`;
 }
 
 export function getQueryResourceState(module, store) {


### PR DESCRIPTION
Fixes https://issues.folio.org/browse/STCOR-220

When `dataKey` is used for given `module` all resources in redux store are prefixed with `dataKey#`. For example:

`patrons#folio_users_records`

The previous implementation was missing `#` so it would try to retrieve a wrong key:

`patronsfolio_users_records`


 
