### PR TITLE
Add HandlerManager to exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,4 +5,5 @@ export { withStripes } from './src/StripesContext';
 export { default as Pluggable } from './src/Pluggable';
 export { setServicePoints, setCurServicePoint } from './src/loginServices';
 export { default as TitleManager } from './src/components/TitleManager';
+export { default as HandlerManager } from './src/components/HandlerManager';
 export { default as coreEvents } from './src/events';


### PR DESCRIPTION
This missing export was found while consuming `stripes-*` modules via `stripes` (the framework) from within `ui-users`.  Related to STRIPES-547 