### PR TITLE
Refactor handler events to strings. Part of UIU-551.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.12.0 (IN PROGRESS)
 
 * Added ability to set the current user's service points in the session object. Available from 2.11.1. Enables UIU-551.
+* Refactor handler events to strings. Part of UIU-551.
 
 ## [2.11.0](https://github.com/folio-org/stripes-core/tree/v2.11.0) (2018-09-04)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.10.0...v2.11.0)

--- a/src/events.js
+++ b/src/events.js
@@ -1,8 +1,8 @@
 const events = {
-  LOGIN: 1,
-  LOGOUT: 2,
-  SELECT_MODULE: 3,
-  CHANGE_SERVICE_POINT: 4,
+  LOGIN: 'LOGIN',
+  LOGOUT: 'LOGOUT',
+  SELECT_MODULE: 'SELECT_MODULE',
+  CHANGE_SERVICE_POINT: 'CHANGE_SERVICE_POINT',
 };
 
 export default events;


### PR DESCRIPTION
The reason for using strings instead of numbers is because we use strings here:

https://github.com/folio-org/ui-servicepoints/blob/master/package.json#L20
