### PR TITLE
Extend mirage start helper to allow additional options

### DIFF
--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -22,6 +22,7 @@ export default function setupApplication({
   modules = [],
   translations = {},
   stripesConfig,
+  mirageOptions,
   scenarios
 } = {}) {
   beforeEach(async function () {
@@ -33,15 +34,12 @@ export default function setupApplication({
       },
 
       setup: () => {
-        this.server = startMirage(scenarios);
+        this.server = startMirage(scenarios, mirageOptions);
         this.server.logging = false;
 
-        withTranslations(this.server, translations);
         withModules(modules);
-        withConfig({
-          logCategories: '',
-          ...stripesConfig
-        });
+        withTranslations(this.server, translations);
+        withConfig({ logCategories: '', ...stripesConfig });
       },
 
       teardown: () => {

--- a/test/bigtest/network/boot.js
+++ b/test/bigtest/network/boot.js
@@ -1,4 +1,4 @@
-import startMirage from '.';
+import startMirage from './start';
 
 /**
 * Start mirage to handle requests in development and production. Note

--- a/test/bigtest/network/index.js
+++ b/test/bigtest/network/index.js
@@ -1,9 +1,28 @@
-/* global require */
+import { camelize } from '@bigtest/mirage';
 
-let start = () => {}; // eslint-disable-line import/no-mutable-exports
+// auto-import all mirage submodules
+const req = require.context('./', true, /\.js$/);
+const modules = req.keys().reduce((acc, modulePath) => {
+  const moduleParts = modulePath.split('/');
+  const moduleType = moduleParts[1];
+  const moduleName = moduleParts[2];
 
-if (process.env.NODE_ENV !== 'production') {
-  start = require('./start').default; // eslint-disable-line global-require
-}
+  if (moduleName) {
+    const moduleKey = camelize(moduleName.replace('.js', ''));
 
-export default start;
+    return Object.assign(acc, {
+      [moduleType]: {
+        ...(acc[moduleType] || {}),
+        [moduleKey]: req(modulePath).default
+      }
+    });
+  } else if (modulePath === './config.js') {
+    return Object.assign(acc, {
+      baseConfig: req(modulePath).default
+    });
+  } else {
+    return acc;
+  }
+}, {});
+
+export default modules;


### PR DESCRIPTION
## Purpose

This makes it so other modules can utilize the `setupApplication` helper and provide their own mirage configuration that would extend the core mirage configuration.

With this change, modules can just use the `setupApplication` helper directly to setup a full stripes app in testing. If the module needs to setup it's own mirage configuration, it can be provided to the `setupApplication` helper as `mirageOptions`.

```js
import setupStripesCore from '@folio/stripes-core/test/bigtest/helpers/setup-application';
import mirageOptions from '../network';

export default function setupApplication({
  scenarios
} = {}) {
  setupStripesCore({
    mirageOptions,
    scenarios
  });
}
```

## Approach

The new `network/start` merges additional options into the core config options. This is so modules do not have to repeat any core-specific boilerplate such as the login route, or hot-module passthrough.

The `network/index` file has been reutilized to _export all mirage modules_ and the environment conditionals that existed there before are moved right into `network/start`.

This makes it so modules do not have to define their own `network/start` and can utilize the one included in `stripes-core` to boot apps with mirage enabled. They just need to be updated to include the `network/index` boilerplate code.

That boilerplate must exist in each module that defines it's own mirage configuration since it uses webpack's `require.context` to assemble the mirage options specific for that module. Maybe in the future that logic can be automatically included in `stripes-cli` somehow.