### PR TITLE
Update i18n docs

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -13,32 +13,31 @@
 
 Folio's i18n implementation is based on components provided by [react-intl](https://github.com/yahoo/react-intl). The [Basic Internationalization Principles](https://formatjs.io/guides/basic-i18n/) and [React Internationalization – How To](https://www.smashingmagazine.com/2017/01/internationalizing-react-apps/) guides mentioned there are worthwhile reads to get the lay of the land. Note that in addition to strings, dates and times also have locale-specific formats, e.g. dates in the US may be expressed as MM/DD/YYYY while in Europe they will be expressed as DD/MM/YYYY.
 
-We store locale data in each app's `translations/` directory, e.g. `translations/en.json`, `translations/de.json` and use the components `<FormattedMessage>` and `<SafeHTMLMessage>`, and the method `stripes.intl.formatMessage`, to replace placeholder strings in the code with values loaded from those files.
+We store locale data in each app's `translations/<module-name>` directory, e.g. `translations/ui-users/en.json`, `translations/ui-users/de.json` and use the components `<FormattedMessage>` and `<SafeHTMLMessage>`, and the method `intl.formatMessage`, to replace placeholder strings in the code with values loaded from those files.
 
-We use the components `<FormattedDate>` and `<FormattedTime>` and the methods `stripes.formatDate`, `stripes.formatTime`, and `stripes.formatDateTime` to render dates and times. Please note that *all date and time data exchanged with the backend happens in UTC* and the `stripes` methods and component take care of handling timezone offsets and daylight saving time.
+We use the components `<FormattedDate>` and `<FormattedTime>` and the methods `intl.formatDate` and `intl.formatTime` to render dates and times. FOLIO front-end modules should stick to exchanging date and time information with the back end in UTC.
 
 Our approach to providing rich-text markup, e.g. `The value <strong>{value}</strong> was removed.`, is to use HTML directly in the translation files and to use the `<SafeHTMLMessage>` component to display it. (HTML markup in values passed through `<FormattedMessage>` will be escaped, e.g. `<strong>` will be converted to `&amp;%lt;strong&gt;&amp;` whereas `<SafeHTMLMessage>` allows HTML markup to stand but sanitizes it to remove dangerous code without escaping known-good values.)
 
-At present, translations are maintained manually by direct editing of the `translations/*.json` files. Plans to integrate with [lokalise.co](https://lokalise.co/) are in progress. This will allow updates to files in a GitHub repository's translation directory to be pushed to Lokalise automatically, and will allow Lokalise to generate pull-requests against the repository when new translations are available.
+At present, translations are maintained manually by direct editing of the `translations/<module-name>/*.json` files. Plans to integrate with [lokalise.co](https://lokalise.co/) are in progress. This will allow updates to files in a GitHub repository's translation directory to be pushed to Lokalise automatically, and will allow Lokalise to generate pull-requests against the repository when new translations are available.
 
 
 ## TL;DR
 
-`stripes-core` adds locale and timezone information to React's context so you don't need to worry about that.
+`stripes-core` sets up a `react-intl` `<IntlProvider>`.
 
-All date and time data exchanged with the backend happens in UTC. The `stripes` date and time functions and components know this and handle it accordingly.
+FOLIO front-end modules should stick to exchanging date and time information with the back end in UTC.
 
-For plain template strings, e.g. `The value {value} was removed.`, use
-```
-this.props.stripes.intl.formatMessage({ id: 'the.message.id' }, { value: "Moose" })
-```
-to receive a string, or
+To print a string, use
 ```
 import { FormattedMessage } from 'react-intl';
 ...
 const message = <FormattedMessage id="the.message.id" values={{ value: "Flying Squirrel" }} />;
 ```
-to receive a component.
+When you need a plain string without a component, inject the `intl` prop into your component with [`injectIntl`](https://github.com/yahoo/react-intl/wiki/API#injection-api), then:
+```
+this.props.intl.formatMessage({ id: 'the.message.id' }, { value: "Moose" })
+```
 
 For HTML template strings, e.g. `The value <strong>{value}</strong> was removed.`, use
 ```
@@ -53,12 +52,10 @@ import { FormattedDate } from 'react-intl';
 ...
 const message = <FormattedDate value={item.metadata.updatedDate} />
 ```
-or the methods on `this.props.stripes`: `formatDate(loan.dueDate)`, `formatTime(loan.dueDate)`, or `formatDateTime(loan.dueDate)`.
+or, if you need a plain string, `injectIntl` and: `this.props.intl.formatDate(loan.dueDate)` and/or `this.props.intl.formatTime(loan.dueDate)`.
 
 
 ## Details
-
-`stripes-core` adds locale and timezone information to React's context so you don't need to worry about providing that information when formatting your strings; you can simply use the available components or `stripes` methods with the knowledge that they have already been correctly initialized.
 
 Keys in libraries have the name of the library automatically prefixed, e.g. a key named `search` in `stripes-components/translations/stripes-components/en.json` would be accessible as `stripes-components.search`. Keys in apps have the name of the app automatically prefixed, e.g. a key named `search` in `ui-users/translations/ui-users/en.json` would be accessible as `ui-users.search`.
 
@@ -79,33 +76,34 @@ Here, the same argument `count` is formatted in two different ways; once as the 
 
 ### Dates and times
 
-All date and time data exchanged with the backend is expressed in UTC. The formatters provided on the `stripes` object will take care of formatting it correctly for the tenant's locale and correctly handling the offset from UTC, including daylight saving time, for the tenant's timezone. Please *do not write your own date-formatters*.
-
-For date and time values, use `import { FormattedDate } from 'react-intl'; ... const message = <FormattedDate value={item.metadata.updatedDate} />` or the methods on `this.props.stripes`: `formatDate(loan.dueDate)`, `formatTime(loan.dueDate)`, or `formatDateTime(loan.dueDate)`.
+For date and time values, use `import { FormattedDate } from 'react-intl'; ... const message = <FormattedDate value={item.metadata.updatedDate} />` or `react-intl`'s methods': `this.props.intl.formatDate(loan.dueDate)` and/or `this.props.intl.formatTime(loan.dueDate)`.
 
 ### intl object
 
-The `<IntlProvider>` is at the root level of the Stripes UI, so all components can retrieve the `intl` object via the [legacy context API](https://reactjs.org/docs/legacy-context.html) (example below). This API is how `react-intl` works today, but a new Context API is available in React 16.3. The legacy API will be removed in a future major version of React.
+The `<IntlProvider>` is at the root level of the `stripes-core` UI, so all child components can use `react-intl`'s components or `injectIntl`.
+
+*Retrieving the `intl` object from `this.context.intl` or `this.context.stripes.intl` is a deprecated pattern.* `react-intl` provides abstractions over the legacy React context API, so sticking to `react-intl`'s components and `injectIntl` pattern is the future-friendly way to use it. `react-intl` will eventually use React's new context API (introduced in 16.3) under the hood.
 
 ```
-import { intlShape } from 'react-intl';
+import { intlShape, injectIntl } from 'react-intl';
 
 class MyComponent extends React.Component {
    render() {
-      const msg = this.context.intl.formatMessage({ id: 'hello.world' });
+      const msg = this.props.intl.formatMessage({ id: 'hello.world' });
       return (<div>{msg}</div>);
    }
 }
 
-MyComponent.contextTypes = {
-  intl: intlShape
+MyComponent.propTypes = {
+  intl: intlShape.isRequired
 };
-export default MyComponent;
+
+export default injectIntl(MyComponent);
 ```
 
 ## Examples
 
-`translations/en.json`
+`translations/ui-my-module/en.json`
 ```
 {
   "search": "Search",
@@ -118,16 +116,12 @@ export default MyComponent;
 ```
 
 ```
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedDate, FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 class ControlledVocab extends React.Component {
   static propTypes = {
-    stripes: PropTypes.shape({
-      intl: PropTypes.shape({
-        formatMessage: PropTypes.func.isRequired,
-      }).isRequired,
-    }).isRequired,
+      intl: intlShape.isRequired
   };
 
   getHtmlMessage(item) {
@@ -155,11 +149,13 @@ class ControlledVocab extends React.Component {
   }
 
   getTextString(item) {
-    return this.props.stripes.intl.formatMessage({ id: 'stripes-smart-components.cv.numberOfObjects' }, { objects: this.props.objectLabel });
+    return this.props.intl.formatMessage({ id: 'stripes-smart-components.cv.numberOfObjects' }, { objects: this.props.objectLabel });
   }
 
   getDate(item) {
     return <FormattedDate value={item.metadata.updatedDate} />;
   }
 }
+
+export default injectIntl(ControlledVocab);
 ```


### PR DESCRIPTION
## Purpose
Three key things:
1. Updates the translation file paths.
2. Makes it clear that it's up to individual module developers to follow the pattern of exchanging date/times with the server only in UTC.
3. "Retrieving the `intl` object from `this.context.intl` or `this.context.stripes.intl` is a deprecated pattern." Most of the edits revolve around encouraging direct use of `react-intl` components and API, instead of being filtered through the `stripes` object.

## Future edits needed
Best practices for time zones.