### PR TITLE
support old and new authtoken interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 2.13.0 (IN PROGRESS) 
+
+* Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
+
 ## [2.12.0](https://github.com/folio-org/stripes-core/tree/v2.12.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.11.0...v2.12.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",
@@ -22,7 +22,7 @@
   "stripes": {
     "okapiInterfaces": {
       "users-bl": "3.0",
-      "authtoken": "1.0",
+      "authtoken": "1.0 2.0",
       "configuration": "2.0"
     },
     "permissionSets": [


### PR DESCRIPTION
mod-login-saml has been updated to require the new authtoken interface,
but mod-login has not. Thus, we need to support both interfaces.

Refs [STCOR-76](https://issues.folio.org/browse/STCOR-76)