### PR TITLE
Release v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-core
 
-## 2.13.0 (IN PROGRESS)
+## [2.13.0](https://github.com/folio-org/stripes-core/tree/v2.13.0) (2018-09-18)
+[Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.12.0...v2.13.0)
 
 * Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
 * Expose timeZone through react-intl provider

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "2.12.2",
+  "version": "2.13.0",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",


### PR DESCRIPTION
* Support mod-login-saml's requirement for the new authtoken interface in addition to the old interface. Refs STCOR-76. Available from v2.12.1.
* Expose timeZone through react-intl provider
 * Export classes and functions intended for external use