### PR TITLE
Fix re-mounting in settings

### DIFF
--- a/src/components/TitledRoute/TitledRoute.js
+++ b/src/components/TitledRoute/TitledRoute.js
@@ -28,7 +28,7 @@ class TitledRoute extends React.Component {
     return (
       <Route
         {...rest}
-        component={() => (
+        render={() => (
           <ErrorBoundary>
             <TitleManager page={formattedName} />
             {component}


### PR DESCRIPTION
@doytch this PR moves the `connect` in `<Settings/>` from render into constructor. Also while chasing multiple re-mounting I noticed that switching from `component` to `render` in `TitledRoute` limits it to a single remount. 