### PR TITLE
Prefer stripes prop if provided in StripesContext

### DIFF
--- a/examples/trivial-okapi/TenantList.js
+++ b/examples/trivial-okapi/TenantList.js
@@ -18,7 +18,7 @@ class TenantList extends Component {
   };
 
   static propTypes = {
-    data: PropTypes.obj.isRequired,
+    data: PropTypes.object.isRequired,
     mutator: PropTypes.func.isRequired,
     pathname: PropTypes.string.isRequired,
   };

--- a/src/StripesContext.js
+++ b/src/StripesContext.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export const StripesContext = React.createContext();
 
@@ -8,6 +9,10 @@ function getDisplayName(WrappedComponent) {
 
 export function withStripes(WrappedComponent) {
   class WithStripes extends React.Component {
+    static propTypes = {
+      stripes: PropTypes.object,
+    }
+
     render() {
       return (
         <StripesContext.Consumer>

--- a/src/StripesContext.js
+++ b/src/StripesContext.js
@@ -11,7 +11,7 @@ export function withStripes(WrappedComponent) {
     render() {
       return (
         <StripesContext.Consumer>
-          {stripes => <WrappedComponent {...this.props} stripes={stripes} /> }
+          {stripes => <WrappedComponent {...this.props} stripes={this.props.stripes || stripes} /> }
         </StripesContext.Consumer>
       );
     }


### PR DESCRIPTION
While writing tests for the `<AppIcon />` component I needed to pass a mock stripes object to the component in order to achieve 100% test coverage.

This was not possible because it got overwritten in the StripesContext HOC and set to `undefined` because of the missing context in the tests/storybook environments.

This PR adds a simple change that allows for passing the stripes-prop manually in cases where the context isn't available.