### PR TITLE
STRIPES-545 Update react-intl-safe-html version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Upgrade to Webpack 4. STCOR-175 and STCOR-217
 * Limit icons generated to reduce dev build time, STCOR-232
 * New context API, RootContext. Legacy context API should be removed in next major version. Available from v2.10.4; STCOR-208
+* Update react-intl-safe-html version. STRIPES-545
 
 ## [2.10.0](https://github.com/folio-org/stripes-core/tree/v2.10.0) (2018-06-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.9.0...v2.10.0)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "stylelint-config-standard": "^17.0.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^1.0.1",
+    "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-connect": "^3.1.2",
     "@folio/stripes-logger": "^0.0.2",


### PR DESCRIPTION
Update react-intl-safe-html version to make sure the latest patch release is included in platform builds.  Related to STRIPES-545