### PR TITLE
Turn on react-hot-loader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,63 @@ jobs:
       - store_artifacts:
           path: ./artifacts
 
+  test-firefox:
+    docker:
+      - image: circleci/node:10-browsers
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command:
+            yarn test
+            --karma.singleRun
+            --karma.browsers=Firefox
+            --karma.reporters mocha junit
+            --karma.junitReporter.outputDir artifacts/junit/karma
+      - store_test_results:
+          path: ./artifacts/junit
+      - store_artifacts:
+          path: ./artifacts
+
+  test-safari:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command:
+            yarn test
+            --karma.singleRun
+            --karma.browsers=bs_safari_11
+            --karma.reporters mocha junit BrowserStack
+            --karma.junitReporter.outputDir artifacts/junit/karma
+      - store_test_results:
+          path: ./artifacts/junit
+      - store_artifacts:
+          path: ./artifacts
+
+  test-edge:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Run tests
+          command:
+            yarn test
+            --karma.singleRun
+            --karma.browsers=bs_ieEdge_windows
+            --karma.reporters mocha junit BrowserStack
+            --karma.junitReporter.outputDir artifacts/junit/karma
+      - store_test_results:
+          path: ./artifacts/junit
+      - store_artifacts:
+          path: ./artifacts
+
 workflows:
   version: 2
   push:
@@ -105,5 +162,14 @@ workflows:
           requires:
             - checkout-and-install
       - test-chrome:
+          requires:
+            - checkout-and-install
+      - test-firefox:
+          requires:
+            - checkout-and-install
+      - test-safari:
+          requires:
+            - checkout-and-install
+      - test-edge:
           requires:
             - checkout-and-install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 2.14.0 (IN PROGRESS)
+
+* Add `react-hot-loader` to development environment
+
 ## [2.13.0](https://github.com/folio-org/stripes-core/tree/v2.13.0) (2018-09-18)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.12.0...v2.13.0)
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,8 +8,38 @@ module.exports = (config) => {
 
     preprocessors: {
       [testIndex]: ['webpack']
+    },
+
+    browserStack: {
+      project: 'stripes-core'
+    },
+
+    browserDisconnectTimeout: 3e5,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 3e5,
+    captureTimeout: 3e5,
+
+    customLaunchers: {
+      bs_safari_11: {
+        base: 'BrowserStack',
+        os: 'OS X',
+        os_version: 'High Sierra',
+        browser: 'safari',
+        browser_version: '11.1'
+      },
+      bs_ieEdge_windows: {
+        base: 'BrowserStack',
+        browser: 'edge',
+        browser_version: '15.0',
+        os: 'Windows',
+        os_version: '10'
+      }
     }
   };
+
+  // BrowserStack launcher isn't automatically added by Stripes CLI
+  configuration.plugins = config.plugins;
+  configuration.plugins.push('karma-browserstack-launcher');
 
   config.set(configuration);
 };

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-apollo": "^2.1.3",
     "react-cookie": "^2.1.4",
     "react-dom": "^16.3.0",
+    "react-hot-loader": "^4.3.10",
     "react-intl": "^2.5.0",
     "react-overlays": "^0.8.3",
     "react-redux": "^5.0.2",

--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -1,0 +1,7 @@
+import 'babel-polyfill';
+import React from 'react';
+import { render } from 'react-dom';
+
+import StripesCore from './App';
+
+render(<StripesCore />, document.getElementById('root'));

--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -1,7 +1,0 @@
-import 'babel-polyfill';
-import React from 'react';
-import { render } from 'react-dom';
-
-import StripesCore from './App';
-
-render(<StripesCore />, document.getElementById('root'));

--- a/src/HotApp.js
+++ b/src/HotApp.js
@@ -1,0 +1,4 @@
+import { hot } from 'react-hot-loader';
+import App from './App';
+
+export default hot(module)(App);

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -50,7 +50,7 @@ class RootWithIntl extends React.Component {
           <TitleManager>
             <HotKeys keyMap={stripes.bindings} noWrapper>
               <Provider store={stripes.store}>
-                <Router history={history}>
+                <Router history={history} key={Math.random()}>
                   { token || disableAuth ?
                     <MainContainer>
                       <OverlayContainer />

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -111,7 +111,7 @@ class MainNav extends Component {
   renderNavButtons(lastVisited) {
     const { modules, location: { pathname }, stripes } = this.props;
 
-    return modules.app.map((entry) => {
+    return modules.app.map((entry, i) => {
       const name = entry.module.replace(/^@[a-z0-9_]+\//, '');
       const perm = `module.${name}.enabled`;
 
@@ -130,7 +130,7 @@ class MainNav extends Component {
           selected={isActive}
           href={href}
           title={entry.displayName}
-          key={entry.route}
+          key={entry.route || i}
           iconKey={name}
         />);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,4 @@
-import 'babel-polyfill';
-import React from 'react';
-import { render } from 'react-dom';
+import { hot } from 'react-hot-loader';
+import AppContainer from './AppContainer';
 
-import StripesCore from './App';
-
-render(<StripesCore />, document.getElementById('root'));
+export default hot(module)(AppContainer);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
-import { hot } from 'react-hot-loader';
-import AppContainer from './AppContainer';
+import 'babel-polyfill';
+import React from 'react';
+import { render } from 'react-dom';
 
-export default hot(module)(AppContainer);
+import HotApp from './HotApp';
+
+render(<HotApp />, document.getElementById('root'));

--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -33,7 +33,8 @@ module.exports = {
       [require.resolve('babel-preset-react')],
     ],
     plugins: [
-      [require.resolve('babel-plugin-transform-decorators-legacy')]
+      [require.resolve('babel-plugin-transform-decorators-legacy')],
+      [require.resolve('react-hot-loader/babel')]
     ]
   },
 };


### PR DESCRIPTION
With the setup changes from https://github.com/folio-org/stripes-core/pull/430, we can now use [`react-hot-loader`](https://github.com/gaearon/react-hot-loader) when running `yarn start` with `stripes-core`:

![2018-09-20 16 49 30](https://user-images.githubusercontent.com/230597/46105124-de176680-c19a-11e8-998f-8fc8e6d94063.gif)

A three line-change in each UI module will activate their ability to take advantage of hot reloading too (I'll open some PRs to demonstrate after this merge).