### PR TITLE
Remove stripes-loader alias

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -20,7 +20,6 @@ module.exports = {
   ],
   resolve: {
     alias: {
-      'stripes-loader': 'stripes-config', // TODO: Remove this alias after UI module references have been updated
       'react': specificReact,
     },
     extensions: ['.js', '.json', '.tsx'],


### PR DESCRIPTION
After merging https://github.com/folio-org/ui-organization/pull/88, the deprecated `ui-okapi-console` is the only `folio-org` repo still using `stripes-loader` instead of `stripes-config`.