### PR TITLE
UIU-551: Added actions/reducers to set the current user's service points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## [CURRENT]
+
+* Added ability to set the current user's service points in the session object. Enables UIU-551.
+
 ## [2.11.0](https://github.com/folio-org/stripes-core/tree/v2.11.0) (2018-09-04)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.10.0...v2.11.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change history for stripes-core
 
-## [CURRENT]
+## 2.12.0 (IN PROGRESS)
 
-* Added ability to set the current user's service points in the session object. Enables UIU-551.
+* Added ability to set the current user's service points in the session object. Available from 2.11.1. Enables UIU-551.
 
 ## [2.11.0](https://github.com/folio-org/stripes-core/tree/v2.11.0) (2018-09-04)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.10.0...v2.11.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",

--- a/src/components/HandlerManager/HandlerManager.js
+++ b/src/components/HandlerManager/HandlerManager.js
@@ -13,6 +13,7 @@ class HandlerManager extends React.Component {
     modules: PropTypes.shape({
       handler: PropTypes.array,
     }),
+    props: PropTypes.object,
   };
 
   constructor(props) {
@@ -22,9 +23,9 @@ class HandlerManager extends React.Component {
   }
 
   render() {
-    const { stripes, data } = this.props;
+    const { stripes, data, props } = this.props;
     return (this.components.map(Component =>
-      (<Component key={Component.name} stripes={stripes} data={data} />)));
+      (<Component key={Component.name} stripes={stripes} data={data} {...props} />)));
   }
 }
 

--- a/src/events.js
+++ b/src/events.js
@@ -2,6 +2,7 @@ const events = {
   LOGIN: 1,
   LOGOUT: 2,
   SELECT_MODULE: 3,
+  CHANGE_SERVICE_POINT: 4,
 };
 
 export default events;

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -20,6 +20,7 @@ import {
   setServerDown,
   setSessionData,
   setCurrentServicePoint,
+  setUserServicePoints,
 } from './okapiActions';
 
 function getHeaders(tenant, token) {
@@ -281,5 +282,13 @@ export function setCurServicePoint(store, servicePoint) {
     sess.user.curServicePoint = servicePoint;
     localforage.setItem('okapiSess', sess);
     store.dispatch(setCurrentServicePoint(servicePoint));
+  });
+}
+
+export function setServicePoints(store, servicePoints) {
+  localforage.getItem('okapiSess').then((sess) => {
+    sess.user.servicePoints = servicePoints;
+    localforage.setItem('okapiSess', sess);
+    store.dispatch(setUserServicePoints(servicePoints));
   });
 }

--- a/src/okapiActions.js
+++ b/src/okapiActions.js
@@ -114,7 +114,15 @@ function setCurrentServicePoint(servicePoint) {
   };
 }
 
-export { setCurrentUser,
+function setUserServicePoints(servicePoints) {
+  return {
+    type: 'SET_USER_SERVICE_POINTS',
+    servicePoints,
+  };
+}
+
+export {
+  setCurrentUser,
   clearCurrentUser,
   setCurrentPerms,
   setLocale,
@@ -130,4 +138,6 @@ export { setCurrentUser,
   setOkapiReady,
   setServerDown,
   setSessionData,
-  setCurrentServicePoint };
+  setCurrentServicePoint,
+  setUserServicePoints
+};

--- a/src/okapiReducer.js
+++ b/src/okapiReducer.js
@@ -38,6 +38,8 @@ export default function okapiReducer(state = {}, action) {
       return Object.assign({}, state, { serverDown: true });
     case 'SET_CURRENT_SERVICE_POINT':
       return { ...state, currentUser: { ...state.currentUser, curServicePoint: action.servicePoint } };
+    case 'SET_USER_SERVICE_POINTS':
+      return { ...state, currentUser: { ...state.currentUser, servicePoints: action.servicePoints } };
     default:
       return state;
   }


### PR DESCRIPTION
This is needed for UIU-551. 

We want to show the `ServicePointsModal` from `ui-servicepoints` whenever a user edits themselves in the Users app. This required a few changes:

- New actions/reducers in Redux.
- Exposing those via `loginServices`
- Passing props to a handler component returned from `HandlerManager`.