### PR TITLE
StripesContext: Pass along this.props

### DIFF
--- a/src/StripesContext.js
+++ b/src/StripesContext.js
@@ -8,10 +8,10 @@ function getDisplayName(WrappedComponent) {
 
 export function withStripes(WrappedComponent) {
   class WithStripes extends React.Component {
-    render(props) {
+    render() {
       return (
         <StripesContext.Consumer>
-          {stripes => <WrappedComponent {...props} stripes={stripes} /> }
+          {stripes => <WrappedComponent {...this.props} stripes={stripes} /> }
         </StripesContext.Consumer>
       );
     }


### PR DESCRIPTION
`props` is undefined in class `render` methods so using `withStripes` stripes all props from the wrapped component currently. This correctly passes them along.