### PR TITLE
FOLIO-1422 i18n: Index into locale-data module for locales array

### DIFF
--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -33,7 +33,7 @@ function getHeaders(tenant, token) {
 export function loadTranslations(store, locale) {
   const parentLocale = locale.split('-')[0];
   return import(`react-intl/locale-data/${parentLocale}`)
-    .then(intlData => addLocaleData(intlData))
+    .then(intlData => addLocaleData(intlData.default))
     .then(() => fetch(translations[parentLocale]))
     .then((response) => {
       if (response.ok) {

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -33,7 +33,7 @@ function getHeaders(tenant, token) {
 export function loadTranslations(store, locale) {
   const parentLocale = locale.split('-')[0];
   return import(`react-intl/locale-data/${parentLocale}`)
-    .then(intlData => addLocaleData(intlData.default))
+    .then(intlData => addLocaleData(intlData.default || intlData))
     .then(() => fetch(translations[parentLocale]))
     .then((response) => {
       if (response.ok) {


### PR DESCRIPTION
I'll explain this backwards:

- Translation strings weren't being shown for non-English languages. We'd either show the label ID (`ui-users.meta.title`) or the original English string. These are the fallback strings.
- The fallback strings were showing because `react-intl` was giving us an empty `messages` array [at this line](https://github.com/yahoo/react-intl/blob/763f3fcbf87abc1a2a1021f684217f56bf8d4581/src/components/provider.js#L134).
- Scroll up from that line and you'll see it was giving us an empty `messages` array because it didn't have locale data for the currently selected locale.
- So why don't we have all the locales loaded into react-intl when we clearly call `addLocaleData` at loginServices.js:36? `import` returns a `Module` object, not the default export. It's behaving like `require` here rather than the `import` we know and love.
- Why is that? [I'm pretty sure it's this breaking change in Webpack 4](https://medium.com/webpack/webpack-4-import-and-commonjs-d619d626b655) that changes the behaviour of `import()`, based on peeking at `node_modules/react-intl/locale-data/de.js`

Now, my read on this suggests that if react-intl changes their locale-data exports to have `__esModule: true` listed on them, we'd need to revert this change. But, this appears to work for now and makes sense. Just something to keep in mind.