### PR TITLE
Upgrade to eslint-config-stripes 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ]
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^2.0.0",
+    "@folio/eslint-config-stripes": "^2.0.3",
     "babel-register": "^6.16.3",
     "chai": "^4.0.2",
     "enzyme": "^2.5.0",


### PR DESCRIPTION
Follow-up to https://github.com/folio-org/stripes-core/pull/353: we shouldn't have any more surprise rule changes with `eslint-config-stripes`, thanks to https://github.com/folio-org/eslint-config-stripes/pull/33