### PR TITLE
STCOR-262

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,9 @@
+@Library ('folio_jenkins_shared_libs@run_script') _
 
 buildNPM {
   publishModDescriptor = 'yes'
   runLint = 'yes'
-  runTest = 'yes'
-  runTestOptions = '--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'
-  stripesPlatform = 'none'
+  runScripts = [
+      'test:core':'--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage',
+      'test:webpack':'' ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,6 @@ buildNPM {
   publishModDescriptor = 'yes'
   runLint = 'yes'
   runScripts = [
-      'test:core':'--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage',
-      'test:webpack':'' ]
+   'test:core':'--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage',
+   'test:webpack':'--reporter mocha-junit-reporter --reporter-options mochaFile=./artifacts/runTest/test-results.xml' ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,5 @@ buildNPM {
   runLint = 'yes'
   runScripts = [
    'test:core':'--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage',
-   'test:webpack':'--reporter mocha-junit-reporter --reporter-options mochaFile=./artifacts/runTest/test-results.xml' ]
+   'test:webpack':'--reporter mocha-junit-reporter --reporter-options mochaFile=./artifacts/runTest/webpack-results.xml' ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,3 @@
-@Library ('folio_jenkins_shared_libs@run_script') _
 
 buildNPM {
   publishModDescriptor = 'yes'


### PR DESCRIPTION
Add a 'runScripts' option to the shared NPM build pipeline which can be configured in the Jenkinsfile as a map consisting of NPM script name and script arguments. 