### PR TITLE
Changed MainNav bg color to HEX instead of RGBA

### DIFF
--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -8,7 +8,7 @@
   border-bottom: 1px solid var(--color-border);
   flex: 0 0 auto;
   padding: 0 6px;
-  background-color: var(--color-fill);
+  background-color: #f7f7f7;
   z-index: 99999;
   position: relative;
 }


### PR DESCRIPTION
The MainNav is on top of all other content but because the BG color had opacity it was looking a bit odd when the backdrop of e.g. a Modal is visible:

<img width="1239" alt="screenshot 2018-08-08 15 43 29" src="https://user-images.githubusercontent.com/640976/43841182-d48e2426-9b22-11e8-9673-714a572a7321.png">

I updated the BG color to it's HEX equivalent to make it look right:

<img width="1237" alt="screenshot 2018-08-08 15 44 23" src="https://user-images.githubusercontent.com/640976/43841204-e46b3294-9b22-11e8-8553-d75d8dc4fba8.png">

**Note:** Currently the color is "hardcoded". We would probably need to change it to a variable instead. This is the only place we use this color.
