### PR TITLE
Remove unnecessary typeof check

### DIFF
--- a/src/components/Notification/ToastNotification.js
+++ b/src/components/Notification/ToastNotification.js
@@ -106,18 +106,7 @@ class ToastNotification extends React.Component {
   }
 
   render() {
-    const message = typeof (this.props.message) === 'string' ? (
-      <Layout className="flex full justified centerItems">
-        {this.props.message}
-        <Button
-          ariaLabel="Dismiss this message"
-          buttonStyle="link"
-          onClick={this.handleHide}
-        >
-          <Icon icon="closeX" />
-        </Button>
-      </Layout>
-    ) : (
+    const message = (
       <Layout className="flex full justified centerItems">
         {this.props.message}
         <Button


### PR DESCRIPTION
SonarCloud scan picked this up as a "bug".

The ternary was returning the exact same thing in both conditions.