### PR TITLE
Start exporting things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
 * Expose timeZone through react-intl provider
+* Export classes and functions intended for external use
 
 ## [2.12.0](https://github.com/folio-org/stripes-core/tree/v2.12.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.11.0...v2.12.0)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+export { RootContext } from './src/components/Root/RootContext';
+export { stripesShape } from './src/Stripes';
+export { withStripes } from './src/StripesContext';
+
+export { default as Pluggable } from './src/Pluggable';
+export { setServicePoints, setCurServicePoint } from './src/loginServices';
+export { default as TitleManager } from './src/components/TitleManager';
+export { default as coreEvents } from './src/events';


### PR DESCRIPTION
I poked around the `folio-org` to see what other repos are importing from `stripes-core`. Those have been added here.

Putting these in an index forces us to think about `stripes-core`'s external API.

Encourages:
```
import { TitleManager } from '@folio/stripes-core';
```

instead of 
```
import TitleManager from '@folio/stripes-core/src/components/TitleManager';
```

Consumers of `stripes-core` APIs shouldn't need to know the directory structure.