### PR TITLE
Extract lastVisited into a separate higher order component. Part of STCOR-254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
 * Expose timeZone through react-intl provider
 * Export classes and functions intended for external use
-* Extract LastVisited to a separate module. Fixes STCOR-254. Available from v2.12.2.
+* Extract `lastVisited` to a separate higher order component. Fixes STCOR-254. Available from v2.12.2.
 
 ## [2.12.0](https://github.com/folio-org/stripes-core/tree/v2.12.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.11.0...v2.12.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
 * Expose timeZone through react-intl provider
 * Export classes and functions intended for external use
-* Close record when `Close without saving` button is used. Fixes STCOR-254. Available from v2.12.2.
+* Extract LastVisited to a separate module. Fixes STCOR-254. Available from v2.12.2.
 
 ## [2.12.0](https://github.com/folio-org/stripes-core/tree/v2.12.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.11.0...v2.12.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
 * Expose timeZone through react-intl provider
 * Export classes and functions intended for external use
-* Close record when `Close without saving` button is used. Fixes STCOM-206. Available from v2.12.2.
+* Close record when `Close without saving` button is used. Fixes STCOR-254. Available from v2.12.2.
 
 ## [2.12.0](https://github.com/folio-org/stripes-core/tree/v2.12.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.11.0...v2.12.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
 * Expose timeZone through react-intl provider
 * Export classes and functions intended for external use
+* Close record when `Close without saving` button is used. Fixes STCOM-206. Available from v2.12.2.
 
 ## [2.12.0](https://github.com/folio-org/stripes-core/tree/v2.12.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.11.0...v2.12.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",

--- a/src/components/LastVisited/LastVisitedContext.js
+++ b/src/components/LastVisited/LastVisitedContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext({});

--- a/src/components/LastVisited/index.js
+++ b/src/components/LastVisited/index.js
@@ -1,0 +1,7 @@
+import LastVisitedContext from './LastVisitedContext';
+import withLastVisited from './withLastVisited';
+
+export {
+  LastVisitedContext,
+  withLastVisited,
+};

--- a/src/components/LastVisited/withLastVisited.js
+++ b/src/components/LastVisited/withLastVisited.js
@@ -42,7 +42,7 @@ function withLastVisited(WrappedComponent) {
     }
 
     getCurrentModule(location) {
-      return this.moduleList.filter(entry => (location.pathname === entry.route ||
+      return this.moduleList.find(entry => (location.pathname === entry.route ||
         location.pathname.startsWith(`${entry.route}/`)));
     }
 

--- a/src/components/LastVisited/withLastVisited.js
+++ b/src/components/LastVisited/withLastVisited.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'redux';
+import { withRouter } from 'react-router';
+
+import { withModules } from '../Modules';
+import LastVisitedContext from './LastVisitedContext';
+
+function withLastVisited(WrappedComponent) {
+  class LastVisited extends React.Component {
+    static propTypes = {
+      history: PropTypes.shape({
+        listen: PropTypes.func.isRequired,
+      }).isRequired,
+      modules: PropTypes.shape({
+        app: PropTypes.array,
+      }),
+    };
+
+    constructor(props) {
+      super();
+
+      const { modules, history } = props;
+
+      this.moduleList = modules.app.concat({
+        route: '/settings',
+        module: '@folio/x_settings',
+      });
+
+      this.goBack = this.goBack.bind(this);
+      this.lastVisited = {};
+      this.previous = {};
+
+      history.listen((location) => {
+        const module = this.getCurrentModule(location);
+        if (!module) return;
+        const name = module.module.replace(/^@folio\//, '');
+        this.previous[name] = this.lastVisited[name];
+        this.lastVisited[name] = `${location.pathname}${location.search}`;
+        this.currentName = name;
+      });
+    }
+
+    getCurrentModule(location) {
+      return this.moduleList.filter(entry => (location.pathname === entry.route ||
+        location.pathname.startsWith(`${entry.route}/`)));
+    }
+
+    goBack() {
+      const name = this.currentName;
+      this.lastVisited[name] = this.previous[name];
+    }
+
+    render() {
+      return (
+        <LastVisitedContext.Provider value={{ lastVisited: this.lastVisited, goBack: this.goBack }}>
+          <WrappedComponent {...this.props} />
+        </LastVisitedContext.Provider>
+      );
+    }
+  }
+
+  return LastVisited;
+}
+
+export default compose(
+  withRouter,
+  withModules,
+  withLastVisited,
+);

--- a/src/components/LastVisited/withLastVisited.js
+++ b/src/components/LastVisited/withLastVisited.js
@@ -27,7 +27,7 @@ function withLastVisited(WrappedComponent) {
         module: '@folio/x_settings',
       });
 
-      this.goBack = this.goBack.bind(this);
+      this.cachePreviousUrl = this.cachePreviousUrl.bind(this);
       this.lastVisited = {};
       this.previous = {};
 
@@ -46,14 +46,19 @@ function withLastVisited(WrappedComponent) {
         location.pathname.startsWith(`${entry.route}/`)));
     }
 
-    goBack() {
+    cachePreviousUrl() {
       const name = this.currentName;
       this.lastVisited[name] = this.previous[name];
     }
 
     render() {
+      const value = {
+        lastVisited: this.lastVisited,
+        cachePreviousUrl: this.cachePreviousUrl
+      };
+
       return (
-        <LastVisitedContext.Provider value={{ lastVisited: this.lastVisited, goBack: this.goBack }}>
+        <LastVisitedContext.Provider value={value}>
           <WrappedComponent {...this.props} />
         </LastVisitedContext.Provider>
       );

--- a/src/components/MainContainer/MainContainer.js
+++ b/src/components/MainContainer/MainContainer.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { withLastVisited } from '../LastVisited';
+
 import css from './MainContainer.css';
 
 const propTypes = {
@@ -15,4 +17,4 @@ function MainContainer(props) {
 
 MainContainer.propTypes = propTypes;
 
-export default MainContainer;
+export default withLastVisited(MainContainer);


### PR DESCRIPTION
@zburke and @MikeTaylor this is another attempt to solve [STCOR-254](https://issues.folio.org/browse/STCOR-254) by extracting `lastVisited` into a separate HOC module and make it available via react context. This would allow us to update the `lastVisited` from stripes-form which is illustrated here:

https://github.com/folio-org/stripes-form/pull/32/files

I'm still not sure about some of the naming conventions. For example the context is exposing `goBack` but we are not really going back when we call it. We are just updating `lastVisited` for the current module to the previous path. 


