### PR TITLE
STCOM-344 Expose timeZone through react-intl provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for stripes-core
 
-## 2.13.0 (IN PROGRESS) 
+## 2.13.0 (IN PROGRESS)
 
 * Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
+* Expose timeZone through react-intl provider
 
 ## [2.12.0](https://github.com/folio-org/stripes-core/tree/v2.12.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.11.0...v2.12.0)

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-apollo": "^2.1.3",
     "react-cookie": "^2.1.4",
     "react-dom": "^16.3.0",
-    "react-intl": "^2.3.0",
+    "react-intl": "^2.5.0",
     "react-overlays": "^0.8.3",
     "react-redux": "^5.0.2",
     "react-router": "^4.0.0",

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -127,7 +127,7 @@ class Root extends Component {
       <ErrorBoundary>
         <RootContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store }}>
           <ApolloProvider client={createApolloClient(okapi)}>
-            <IntlProvider locale={locale} key={locale} messages={translations}>
+            <IntlProvider locale={locale} key={locale} timeZone={timezone} messages={translations}>
               <RootWithIntl stripes={stripes} token={token} disableAuth={disableAuth} history={history} />
             </IntlProvider>
           </ApolloProvider>

--- a/util/dateUtil.js
+++ b/util/dateUtil.js
@@ -1,27 +1,27 @@
 import React from 'react';
-import moment from 'moment-timezone'; // eslint-disable-line import/no-extraneous-dependencies
-import { FormattedDate, FormattedTime } from 'react-intl'; // eslint-disable-line import/no-extraneous-dependencies,
+import moment from 'moment-timezone';
+import { FormattedDate, FormattedTime } from 'react-intl';
 
-export function formatDate(dateStr, timezone) {
+export function formatDate(dateStr, timeZone) {
   if (!dateStr) return dateStr;
-  const dateTime = moment.tz(dateStr, timezone);
-  return (<FormattedDate value={dateTime} timeZone={timezone} />);
+  const dateTime = moment.tz(dateStr, timeZone);
+  return (<FormattedDate value={dateTime} timeZone={timeZone} />);
 }
 
-export function formatTime(dateStr, timezone) {
+export function formatTime(dateStr, timeZone) {
   if (!dateStr) return dateStr;
-  const dateTime = moment.tz(dateStr, timezone);
-  return (<FormattedTime value={dateTime} timeZone={timezone} />);
+  const dateTime = moment.tz(dateStr, timeZone);
+  return (<FormattedTime value={dateTime} timeZone={timeZone} />);
 }
 
-export function formatDateTime(dateStr, timezone) {
+export function formatDateTime(dateStr, timeZone) {
   if (!dateStr) return dateStr;
-  const dateTime = moment.tz(dateStr, timezone);
+  const dateTime = moment.tz(dateStr, timeZone);
   return (
     <span>
-      <FormattedDate value={dateTime} timeZone={timezone} />
+      <FormattedDate value={dateTime} timeZone={timeZone} />
       {' '}
-      <FormattedTime value={dateStr} timeZone={timezone} />
+      <FormattedTime value={dateStr} timeZone={timeZone} />
     </span>
   );
 }


### PR DESCRIPTION
## Purpose
With `react-intl@2.5.0`, the `<IntlProvider>` can now accept a `timeZone` prop.

Part of https://issues.folio.org/browse/STCOM-344

## Approach
- The `stripes-components` `<Datepicker>` and `<Timepicker>` will no longer need to use `withStripes` - instead they can get `timeZone` directly from the `intl` object.
- I updated a few utils to camel case `timeZone`, but left alone the places where it would be a breaking change.
- Accessing `stripes.timezone` still works for modules consuming it that way.

