### PR TITLE
Remove empty params during transitioning. Fixes STCOR-223

### DIFF
--- a/src/locationService.js
+++ b/src/locationService.js
@@ -1,4 +1,4 @@
-import { snakeCase, isEqual, omitBy, isNil, isEmpty, unset } from 'lodash';
+import { snakeCase, isEqual, omitBy, isEmpty, unset } from 'lodash';
 import queryString from 'query-string';
 import { replaceQueryResource } from './locationActions';
 
@@ -30,12 +30,14 @@ export function updateQueryResource(location, module, store) {
 export function updateLocation(module, curQuery, store, history, location) {
   const stateQuery = getQueryResourceState(module, store);
   const locationQuery = getLocationQuery(location);
+  const cleanStateQuery = omitBy(stateQuery, isEmpty);
+  const cleanLocationQuery = omitBy(locationQuery, isEmpty);
 
-  if (isEqual(stateQuery, locationQuery)) return curQuery;
+  if (isEqual(cleanStateQuery, cleanLocationQuery)) return curQuery;
 
-  const params = omitBy(Object.assign({}, locationQuery, stateQuery), isNil);
+  const params = omitBy(Object.assign({}, locationQuery, stateQuery), isEmpty);
+
   let url = params._path || location.pathname;
-
   unset(params, '_path');
 
   if (isEqual(curQuery, params) && url === location.pathname) {


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-223

@zburke and @aditya-matukumalli would you mind taking quick look at this? Also if you could checkout that branch and test it out that would be great! 

@aditya-matukumalli you should be able to remove `query=` from https://github.com/folio-org/ui-checkout/blob/master/lib/ViewItem/ViewItem.js#L126 and https://github.com/folio-org/ui-checkout/blob/master/lib/ViewItem/ViewItem.js#L133 and ideally everything should still work.
