### PR TITLE
STCOM-331 Move Pluggable

### DIFF
--- a/src/Pluggable.js
+++ b/src/Pluggable.js
@@ -26,6 +26,7 @@ const Pluggable = (props) => {
 
   if (!props.children) return null;
   if (props.children.length) {
+    // eslint-disable-next-line no-console
     console.error(`<Pluggable type="${props.type}"> has ${props.children.length} children, can only return one`);
   }
   return props.children;


### PR DESCRIPTION
## Purpose
`Pluggable` doesn't meet the definition of a purely presentational component (https://issues.folio.org/browse/STCOM-298), since it's coupled to `stripes-config`. Its most logical new home is in `stripes-core`.

<img width="571" alt="screen shot 2018-09-04 at 5 07 46 am" src="https://user-images.githubusercontent.com/230597/45025213-8012bb80-b000-11e8-8c95-dc9dc78730c0.png">

https://issues.folio.org/browse/STCOM-331

## Approach
Used `git-subtree` to preserve as much git history for these files as possible from `stripes-components`.

## Next Steps
- [ ] Introduce deprecation warning in `stripes-components`
- [ ] Adjust imports in `folio-org` `ui-*` modules
- [ ] Remove `Pluggable` from `stripes-components` `v4.0.0` branch