### PR TITLE
STCOR-232 Change favicon settings to reduce dev build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix typo in [The Stripes Module Developer's Guide](doc/dev-guide.md). Fixes STCOR-227.
 * Added `ModulesContext` and `withModule` and `withModules` HOCs for module i18n. Fixes STCOR-228.
 * Upgrade to Webpack 4. STCOR-175 and STCOR-217
+* Limit icons generated to reduce dev build time, STCOR-232
 
 ## [2.10.0](https://github.com/folio-org/stripes-core/tree/v2.10.0) (2018-06-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.9.0...v2.10.0)

--- a/test/webpack/stripes-branding-plugin.spec.js
+++ b/test/webpack/stripes-branding-plugin.spec.js
@@ -49,7 +49,7 @@ describe('The stripes-branding-plugin', function () {
     });
 
     it('accepts tenant branding', function () {
-      const sut = new StripesBrandingPlugin(tenantBranding);
+      const sut = new StripesBrandingPlugin({ tenantBranding });
       expect(sut.branding).to.be.an('object').with.property('logo');
       expect(sut.branding).to.deep.include(tenantBranding);
     });
@@ -63,6 +63,37 @@ describe('The stripes-branding-plugin', function () {
 
       expect(FaviconsWebpackPlugin.prototype.apply).to.have.been.calledOnce;
       expect(FaviconsWebpackPlugin.prototype.apply).to.be.calledWith(compilerStub);
+    });
+  });
+
+  describe('_getFaviconOptions method', function () {
+    it('enables all favicons when "buildAllFavicons" is true', function () {
+      const sut = new StripesBrandingPlugin({ buildAllFavicons: true });
+      const options = sut._getFaviconOptions();
+      expect(options).to.be.a('object').with.property('icons').that.includes({
+        android: true,
+        appleIcon: true,
+        appleStartup: true,
+        coast: true,
+        favicons: true,
+        firefox: true,
+        windows: true,
+        yandex: true,
+      });
+    });
+    it('enables only standard favicons when "buildAllFavicons" is false', function () {
+      const sut = new StripesBrandingPlugin({ buildAllFavicons: false });
+      const options = sut._getFaviconOptions();
+      expect(options).to.be.a('object').with.property('icons').that.includes({
+        android: false,
+        appleIcon: false,
+        appleStartup: false,
+        coast: false,
+        favicons: true,
+        firefox: false,
+        windows: false,
+        yandex: false,
+      });
     });
   });
 

--- a/webpack/stripes-branding-plugin.js
+++ b/webpack/stripes-branding-plugin.js
@@ -6,23 +6,58 @@ const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const defaultBranding = require('../default-assets/branding');
 const logger = require('./logger')('stripesBrandingPlugin');
 
+// Minimal favicon settings for favicons-webpack-plugin
+const standardFaviconsOnly = {
+  android: false,
+  appleIcon: false,
+  appleStartup: false,
+  coast: false,
+  favicons: true,
+  firefox: false,
+  windows: false,
+  yandex: false,
+};
+
+// Complete favicon settings for favicons-webpack-plugin
+const allFavicons = {
+  android: true,
+  appleIcon: true,
+  appleStartup: true,
+  coast: true,
+  favicons: true,
+  firefox: true,
+  windows: true,
+  yandex: true,
+};
+
 module.exports = class StripesBrandingPlugin {
-  constructor(tenantBranding) {
+  constructor(options) {
     logger.log('initializing...');
     // TODO: Validate incoming tenantBranding paths
+    const tenantBranding = (options && options.tenantBranding) ? options.tenantBranding : {};
     this.branding = Object.assign({}, defaultBranding, tenantBranding);
+    this.buildAllFavicons = options && options.buildAllFavicons;
   }
 
   apply(compiler) {
     // FaviconsWebpackPlugin will inject the necessary html via HtmlWebpackPlugin
-    const faviconPath = StripesBrandingPlugin._initFavicon(this.branding.favicon.src);
-    new FaviconsWebpackPlugin(faviconPath).apply(compiler);
+    const faviconOptions = this._getFaviconOptions();
+    new FaviconsWebpackPlugin(faviconOptions).apply(compiler);
 
     // Hook into stripesConfigPlugin to supply branding config
     compiler.hooks.stripesConfigPluginBeforeWrite.tap('StripesBrandingPlugin', (config) => {
       config.branding = this.branding;
       logger.log('stripesConfigPluginBeforeWrite', config.branding);
     });
+  }
+
+  _getFaviconOptions() {
+    const faviconOptions = {
+      logo: StripesBrandingPlugin._initFavicon(this.branding.favicon.src),
+      icons: this.buildAllFavicons ? allFavicons : standardFaviconsOnly,
+    };
+    logger.log('favicon options', faviconOptions);
+    return faviconOptions;
   }
 
   // Prep favicon path for use with HtmlWebpackPlugin

--- a/webpack/stripes-webpack-plugin.js
+++ b/webpack/stripes-webpack-plugin.js
@@ -13,9 +13,14 @@ module.exports = class StripesWebpackPlugin {
 
   apply(compiler) {
     logger.log('Creating Stripes plugins...');
+    const isProduction = compiler.options.mode === 'production';
+
     const stripesPlugins = [
       new StripesConfigPlugin(this.stripesConfig),
-      new StripesBrandingPlugin(this.stripesConfig.branding),
+      new StripesBrandingPlugin({
+        tenantBranding: this.stripesConfig.branding,
+        buildAllFavicons: isProduction,
+      }),
       new StripesTranslationsPlugin(this.stripesConfig),
       new StripesDuplicatesPlugin(),
     ];


### PR DESCRIPTION
The favicons-webpack-plugin introduced during the Webpack 4 upgrade has contributed to increased build times due to the large number of icons it generates by default.

With this change, a minimum configuration is passed to favicons-webpack-plugin during non-production builds reducing build time by approximately 10%.   Production builds continue to receive the default settings, which are now explicitly defined.

See STCOR-232 for more details.