### PR TITLE
STCOR-221 Add babel plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.0.0",
     "babel-plugin-react-transform": "^2.0.2",
+    "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.16.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.0.0",
     "babel-plugin-react-transform": "^2.0.2",
+    "babel-plugin-remove-jsx-attributes": "^0.0.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.6.0",

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -55,4 +55,13 @@ prodConfig.module.rules.push({
   }),
 });
 
+// Remove all data-test or data-test-* attributes
+const babelLoaderConfig = prodConfig.module.rules.find(rule => rule.loader === 'babel-loader');
+
+babelLoaderConfig.options.plugins = (babelLoaderConfig.options.plugins || []).concat([
+  [require.resolve('babel-plugin-remove-jsx-attributes'), {
+    patterns: ['^data-test.*$']
+  }]
+]);
+
 module.exports = prodConfig;

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -32,5 +32,8 @@ module.exports = {
       [require.resolve('babel-preset-stage-2')],
       [require.resolve('babel-preset-react')],
     ],
+    plugins: [
+      [require.resolve('babel-plugin-transform-decorators-legacy')]
+    ]
   },
 };


### PR DESCRIPTION
## Purpose
`ui-eholdings` has been adding two babel plugins for a while in a [`.stripesclirc.js`](https://github.com/folio-org/ui-eholdings/blob/master/.stripesclirc.js):
### [babel-plugin-transform-decorators-legacy](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy)
`ui-eholdings` makes use of decorators in the "interactors" for UI tests. Example: https://github.com/folio-org/ui-eholdings/blob/master/tests/pages/datepicker.js. `ui-eholdings` only adds this plugin in the `test` environment, but I don't see any harm in adding it for all builds.

### [babel-plugin-remove-jsx-attributes](https://github.com/wireapp/babel-plugin-remove-jsx-attributes)
Used to remove `data-test` and `data-test-*` attributes from production builds. `ui-eholdings` relies on `data-test-*` attributes for UI testing instead of IDs (with some exceptions). There were discussions recently about taking this approach in more of the `stripes` ecosystem. This won't break any existing tests using IDs, but will make `data-test` attributes a more attractive option for everyone.

## Approach
I have doubts about the elegance of the way I'm injecting `babel-plugin-remove-jsx-attributes` into production builds (and only production builds). Suggestions welcome.