### PR TITLE
Use new type stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `react-hot-loader` to development environment
 * Remove notifications, STCOR-257
+* Use new type stack
 
 ## [2.13.0](https://github.com/folio-org/stripes-core/tree/v2.13.0) (2018-09-18)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.12.0...v2.13.0)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
-    "@folio/stripes-components": "^3.2.0",
+    "@folio/stripes-components": "^3.3.0",
     "@folio/stripes-connect": "^3.1.2",
     "@folio/stripes-logger": "^0.0.2",
     "apollo-cache-inmemory": "^1.1.1",

--- a/src/components/Front.css
+++ b/src/components/Front.css
@@ -1,3 +1,5 @@
+@import "@folio/stripes-components/lib/variables.css";
+
 /**
  * Front
  */
@@ -18,6 +20,6 @@ h1.frontTitle {
 
 @media screen and (max-width: 900px) {
   h1.frontTitle {
-    font-size: 26px;
+    font-size: var(--font-size-large);
   }
 }

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -1,3 +1,5 @@
+@import "@folio/stripes-components/lib/variables.css";
+
 /**
  * Current App
  */
@@ -19,7 +21,7 @@
  * Badge
  */
 .badge {
-  font-size: 10px;
+  font-size: var(--font-size-x-small);
   position: absolute;
   top: 0;
   right: -1px;

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -6,6 +6,7 @@
   height: 44px;
   outline: 0;
   color: var(--color-text);
+  font-size: var(--font-size-small);
 
   &::-moz-focus-inner {
     border: 0;
@@ -90,7 +91,7 @@ button.navButton {
  * Badge
  */
 .navButton .badge {
-  font-size: 10px;
+  font-size: var(--font-size-x-small);
   position: absolute;
   top: 0;
   right: -1px;

--- a/src/components/MainNav/NavDropdownMenu/NavDropdownMenu.css
+++ b/src/components/MainNav/NavDropdownMenu/NavDropdownMenu.css
@@ -9,7 +9,6 @@
   float: left;
   padding: 5px 8px;
   margin: 6px 0 0;
-  font-size: 14px;
   text-align: left;
   list-style: none;
   background-color: #fff;


### PR DESCRIPTION
Adopts the type variables introduced in https://github.com/folio-org/stripes-components/pull/627

<img width="948" alt="screen shot 2018-09-28 at 10 13 08 pm" src="https://user-images.githubusercontent.com/230597/46240355-c4794900-c36b-11e8-8462-214cfbefe2a6.png">

### TODO
- [x] merge and release https://github.com/folio-org/stripes-components/pull/627 first
- [x] remove the link to the fork in `package.json`