### PR TITLE
Slim down hot reloading server calls

### DIFF
--- a/src/HotApp.js
+++ b/src/HotApp.js
@@ -1,4 +1,0 @@
-import { hot } from 'react-hot-loader';
-import App from './App';
-
-export default hot(module)(App);

--- a/src/components/Root/index.js
+++ b/src/components/Root/index.js
@@ -1,1 +1,4 @@
-export { default } from './Root';
+import { hot } from 'react-hot-loader';
+import Root from './Root';
+
+export default hot(module)(Root);

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,6 @@ import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 
-import HotApp from './HotApp';
+import App from './App';
 
-render(<HotApp />, document.getElementById('root'));
+render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Approach
Moved the `hot()` down the component stack a little.

### Before
These calls would fire on every hot reload:
![screen shot 2018-09-27 at 6 09 50 pm](https://user-images.githubusercontent.com/230597/46179447-e8ac2b80-c280-11e8-9a4f-fcc482ddedc4.png)

### After
![screen shot 2018-09-27 at 6 08 25 pm](https://user-images.githubusercontent.com/230597/46179448-ec3fb280-c280-11e8-9f60-14c2e04b9947.png)

## Next steps
https://issues.folio.org/browse/STCOR-257 will take of the notifications calls. Looks like the tenant modules call might need to be pulled higher up in the component hierarchy.