### PR TITLE
Add stripes context provider to settings. Part of STCOR-231

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -12,6 +12,7 @@ import Pane from '@folio/stripes-components/lib/Pane';
 import { FormattedMessage } from 'react-intl';
 
 import About from '../About';
+import { StripesContext } from '../../StripesContext';
 import AddContext from '../../AddContext';
 import { withModules } from '../Modules';
 import { stripesShape } from '../../Stripes';
@@ -42,6 +43,7 @@ const Settings = (props) => {
   const routes = settingsModules.filter(
     x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`),
   ).map((m) => {
+
     const connect = connectFor(m.module, stripes.epics, stripes.logger);
     const Current = connect(m.getModule());
     const moduleStripes = stripes.clone({ connect });
@@ -50,9 +52,11 @@ const Settings = (props) => {
       path={`/settings${m.route}`}
       key={m.route}
       render={props2 => (
-        <AddContext context={{ stripes: moduleStripes }}>
-          <Current {...props2} stripes={moduleStripes} showSettings />
-        </AddContext>
+        <StripesContext.Provider value={moduleStripes}>
+          <AddContext context={{ stripes: moduleStripes }}>
+            <Current {...props2} stripes={moduleStripes} showSettings />
+          </AddContext>
+        </StripesContext.Provider>
       )}
     />);
   });


### PR DESCRIPTION
The stripes object received via `StripesContext.Consumer` from `withStripes` HOC in `Settings` was using the original `connect` function defined in `RootWithIntl`. This PR just adds `StripesContext.Provider` so we get the correct `stripes` object down below. 