### PR TITLE
STCOR-226: Add ModuleContext which stores i18n'd module metadata

### DIFF
--- a/doc/app-metadata.md
+++ b/doc/app-metadata.md
@@ -50,7 +50,7 @@ The `stripes` structure contains the following extension fields:
 Field | Location | Description and notes
 :---- | :------- | :--------------------
 Type | `type` | The type of the module: may be `app` for a regular full-page application, `popover` for an application that can run in popover mode as well as in regular full-page mode, or `settings` for modules that only provide an entry in the Settings page.
-Short title | `displayName` | This is needed in the header, where, based on user preference or screen size, the names of the apps may be displayed next to their icons.
+Short title ID | `displayName` | [A translation ID](./i18n.md) to look up to find a brief title. This is needed in the header, where, based on user preference or screen size, the names of the apps may be displayed next to their icons.
 Full title | `fullName` | The full title of the application: for example, when this is "Library Yearly Calendar", the short title might be just "Calendar".
 Default popover size | `defaultPopoverSize` | For applications that can run in popover mode as well as in full-screen, specifies how wide the popover should be when it first appears (subject to subsequent resizing by the user). May be specified as a percentage (e.g. `40%`) or as a pixel width (e.g. `300px`).
 Default preview width | `defaultPreviewWidth` | Specifies how wide the preview pane should be when it first appears (subject to subsequent resizing by the user). May be specified as a percentage (e.g. `40%`) or as a pixel width (e.g. `300px`).
@@ -115,7 +115,7 @@ shown here should allow all application-level metadata to be recorded.
   },
   "stripes": {
     "type": "app",
-    "displayName": "Codex Search",
+    "displayName": "ui-search.title",
     "fullName": "Codex Search",
     "defaultPopoverSize": "400px",
     "defaultPreviewWidth": "40%",

--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -108,7 +108,7 @@ A module is presented as an [NPM package](https://en.wikipedia.org/wiki/Npm_(sof
 
 * `pluginType` (only for modules of type `plugin`) -- an indication of which pluggable surface the module can be mounted on. See [below](#plugins).
 
-* `displayName` -- the name of the module as it should be viewed by human users -- e.g. "Okapi Console".
+* `displayName` -- [a translation ID](./i18n.md) to the name of the module as it should be viewed by human users -- e.g. "ui-search.title".
 
 * `route` -- the route (partial URL) by which an application module is addressed: for example, the Okapi Console module might be addressed at `/console`. The same route is used as a subroute within `/settings` to present the module's settings, if any.
 

--- a/src/ModulesContext.js
+++ b/src/ModulesContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { modules } from 'stripes-config';
+
+
+export default React.createContext(modules);

--- a/src/ModulesContext.js
+++ b/src/ModulesContext.js
@@ -3,3 +3,4 @@ import { modules } from 'stripes-config';
 
 
 export default React.createContext(modules);
+export { modules as originalModules };

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -22,64 +22,126 @@ import OverlayContainer from './components/OverlayContainer';
 import getModuleRoutes from './moduleRoutes';
 import { stripesShape } from './Stripes';
 import { StripesContext } from './StripesContext';
+import ModulesContext from './ModulesContext';
 
-const RootWithIntl = (props, context) => {
-  const intl = context.intl;
-  const connect = connectFor('@folio/core', props.stripes.epics, props.stripes.logger);
-  const stripes = props.stripes.clone({ intl, connect });
-  const { token, disableAuth, history } = props;
-  return (
-    <StripesContext.Provider value={stripes}>
-      <TitleManager>
-        <HotKeys keyMap={stripes.bindings} noWrapper>
-          <Provider store={stripes.store}>
-            <Router history={history}>
-              { token || disableAuth ?
-                <MainContainer>
-                  <OverlayContainer />
-                  <MainNav stripes={stripes} />
-                  { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
-                    <ModuleContainer id="content">
-                      <Switch>
-                        <TitledRoute name="home" path="/" key="root" exact component={<Front stripes={stripes} />} />
-                        <TitledRoute name="ssoRedirect" path="/sso-landing" key="sso-landing" component={<SSORedirect stripes={stripes} />} />
-                        <TitledRoute name="settings" path="/settings" component={<Settings stripes={stripes} />} />
-                        {getModuleRoutes(stripes)}
-                        <TitledRoute
-                          name="notFound"
-                          component={(
-                            <div>
-                              <h2>Uh-oh!</h2>
-                              <p>This route does not exist.</p>
-                            </div>
-                          )}
-                        />
-                      </Switch>
-                    </ModuleContainer>
-                  )}
-                </MainContainer> :
-                <Switch>
-                  <TitledRoute name="ssoLanding" exact path="/sso-landing" component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>} key="sso-landing" />
-                  <TitledRoute name="login" component={<LoginCtrl autoLogin={stripes.config.autoLogin} stripes={stripes} />} />
-                </Switch>
-              }
-            </Router>
-          </Provider>
-        </HotKeys>
-      </TitleManager>
-    </StripesContext.Provider>
-  );
-};
+import { modules } from 'stripes-config';
 
-RootWithIntl.contextTypes = {
-  intl: intlShape.isRequired,
-};
+class RootWithIntl extends React.Component {
+  static propTypes = {
+    stripes: stripesShape.isRequired,
+    token: PropTypes.string,
+    disableAuth: PropTypes.bool.isRequired,
+    history: PropTypes.shape({}),
+  };
 
-RootWithIntl.propTypes = {
-  stripes: stripesShape.isRequired,
-  token: PropTypes.string,
-  disableAuth: PropTypes.bool.isRequired,
-  history: PropTypes.shape({}),
-};
+  static contextTypes = {
+    intl: intlShape.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      modules,
+    };
+  }
+
+  componentDidMount() {
+    this.translateModules();
+  }
+
+  translateModules = () => {
+    this.setState({
+      modules: {
+        app: modules.app.map(this.translateModule),
+        plugin: modules.plugin.map(this.translateModule),
+        settings: modules.settings.map(this.translateModule),
+      }
+    });
+  }
+
+  translateModule = (module) => {
+    const { formatMessage } = this.context.intl;
+
+    return {
+      ...module,
+      description: module.description ? formatMessage({ id: module.description }) : undefined,
+      displayName: module.displayName ? formatMessage({ id: module.displayName }) : undefined,
+      icons: module.icons ? module.icons.map(this.translateIcons) : undefined,
+      permissionSets: module.permissionSets ? module.permissionSets.map(this.translatePermissionSets) : undefined,
+    };
+  }
+
+  translateIcons = (icon) => {
+    const { formatMessage } = this.context.intl;
+
+    return {
+      ...icon,
+      alt: icon.alt ? formatMessage({ id: icon.alt }) : undefined,
+      title: icon.title ? formatMessage({ id: icon.title }) : undefined,
+    };
+  }
+
+  translatePermissionSets = (perm) => {
+    const { formatMessage } = this.context.intl;
+
+    return {
+      ...perm,
+      displayName: perm.displayName ? formatMessage({ id: perm.displayName }) : undefined,
+      description: perm.description ? formatMessage({ id: perm.description }) : undefined,
+    };
+  }
+
+  render() {
+    const intl = this.context.intl;
+    const connect = connectFor('@folio/core', this.props.stripes.epics, this.props.stripes.logger);
+    const stripes = this.props.stripes.clone({ intl, connect });
+    const { token, disableAuth, history } = this.props;
+
+    return (
+      <ModulesContext.Provider value={this.state.modules}>
+        <StripesContext.Provider value={stripes}>
+          <TitleManager>
+            <HotKeys keyMap={stripes.bindings} noWrapper>
+              <Provider store={stripes.store}>
+                <Router history={history}>
+                  { token || disableAuth ?
+                    <MainContainer>
+                      <OverlayContainer />
+                      <MainNav stripes={stripes} />
+                      { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
+                        <ModuleContainer id="content">
+                          <Switch>
+                            <TitledRoute name="home" path="/" key="root" exact component={<Front stripes={stripes} />} />
+                            <TitledRoute name="ssoRedirect" path="/sso-landing" key="sso-landing" component={<SSORedirect stripes={stripes} />} />
+                            <TitledRoute name="settings" path="/settings" component={<Settings stripes={stripes} />} />
+                            {getModuleRoutes(stripes)}
+                            <TitledRoute
+                              name="notFound"
+                              component={(
+                                <div>
+                                  <h2>Uh-oh!</h2>
+                                  <p>This route does not exist.</p>
+                                </div>
+                              )}
+                            />
+                          </Switch>
+                        </ModuleContainer>
+                      )}
+                    </MainContainer> :
+                    <Switch>
+                      <TitledRoute name="ssoLanding" exact path="/sso-landing" component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>} key="sso-landing" />
+                      <TitledRoute name="login" component={<LoginCtrl autoLogin={stripes.config.autoLogin} stripes={stripes} />} />
+                    </Switch>
+                  }
+                </Router>
+              </Provider>
+            </HotKeys>
+          </TitleManager>
+        </StripesContext.Provider>
+      </ModulesContext.Provider>
+    );
+  }
+}
 
 export default RootWithIntl;

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -6,12 +6,12 @@ import { Provider } from 'react-redux';
 import { CookiesProvider } from 'react-cookie';
 import { HotKeys } from '@folio/stripes-components/lib/HotKeys';
 import { connectFor } from '@folio/stripes-connect';
-import { modules } from 'stripes-config';
 import { intlShape } from 'react-intl';
 
 import MainContainer from './components/MainContainer';
 import MainNav from './components/MainNav';
 import ModuleContainer from './components/ModuleContainer';
+import ModuleTranslator from './components/ModuleTranslator';
 import TitledRoute from './components/TitledRoute';
 import Front from './components/Front';
 import SSOLanding from './components/SSOLanding';
@@ -23,7 +23,6 @@ import OverlayContainer from './components/OverlayContainer';
 import getModuleRoutes from './moduleRoutes';
 import { stripesShape } from './Stripes';
 import { StripesContext } from './StripesContext';
-import ModulesContext from './ModulesContext';
 
 class RootWithIntl extends React.Component {
   static propTypes = {
@@ -37,38 +36,6 @@ class RootWithIntl extends React.Component {
     intl: intlShape.isRequired,
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      modules,
-    };
-  }
-
-  componentDidMount() {
-    this.translateModules();
-  }
-
-  translateModules = () => {
-    this.setState({
-      modules: {
-        app: modules.app.map(this.translateModule),
-        plugin: modules.plugin.map(this.translateModule),
-        settings: modules.settings.map(this.translateModule),
-      }
-    });
-  }
-
-  translateModule = (module) => {
-    const { formatMessage } = this.context.intl;
-
-    return {
-      ...module,
-      description: module.description ? formatMessage({ id: module.description }) : undefined,
-      displayName: module.displayName ? formatMessage({ id: module.displayName }) : undefined,
-    };
-  }
-
   render() {
     const intl = this.context.intl;
     const connect = connectFor('@folio/core', this.props.stripes.epics, this.props.stripes.logger);
@@ -76,8 +43,8 @@ class RootWithIntl extends React.Component {
     const { token, disableAuth, history } = this.props;
 
     return (
-      <ModulesContext.Provider value={this.state.modules}>
-        <StripesContext.Provider value={stripes}>
+      <StripesContext.Provider value={stripes}>
+        <ModuleTranslator>
           <TitleManager>
             <HotKeys keyMap={stripes.bindings} noWrapper>
               <Provider store={stripes.store}>
@@ -115,8 +82,8 @@ class RootWithIntl extends React.Component {
               </Provider>
             </HotKeys>
           </TitleManager>
-        </StripesContext.Provider>
-      </ModulesContext.Provider>
+        </ModuleTranslator>
+      </StripesContext.Provider>
     );
   }
 }

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -39,12 +39,12 @@ const RootWithIntl = (props, context) => {
                 { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
                   <ModuleContainer id="content">
                     <Switch>
-                      <TitledRoute displayName="Home" path="/" key="root" exact component={<Front stripes={stripes} />} />
-                      <TitledRoute displayName="SSO Redirect" path="/sso-landing" key="sso-landing" component={<SSORedirect stripes={stripes} />} />
-                      <TitledRoute displayName="Settings" path="/settings" component={<Settings stripes={stripes} />} />
+                      <TitledRoute name="home" path="/" key="root" exact component={<Front stripes={stripes} />} />
+                      <TitledRoute name="ssoRedirect" path="/sso-landing" key="sso-landing" component={<SSORedirect stripes={stripes} />} />
+                      <TitledRoute name="settings" path="/settings" component={<Settings stripes={stripes} />} />
                       {getModuleRoutes(stripes)}
                       <TitledRoute
-                        displayName="Not Found"
+                        name="notFound"
                         component={(
                           <div>
                             <h2>Uh-oh!</h2>
@@ -57,8 +57,8 @@ const RootWithIntl = (props, context) => {
                 )}
               </MainContainer> :
               <Switch>
-                <TitledRoute displayName="SSO Landing" exact path="/sso-landing" component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>} key="sso-landing" />
-                <TitledRoute displayName="Log in" component={<LoginCtrl autoLogin={stripes.config.autoLogin} stripes={stripes} />} />
+                <TitledRoute name="ssoLanding" exact path="/sso-landing" component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>} key="sso-landing" />
+                <TitledRoute name="login" component={<LoginCtrl autoLogin={stripes.config.autoLogin} stripes={stripes} />} />
               </Switch>
             }
           </Router>

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import { CookiesProvider } from 'react-cookie';
 import { HotKeys } from '@folio/stripes-components/lib/HotKeys';
 import { connectFor } from '@folio/stripes-connect';
+import { modules } from 'stripes-config';
 import { intlShape } from 'react-intl';
 
 import MainContainer from './components/MainContainer';
@@ -23,8 +24,6 @@ import getModuleRoutes from './moduleRoutes';
 import { stripesShape } from './Stripes';
 import { StripesContext } from './StripesContext';
 import ModulesContext from './ModulesContext';
-
-import { modules } from 'stripes-config';
 
 class RootWithIntl extends React.Component {
   static propTypes = {

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -67,28 +67,6 @@ class RootWithIntl extends React.Component {
       ...module,
       description: module.description ? formatMessage({ id: module.description }) : undefined,
       displayName: module.displayName ? formatMessage({ id: module.displayName }) : undefined,
-      icons: module.icons ? module.icons.map(this.translateIcons) : undefined,
-      permissionSets: module.permissionSets ? module.permissionSets.map(this.translatePermissionSets) : undefined,
-    };
-  }
-
-  translateIcons = (icon) => {
-    const { formatMessage } = this.context.intl;
-
-    return {
-      ...icon,
-      alt: icon.alt ? formatMessage({ id: icon.alt }) : undefined,
-      title: icon.title ? formatMessage({ id: icon.title }) : undefined,
-    };
-  }
-
-  translatePermissionSets = (perm) => {
-    const { formatMessage } = this.context.intl;
-
-    return {
-      ...perm,
-      displayName: perm.displayName ? formatMessage({ id: perm.displayName }) : undefined,
-      description: perm.description ? formatMessage({ id: perm.description }) : undefined,
     };
   }
 

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-// import { modules as uiModules } from 'stripes-config'; // eslint-disable-line
 import { FormattedMessage } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { withModules } from '@folio/stripes-core/src/components/Modules';

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -1,9 +1,10 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { modules as uiModules } from 'stripes-config'; // eslint-disable-line
+// import { modules as uiModules } from 'stripes-config'; // eslint-disable-line
 import { FormattedMessage } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import { withModules } from '@folio/stripes-core/src/components/Modules';
 /* eslint-disable import/extensions */
 import stripesConnect from '@folio/stripes-connect/package.json';
 import stripesComponents from '@folio/stripes-components/package.json';
@@ -143,7 +144,7 @@ const About = (props) => {
             itemFormatter={item => (<li key={item.key}>{item.value}</li>)}
           />
           <br />
-          {Object.keys(uiModules).map(key => listModules(key, uiModules[key]))}
+          {Object.keys(props.modules).map(key => listModules(key, props.modules[key]))}
         </div>
         <div className={css.versionsColumn}>
           <Headline size="large">
@@ -187,7 +188,7 @@ const About = (props) => {
           </Headline>
           {renderDependencies(Object.assign({}, stripesCore.stripes || {}, { module: 'stripes-core' }), interfaces)}
           <br />
-          {Object.keys(uiModules).map(key => listModules(key, uiModules[key], interfaces))}
+          {Object.keys(props.modules).map(key => listModules(key, props.modules[key], interfaces))}
           <Headline size="small">
             <FormattedMessage id="stripes-core.about.legendKey" />
           </Headline>
@@ -211,6 +212,7 @@ const About = (props) => {
 };
 
 About.propTypes = {
+  modules: PropTypes.object,
   stripes: PropTypes.shape({
     discovery: PropTypes.shape({
       modules: PropTypes.object,
@@ -223,4 +225,4 @@ About.propTypes = {
   }).isRequired,
 };
 
-export default About;
+export default withModules(About);

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { withModules } from '@folio/stripes-core/src/components/Modules';
 /* eslint-disable import/extensions */
 import stripesConnect from '@folio/stripes-connect/package.json';
 import stripesComponents from '@folio/stripes-components/package.json';
@@ -15,6 +14,7 @@ import Headline from '@folio/stripes-components/lib/Headline';
 import List from '@folio/stripes-components/lib/List';
 import { isVersionCompatible } from '../../discoverServices';
 import AboutEnabledModules from './AboutEnabledModules';
+import { withModules } from '../Modules';
 
 import stripesCore from '../../../package.json'; // eslint-disable-line
 import css from './About.css';

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import AppIcon from '@folio/stripes-components/lib/AppIcon';
 import Badge from '@folio/stripes-components/lib/Badge';
 import Headline from '@folio/stripes-components/lib/Headline';
+import { withStripes } from '../../../StripesContext';
 import css from './CurrentApp.css';
 
 const propTypes = {
@@ -22,14 +23,24 @@ const propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
+  stripes: PropTypes.shape({
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func,
+    })
+  })
 };
 
 const defaultProps = {
   currentApp: { displayName: 'FOLIO', description: 'FOLIO platform' },
 };
 
-const CurrentApp = ({ currentApp, iconData, id, badge }) => {
-  const { displayName, description, module } = currentApp;
+const CurrentApp = ({ currentApp, iconData, id, badge, stripes }) => {
+  const { description, module } = currentApp;
+  const displayName = stripes.intl.formatMessage({
+    id: currentApp.displayName,
+    defaultMessage: currentApp.displayName,
+  });
+
   const iconKey = module && module.replace(/^@[a-z0-9_]+\//, '');
 
   return (
@@ -44,4 +55,4 @@ const CurrentApp = ({ currentApp, iconData, id, badge }) => {
 CurrentApp.propTypes = propTypes;
 CurrentApp.defaultProps = defaultProps;
 
-export default CurrentApp;
+export default withStripes(CurrentApp);

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -36,7 +36,6 @@ const defaultProps = {
 
 const CurrentApp = ({ currentApp, iconData, id, badge, stripes }) => {
   const { description, module } = currentApp;
-  const displayName = stripes.intl.formatMessage({ id: currentApp.displayName });
 
   const iconKey = module && module.replace(/^@[a-z0-9_]+\//, '');
 
@@ -44,7 +43,7 @@ const CurrentApp = ({ currentApp, iconData, id, badge, stripes }) => {
     <div id={id} title={description} className={css.currentApp}>
       {badge && (<Badge color="red" className={css.badge}>{badge}</Badge>)}
       <AppIcon icon={iconData} app={iconKey} className={css.icon} />
-      <Headline tag="h1" size="small" margin="none">{displayName}</Headline>
+      <Headline tag="h1" size="small" margin="none">{currentApp.displayName}</Headline>
     </div>
   );
 };

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -29,15 +29,14 @@ const defaultProps = {
 };
 
 const CurrentApp = ({ currentApp, iconData, id, badge }) => {
-  const { description, module } = currentApp;
-
+  const { displayName, description, module } = currentApp;
   const iconKey = module && module.replace(/^@[a-z0-9_]+\//, '');
 
   return (
     <div id={id} title={description} className={css.currentApp}>
       {badge && (<Badge color="red" className={css.badge}>{badge}</Badge>)}
       <AppIcon icon={iconData} app={iconKey} className={css.icon} />
-      <Headline tag="h1" size="small" margin="none">{currentApp.displayName}</Headline>
+      <Headline tag="h1" size="small" margin="none">{displayName}</Headline>
     </div>
   );
 };

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import AppIcon from '@folio/stripes-components/lib/AppIcon';
 import Badge from '@folio/stripes-components/lib/Badge';
 import Headline from '@folio/stripes-components/lib/Headline';
-import { withStripes } from '../../../StripesContext';
 import css from './CurrentApp.css';
 
 const propTypes = {
@@ -23,18 +22,13 @@ const propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
-  stripes: PropTypes.shape({
-    intl: PropTypes.shape({
-      formatMessage: PropTypes.func,
-    })
-  })
 };
 
 const defaultProps = {
   currentApp: { displayName: 'FOLIO', description: 'FOLIO platform' },
 };
 
-const CurrentApp = ({ currentApp, iconData, id, badge, stripes }) => {
+const CurrentApp = ({ currentApp, iconData, id, badge }) => {
   const { description, module } = currentApp;
 
   const iconKey = module && module.replace(/^@[a-z0-9_]+\//, '');
@@ -51,4 +45,4 @@ const CurrentApp = ({ currentApp, iconData, id, badge, stripes }) => {
 CurrentApp.propTypes = propTypes;
 CurrentApp.defaultProps = defaultProps;
 
-export default withStripes(CurrentApp);
+export default CurrentApp;

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -36,10 +36,7 @@ const defaultProps = {
 
 const CurrentApp = ({ currentApp, iconData, id, badge, stripes }) => {
   const { description, module } = currentApp;
-  const displayName = stripes.intl.formatMessage({
-    id: currentApp.displayName,
-    defaultMessage: currentApp.displayName,
-  });
+  const displayName = stripes.intl.formatMessage({ id: currentApp.displayName });
 
   const iconKey = module && module.replace(/^@[a-z0-9_]+\//, '');
 

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -126,7 +126,13 @@ class MainNav extends Component {
   render() {
     const { stripes, location: { pathname } } = this.props;
     const formatMsg = stripes.intl.formatMessage;
-    const selectedApp = modules.app.find(entry => pathname.startsWith(entry.route));
+
+    const apps = modules.app.map(m => ({
+      ...m,
+      displayName: formatMsg({ id: m.displayName }),
+    }));
+
+    const selectedApp = apps.find(entry => pathname.startsWith(entry.route));
 
     // Temporary until settings becomes an app
     const settingsIconData = {
@@ -134,10 +140,9 @@ class MainNav extends Component {
       alt: 'Tenant Settings',
       title: formatMsg({ id: 'stripes-core.settings' }),
     };
-    const menuLinks = modules.app.map((entry) => {
+    const menuLinks = apps.map((entry) => {
       const name = entry.module.replace(/^@[a-z0-9_]+\//, '');
       const perm = `module.${name}.enabled`;
-      const displayName = formatMsg({ id: entry.displayName });
 
       if (!stripes.hasPerm(perm)) {
         return null;
@@ -149,11 +154,11 @@ class MainNav extends Component {
 
       return (
         <NavButton
-          label={displayName}
+          label={entry.displayName}
           id={navId}
           selected={isActive}
           href={href}
-          title={displayName}
+          title={entry.displayName}
           key={entry.route}
           iconKey={name}
         />);

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -137,10 +137,7 @@ class MainNav extends Component {
     const menuLinks = modules.app.map((entry) => {
       const name = entry.module.replace(/^@[a-z0-9_]+\//, '');
       const perm = `module.${name}.enabled`;
-      const displayName = formatMsg({
-        id: entry.displayName,
-        defaultMessage: entry.displayName,
-      });
+      const displayName = formatMsg({ id: entry.displayName });
 
       if (!stripes.hasPerm(perm)) {
         return null;

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -7,9 +7,6 @@ import { Dropdown } from '@folio/stripes-components/lib/Dropdown'; // eslint-dis
 import { withRouter } from 'react-router';
 import localforage from 'localforage';
 
-// import { modules } from 'stripes-config'; // eslint-disable-line
-// import { apps } from '../../modules';
-
 import { withModules } from '../Modules';
 import { clearOkapiToken, clearCurrentUser } from '../../okapiActions';
 import { resetStore } from '../../mainActions';
@@ -24,10 +21,6 @@ import CurrentApp from './CurrentApp';
 import MyProfile from './MyProfile';
 import NotificationsDropdown from './Notifications/NotificationsDropdown';
 import settingsIcon from './settings.svg';
-
-// if (!Array.isArray(apps()) || apps().length < 1) {
-//   throw new Error('At least one module of type "app" must be enabled.');
-// }
 
 class MainNav extends Component {
   static propTypes = {

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -137,6 +137,10 @@ class MainNav extends Component {
     const menuLinks = modules.app.map((entry) => {
       const name = entry.module.replace(/^@[a-z0-9_]+\//, '');
       const perm = `module.${name}.enabled`;
+      const displayName = formatMsg({
+        id: entry.displayName,
+        defaultMessage: entry.displayName,
+      });
 
       if (!stripes.hasPerm(perm)) {
         return null;
@@ -148,11 +152,11 @@ class MainNav extends Component {
 
       return (
         <NavButton
-          label={entry.displayName}
+          label={displayName}
           id={navId}
           selected={isActive}
           href={href}
-          title={entry.displayName}
+          title={displayName}
           key={entry.route}
           iconKey={name}
         />);

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -7,8 +7,10 @@ import { Dropdown } from '@folio/stripes-components/lib/Dropdown'; // eslint-dis
 import { withRouter } from 'react-router';
 import localforage from 'localforage';
 
-import { modules } from 'stripes-config'; // eslint-disable-line
+// import { modules } from 'stripes-config'; // eslint-disable-line
+// import { apps } from '../../modules';
 
+import { withModules } from '../Modules';
 import { clearOkapiToken, clearCurrentUser } from '../../okapiActions';
 import { resetStore } from '../../mainActions';
 import { updateQueryResource, updateLocation } from '../../locationService';
@@ -23,9 +25,9 @@ import MyProfile from './MyProfile';
 import NotificationsDropdown from './Notifications/NotificationsDropdown';
 import settingsIcon from './settings.svg';
 
-if (!Array.isArray(modules.app) || modules.app.length < 1) {
-  throw new Error('At least one module of type "app" must be enabled.');
-}
+// if (!Array.isArray(apps()) || apps().length < 1) {
+//   throw new Error('At least one module of type "app" must be enabled.');
+// }
 
 class MainNav extends Component {
   static propTypes = {
@@ -47,6 +49,9 @@ class MainNav extends Component {
     location: PropTypes.shape({
       pathname: PropTypes.string,
     }).isRequired,
+    modules: PropTypes.shape({
+      app: PropTypes.array,
+    })
   };
 
   static contextTypes = {
@@ -68,7 +73,7 @@ class MainNav extends Component {
     this.lastVisited = {};
     this.queryValues = null;
 
-    this.moduleList = modules.app.concat({
+    this.moduleList = props.modules.app.concat({
       route: '/settings',
       module: '@folio/x_settings',
     });
@@ -124,15 +129,8 @@ class MainNav extends Component {
   }
 
   render() {
-    const { stripes, location: { pathname } } = this.props;
+    const { stripes, location: { pathname }, modules } = this.props;
     const formatMsg = stripes.intl.formatMessage;
-
-    const apps = modules.app.map(m => ({
-      ...m,
-      displayName: formatMsg({ id: m.displayName }),
-    }));
-
-    const selectedApp = apps.find(entry => pathname.startsWith(entry.route));
 
     // Temporary until settings becomes an app
     const settingsIconData = {
@@ -140,7 +138,10 @@ class MainNav extends Component {
       alt: 'Tenant Settings',
       title: formatMsg({ id: 'stripes-core.settings' }),
     };
-    const menuLinks = apps.map((entry) => {
+
+    // const stripesApps = modules.app;
+    const selectedApp = modules.app.find(entry => pathname.startsWith(entry.route));
+    const menuLinks = modules.app.map((entry) => {
       const name = entry.module.replace(/^@[a-z0-9_]+\//, '');
       const perm = `module.${name}.enabled`;
 
@@ -239,4 +240,4 @@ class MainNav extends Component {
   }
 }
 
-export default withRouter(MainNav);
+export default withRouter(withModules(MainNav));

--- a/src/components/ModuleTranslator/ModuleTranslator.js
+++ b/src/components/ModuleTranslator/ModuleTranslator.js
@@ -31,7 +31,6 @@ class ModuleTranslator extends React.Component {
 
     return {
       ...module,
-      description: module.description ? formatMessage({ id: module.description }) : undefined,
       displayName: module.displayName ? formatMessage({ id: module.displayName }) : undefined,
     };
   }

--- a/src/components/ModuleTranslator/ModuleTranslator.js
+++ b/src/components/ModuleTranslator/ModuleTranslator.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
+
+import ModulesContext, { originalModules } from '../../ModulesContext';
+
+class ModuleTranslator extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    intl: intlShape,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      modules: this.translateModules(),
+    };
+  }
+
+  translateModules = () => {
+    return {
+      app: originalModules.app.map(this.translateModule),
+      plugin: originalModules.plugin.map(this.translateModule),
+      settings: originalModules.settings.map(this.translateModule),
+    };
+  }
+
+  translateModule = (module) => {
+    const { formatMessage } = this.props.intl;
+
+    return {
+      ...module,
+      description: module.description ? formatMessage({ id: module.description }) : undefined,
+      displayName: module.displayName ? formatMessage({ id: module.displayName }) : undefined,
+    };
+  }
+
+  render() {
+    return (
+      <ModulesContext.Provider value={this.state.modules}>
+        { this.props.children }
+      </ModulesContext.Provider>
+    );
+  }
+}
+
+export default injectIntl(ModuleTranslator);

--- a/src/components/ModuleTranslator/index.js
+++ b/src/components/ModuleTranslator/index.js
@@ -1,0 +1,1 @@
+export { default } from './ModuleTranslator';

--- a/src/components/Modules/index.js
+++ b/src/components/Modules/index.js
@@ -1,0 +1,7 @@
+import withModule from './withModule';
+import withModules from './withModules';
+
+export {
+  withModule,
+  withModules,
+};

--- a/src/components/Modules/withModule.js
+++ b/src/components/Modules/withModule.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import ModulesContext from './../../ModulesContext';
+
+const getDisplayName = (WrappedComponent) => {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+};
+
+const findModuleInArray = (array, moduleName) => {
+  return array.find(m => m.name === moduleName || m.name === `@folio/${moduleName}`);
+};
+
+const findModule = (modules, moduleName) => {
+  return (
+    findModuleInArray(modules.app, moduleName) ||
+    findModuleInArray(modules.plugin, moduleName) ||
+    findModuleInArray(modules.settings, moduleName)
+  );
+};
+
+export default function withModule(moduleName) {
+  return (WrappedComponent) => {
+    class WithModule extends React.Component {
+      render() {
+        return (
+          <ModulesContext.Consumer>
+            {modules => <WrappedComponent {...this.props} module={findModule(modules, moduleName)} /> }
+          </ModulesContext.Consumer>
+        );
+      }
+    }
+    WithModule.displayName = `WithModule(${getDisplayName(WrappedComponent)})`;
+    return WithModule;
+  };
+}
+

--- a/src/components/Modules/withModule.js
+++ b/src/components/Modules/withModule.js
@@ -6,7 +6,7 @@ const getDisplayName = (WrappedComponent) => {
 };
 
 const findModuleInArray = (array, moduleName) => {
-  return array.find(m => m.name === moduleName || m.name === `@folio/${moduleName}`);
+  return array.find(m => m.module === moduleName || m.module === `@folio/${moduleName}`);
 };
 
 const findModule = (modules, moduleName) => {
@@ -21,9 +21,14 @@ export default function withModule(moduleName) {
   return (WrappedComponent) => {
     class WithModule extends React.Component {
       render() {
+        let name = moduleName;
+        if (typeof moduleName === 'function') {
+          name = moduleName(this.props);
+        }
+
         return (
           <ModulesContext.Consumer>
-            {modules => <WrappedComponent {...this.props} module={findModule(modules, moduleName)} /> }
+            {modules => <WrappedComponent {...this.props} module={findModule(modules, name)} /> }
           </ModulesContext.Consumer>
         );
       }

--- a/src/components/Modules/withModules.js
+++ b/src/components/Modules/withModules.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import ModulesContext from './../../ModulesContext';
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+export default function withModules(WrappedComponent) {
+  class WithModules extends React.Component {
+    render() {
+      return (
+        <ModulesContext.Consumer>
+          {modules => <WrappedComponent {...this.props} modules={modules} /> }
+        </ModulesContext.Consumer>
+      );
+    }
+  }
+  WithModules.displayName = `WithModules(${getDisplayName(WrappedComponent)})`;
+  return WithModules;
+}

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -20,7 +20,9 @@ import SystemSkeleton from '../SystemSkeleton';
 
 import './Root.css';
 
-import { modules, metadata } from 'stripes-config'; // eslint-disable-line
+import { metadata } from 'stripes-config'; // eslint-disable-line
+import { withModules } from '../Modules';
+
 if (!metadata) {
   // eslint-disable-next-line no-console
   console.error('No metadata harvested from package files, so you will not get app icons. Probably the stripes-core in your Stripes CLI is too old. Try `yarn global upgrade @folio/stripes-cli`');
@@ -33,7 +35,7 @@ class Root extends Component {
     this.epics = {};
     this.withOkapi = this.props.okapi.withoutOkapi !== true;
 
-    const appModule = modules.app.find(m => window.location.pathname.startsWith(m.route) && m.queryResource);
+    const appModule = this.props.modules.app.find(m => window.location.pathname.startsWith(m.route) && m.queryResource);
     this.queryResourceStateKey = (appModule) ? getQueryResourceKey(appModule) : null;
   }
 
@@ -152,6 +154,9 @@ Root.propTypes = {
   locale: PropTypes.string,
   timezone: PropTypes.string,
   translations: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  modules: PropTypes.shape({
+    app: PropTypes.array,
+  }),
   plugins: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   bindings: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   config: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -204,4 +209,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(Root);
+export default connect(mapStateToProps)(withModules(Root));

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Switch from 'react-router-dom/Switch';
 import Route from 'react-router-dom/Route';
 import { connectFor } from '@folio/stripes-connect';
-// import { modules } from 'stripes-config'; // eslint-disable-line
 import { withRouter } from 'react-router';
 import NavList from '@folio/stripes-components/lib/NavList';
 import NavListItem from '@folio/stripes-components/lib/NavListItem';

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -26,10 +26,7 @@ const Settings = (props) => {
   const navLinks = settingsModules.map(
     m => ({
       ...m,
-      displayName: stripes.intl.formatMessage({
-        id: m.displayName,
-        defaultMessage: m.displayName,
-      })
+      displayName: stripes.intl.formatMessage({ id: m.displayName })
     })
   ).sort(
     (x, y) => x.displayName.toLowerCase() > y.displayName.toLowerCase(),

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Switch from 'react-router-dom/Switch';
 import Route from 'react-router-dom/Route';
 import { connectFor } from '@folio/stripes-connect';
-import { modules } from 'stripes-config'; // eslint-disable-line
+// import { modules } from 'stripes-config'; // eslint-disable-line
 import { withRouter } from 'react-router';
 import NavList from '@folio/stripes-components/lib/NavList';
 import NavListItem from '@folio/stripes-components/lib/NavListItem';
@@ -14,32 +14,39 @@ import { FormattedMessage } from 'react-intl';
 
 import About from '../About';
 import AddContext from '../../AddContext';
+import { withModules } from '../Modules';
 import { stripesShape } from '../../Stripes';
 
-const settingsModules = [].concat(
-  (modules.app || []).filter(m => m.hasSettings),
-  (modules.settings || []),
+const getSettingsModules = (modules) => (
+  [].concat(
+    (modules.app || []).filter(m => m.hasSettings),
+    (modules.settings || []),
+  )
 );
+// const settingsModules = [].concat(
+//   (modules.app || []).filter(m => m.hasSettings),
+//   (modules.settings || []),
+// );
 
 const Settings = (props) => {
   const stripes = props.stripes;
-  const navLinks = settingsModules.map(
-    m => ({
-      ...m,
-      displayName: stripes.intl.formatMessage({ id: m.displayName })
-    })
-  ).sort(
-    (x, y) => x.displayName.toLowerCase() > y.displayName.toLowerCase(),
-  ).filter(
-    x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`),
-  ).map(m => (
-    <NavListItem
-      key={m.route}
-      to={`/settings${m.route}`}
-    >
-      {m.displayName}
-    </NavListItem>
-  ));
+  const settingsModules = getSettingsModules(props.modules);
+
+  const navLinks = settingsModules
+    // .map(m => ({
+    //   ...m,
+    //   displayName: stripes.intl.formatMessage({ id: m.displayName })
+    // }))
+    .sort((x, y) => x.displayName.toLowerCase() > y.displayName.toLowerCase())
+    .filter(x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`))
+    .map(m => (
+      <NavListItem
+        key={m.route}
+        to={`/settings${m.route}`}
+      >
+        {m.displayName}
+      </NavListItem>
+    ));
 
   const routes = settingsModules.filter(
     x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`),
@@ -90,6 +97,10 @@ Settings.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }).isRequired,
+  modules: PropTypes.shape({
+    app: PropTypes.array,
+    settings: PropTypes.array,
+  })
 };
 
-export default withRouter(Settings);
+export default withRouter(withModules(Settings));

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -22,20 +22,12 @@ const getSettingsModules = (modules) => (
     (modules.settings || []),
   )
 );
-// const settingsModules = [].concat(
-//   (modules.app || []).filter(m => m.hasSettings),
-//   (modules.settings || []),
-// );
 
 const Settings = (props) => {
   const stripes = props.stripes;
   const settingsModules = getSettingsModules(props.modules);
 
   const navLinks = settingsModules
-    // .map(m => ({
-    //   ...m,
-    //   displayName: stripes.intl.formatMessage({ id: m.displayName })
-    // }))
     .sort((x, y) => x.displayName.toLowerCase() > y.displayName.toLowerCase())
     .filter(x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`))
     .map(m => (

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -23,7 +23,15 @@ const settingsModules = [].concat(
 
 const Settings = (props) => {
   const stripes = props.stripes;
-  const navLinks = settingsModules.sort(
+  const navLinks = settingsModules.map(
+    m => ({
+      ...m,
+      displayName: stripes.intl.formatMessage({
+        id: m.displayName,
+        defaultMessage: m.displayName,
+      })
+    })
+  ).sort(
     (x, y) => x.displayName.toLowerCase() > y.displayName.toLowerCase(),
   ).filter(
     x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`),

--- a/src/components/TitledRoute/TitledRoute.js
+++ b/src/components/TitledRoute/TitledRoute.js
@@ -1,22 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
-import { injectIntl, intlShape } from 'react-intl';
 
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
 
+import { withStripes } from '../../StripesContext';
 import TitleManager from '../TitleManager';
 
 class TitledRoute extends React.Component {
   static propTypes = {
     name: PropTypes.string,
     component: PropTypes.element,
-    intl: intlShape.isRequired,
+    stripes: PropTypes.shape({
+      intl: PropTypes.shape({
+        formatMessage: PropTypes.func,
+      })
+    })
   }
 
   render() {
-    const { name, component, intl, ...rest } = this.props;
-    const formattedName = intl.formatMessage({
+    const { name, component, stripes, ...rest } = this.props;
+    const formattedName = stripes.intl.formatMessage({
       id: `stripes-core.title.${name}`,
       defaultMessage: name,
     });
@@ -35,4 +39,4 @@ class TitledRoute extends React.Component {
   }
 }
 
-export default injectIntl(TitledRoute);
+export default withStripes(TitledRoute);

--- a/src/components/TitledRoute/TitledRoute.js
+++ b/src/components/TitledRoute/TitledRoute.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
+import { injectIntl, intlShape } from 'react-intl';
 
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
 
@@ -8,19 +9,24 @@ import TitleManager from '../TitleManager';
 
 class TitledRoute extends React.Component {
   static propTypes = {
-    displayName: PropTypes.string,
+    name: PropTypes.string,
     component: PropTypes.element,
+    intl: intlShape.isRequired,
   }
 
   render() {
-    const { displayName, component, ...rest } = this.props;
+    const { name, component, intl, ...rest } = this.props;
+    const formattedName = intl.formatMessage({
+      id: `stripes-core.title.${name}`,
+      defaultMessage: name,
+    });
 
     return (
       <Route
         {...rest}
         component={() => (
           <ErrorBoundary>
-            <TitleManager page={displayName} />
+            <TitleManager page={formattedName} />
             {component}
           </ErrorBoundary>
         )}
@@ -29,4 +35,4 @@ class TitledRoute extends React.Component {
   }
 }
 
-export default TitledRoute;
+export default injectIntl(TitledRoute);

--- a/src/gatherActions.js
+++ b/src/gatherActions.js
@@ -1,6 +1,6 @@
 // Gather actionNames from all registered modules for hot-key mapping
 
-import { modules } from 'stripes-config'; // eslint-disable-line
+import { modules } from 'stripes-config';
 import stripesComponents from '@folio/stripes-components/package.json'; // eslint-disable-line
 
 function addKeys(moduleName, register, list) {

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -3,7 +3,7 @@ import 'isomorphic-fetch';
 import localforage from 'localforage';
 import { change } from 'redux-form';
 import { addLocaleData } from 'react-intl';
-import { modules, translations } from 'stripes-config'; // eslint-disable-line
+import { translations } from 'stripes-config'; // eslint-disable-line import/no-unresolved
 
 import {
   setCurrentUser,

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -11,6 +11,8 @@ if (!Array.isArray(modules.app) && modules.length < 0) {
 }
 
 function getModuleRoutes(stripes) {
+  const { intl } = stripes;
+
   return modules.app.map((module) => {
     const name = module.module.replace(/^@folio\//, '');
     const perm = `module.${name}.enabled`;
@@ -20,6 +22,9 @@ function getModuleRoutes(stripes) {
     const Current = connect(module.getModule());
     const moduleStripes = stripes.clone({ connect });
 
+    let displayName = module.displayName;
+    if (module.displayNameKey) displayName = intl.formatMessage({ id: module.displayNameKey });
+
     return (
       <Route
         path={module.route}
@@ -28,7 +33,7 @@ function getModuleRoutes(stripes) {
           <AddContext context={{ stripes: moduleStripes }}>
             <div id={`${name}-module-display`} data-module={module.module} data-version={module.version} >
               <ErrorBoundary>
-                <TitleManager page={module.displayName}>
+                <TitleManager page={displayName}>
                   <Current {...props} connect={connect} stripes={moduleStripes} />
                 </TitleManager>
               </ErrorBoundary>

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -2,49 +2,52 @@ import React from 'react';
 import Route from 'react-router-dom/Route';
 import { connectFor } from '@folio/stripes-connect';
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
-import { modules } from 'stripes-config'; // eslint-disable-line
+// import { modules } from 'stripes-config';
+import ModulesContext from './ModulesContext';
 import { StripesContext } from './StripesContext';
 import AddContext from './AddContext';
 import TitleManager from './components/TitleManager';
 
-if (!Array.isArray(modules.app) && modules.length < 0) {
-  throw new Error('At least one module of type "app" must be enabled.');
-}
-
 function getModuleRoutes(stripes) {
-  const { intl } = stripes;
+  return (
+    <ModulesContext.Consumer>
+      {(modules) => {
+        if (!Array.isArray(modules.app) && modules.length < 1) {
+          throw new Error('At least one module of type "app" must be enabled.');
+        }
 
-  return modules.app.map((module) => {
-    const name = module.module.replace(/^@folio\//, '');
-    const perm = `module.${name}.enabled`;
-    if (!stripes.hasPerm(perm)) return null;
+        return modules.app.map((module) => {
+          const name = module.module.replace(/^@folio\//, '');
+          const perm = `module.${name}.enabled`;
+          if (!stripes.hasPerm(perm)) return null;
 
-    const connect = connectFor(module.module, stripes.epics, stripes.logger);
-    const Current = connect(module.getModule());
-    const moduleStripes = stripes.clone({ connect });
+          const connect = connectFor(module.module, stripes.epics, stripes.logger);
+          const Current = connect(module.getModule());
+          const moduleStripes = stripes.clone({ connect });
 
-    const displayName = intl.formatMessage({ id: module.displayName });
-
-    return (
-      <Route
-        path={module.route}
-        key={module.route}
-        render={props => (
-          <StripesContext.Provider value={moduleStripes}>
-            <AddContext context={{ stripes: moduleStripes }}>
-              <div id={`${name}-module-display`} data-module={module.module} data-version={module.version} >
-                <ErrorBoundary>
-                  <TitleManager page={displayName}>
-                    <Current {...props} connect={connect} stripes={moduleStripes} />
-                  </TitleManager>
-                </ErrorBoundary>
-              </div>
-            </AddContext>
-          </StripesContext.Provider>
-        )}
-      />
-    );
-  }).filter(x => x);
+          return (
+            <Route
+              path={module.route}
+              key={module.route}
+              render={props => (
+                <StripesContext.Provider value={moduleStripes}>
+                  <AddContext context={{ stripes: moduleStripes }}>
+                    <div id={`${name}-module-display`} data-module={module.module} data-version={module.version} >
+                      <ErrorBoundary>
+                        <TitleManager page={module.displayName}>
+                          <Current {...props} connect={connect} stripes={moduleStripes} />
+                        </TitleManager>
+                      </ErrorBoundary>
+                    </div>
+                  </AddContext>
+                </StripesContext.Provider>
+              )}
+            />
+          );
+        }).filter(x => x);
+      }}
+    </ModulesContext.Consumer>
+  );
 }
 
 export default getModuleRoutes;

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -23,10 +23,7 @@ function getModuleRoutes(stripes) {
     const Current = connect(module.getModule());
     const moduleStripes = stripes.clone({ connect });
 
-    const displayName = intl.formatMessage({
-      id: module.displayName,
-      defaultMessage: module.displayName,
-    });
+    const displayName = intl.formatMessage({ id: module.displayName });
 
     return (
       <Route

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -23,7 +23,9 @@ function getModuleRoutes(stripes) {
     const moduleStripes = stripes.clone({ connect });
 
     let displayName = module.displayName;
-    if (module.displayNameKey) displayName = intl.formatMessage({ id: module.displayNameKey });
+    if (module.displayNameTranslationKey) {
+      displayName = intl.formatMessage({ id: module.displayNameTranslationKey });
+    }
 
     return (
       <Route

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -23,7 +23,7 @@ function getModuleRoutes(stripes) {
     const Current = connect(module.getModule());
     const moduleStripes = stripes.clone({ connect });
 
-    module.displayName = intl.formatMessage({
+    const displayName = intl.formatMessage({
       id: module.displayName,
       defaultMessage: module.displayName,
     });
@@ -37,7 +37,7 @@ function getModuleRoutes(stripes) {
             <AddContext context={{ stripes: moduleStripes }}>
               <div id={`${name}-module-display`} data-module={module.module} data-version={module.version} >
                 <ErrorBoundary>
-                  <TitleManager page={module.displayName}>
+                  <TitleManager page={displayName}>
                     <Current {...props} connect={connect} stripes={moduleStripes} />
                   </TitleManager>
                 </ErrorBoundary>

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Route from 'react-router-dom/Route';
 import { connectFor } from '@folio/stripes-connect';
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
-// import { modules } from 'stripes-config';
 import ModulesContext from './ModulesContext';
 import { StripesContext } from './StripesContext';
 import AddContext from './AddContext';

--- a/translations/stripes-core/de.json
+++ b/translations/stripes-core/de.json
@@ -1,4 +1,8 @@
 {
+  "title.home": "Startseite",
+  "title.settings": "Einstellungen",
+  "title.login": "Einloggen",
+
   "front.welcome": "Willkommen, die Zukunft der Bibliotheken ist OFFEN!",
   "front.home": "Startseite",
   "front.about": "Installationsdetails",

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -1,4 +1,11 @@
 {
+  "title.home": "Home",
+  "title.ssoRedirect": "SSO Redirect",
+  "title.settings": "Settings",
+  "title.notFound": "Not Found",
+  "title.ssoLanding": "SSO Landing",
+  "title.login": "Log in",
+
   "front.welcome": "Welcome, the Future Of Libraries Is OPEN!",
   "front.home": "Home",
   "front.about": "Software versions",

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -1,6 +1,10 @@
 // This webpack plugin generates a virtual module containing the stripes configuration
 // To access this configuration simply import 'stripes-config' within your JavaScript:
 //   import { okapi, config, modules } from 'stripes-config';
+//
+// NOTE: If importing module data for UI purposes such as displaying
+// the module name, DO NOT import this module.
+// Instead, use the ModulesContext directly or via the withModules/withModule HOCs.
 
 const _ = require('lodash');
 const VirtualModulesPlugin = require('webpack-virtual-modules');


### PR DESCRIPTION
**Updated**

- ModulesContext.js creates a React Context of modules. The modules are originally pulled from the `stripes-config` virtual module and then translated by `RootWithIntl`. In the future, the actual translation work can get pulled out into another component but I'm tempted to leave it as-is atm because the translation of icons and permission sets may change where/how we want to do it.
- `stripes-core` now provides `withModule` and `withModules` HOCs. The latter provides all the translated modules, while the former takes either a module name or a `mapStateToProps`-y callback (with props as the arg) that returns the module name, and returns just that module.
   - `SearchAndSort` is an example of an app that makes us of that mSTP format.
- Various pages updated to remove their translations now that it's being done centrally.
- `TitledRoute` updated to translate generic Folio routes.