### PR TITLE
Fix currentUser error in tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ import Root from './components/Root';
 export default class StripesCore extends Component {
   static propTypes = {
     history: PropTypes.object,
-    initiailState: PropTypes.object
+    initialState: PropTypes.object
   };
 
   constructor(props) {

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { okapi as okapiConfig, config } from 'stripes-config';
+import merge from 'lodash/merge';
 
 import connectErrorEpic from './connectErrorEpic';
 import configureEpics from './configureEpics';
@@ -13,7 +14,8 @@ import Root from './components/Root';
 
 export default class StripesCore extends Component {
   static propTypes = {
-    history: PropTypes.object
+    history: PropTypes.object,
+    initiailState: PropTypes.object
   };
 
   constructor(props) {
@@ -22,11 +24,13 @@ export default class StripesCore extends Component {
     const okapi = (typeof okapiConfig === 'object' && Object.keys(okapiConfig).length > 0)
       ? okapiConfig : { withoutOkapi: true };
 
+    const initialState = merge({}, { okapi }, props.initialState);
+
     this.logger = configureLogger(config);
     this.logger.log('core', 'Starting Stripes ...');
 
     this.epics = configureEpics(connectErrorEpic);
-    this.store = configureStore({ okapi }, this.logger, this.epics);
+    this.store = configureStore(initialState, this.logger, this.epics);
     if (!okapi.withoutOkapi) discoverServices(this.store);
 
     this.actionNames = gatherActions();

--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,10 @@ export default class StripesCore extends Component {
   }
 
   render() {
+    // no need to pass along `initialState`
+    // eslint-disable-next-line no-unused-vars
+    const { initialState, ...props } = this.props;
+
     return (
       <Root
         store={this.store}
@@ -45,7 +49,7 @@ export default class StripesCore extends Component {
         config={config}
         actionNames={this.actionNames}
         disableAuth={(config && config.disableAuth) || false}
-        {...this.props}
+        {...props}
       />
     );
   }

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -28,11 +28,33 @@ export default function setupApplication({
   scenarios
 } = {}) {
   beforeEach(async function () {
+    const initialState = {};
+
+    // when auth is disabled, add a fake user to the store
+    if (disableAuth) {
+      initialState.okapi = {
+        token: 'test',
+        currentUser: {
+          id: 'test',
+          username: 'testuser',
+          firstName: 'Test',
+          lastName: 'User',
+          email: 'user@folio.org',
+          addresses: [],
+          servicePoints: []
+        },
+        currentPerms: {
+          'perms.all': true
+        }
+      };
+    }
+
+    // mount the app
     this.app = await setupAppForTesting(App, {
       mountId: 'testing-root',
 
       props: {
-        disableAuth
+        initialState
       },
 
       setup: () => {

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -44,10 +44,7 @@ export default function setupApplication({
           addresses: [],
           servicePoints: []
         },
-        currentPerms: {
-          'perms.all': true,
-          ...permissions
-        }
+        currentPerms: permissions
       };
     }
 

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -23,6 +23,7 @@ export default function setupApplication({
   disableAuth = true,
   modules = [],
   translations = {},
+  permissions = {},
   stripesConfig,
   mirageOptions,
   scenarios
@@ -44,7 +45,8 @@ export default function setupApplication({
           servicePoints: []
         },
         currentPerms: {
-          'perms.all': true
+          'perms.all': true,
+          ...permissions
         }
       };
     }


### PR DESCRIPTION
## Purpose

https://github.com/folio-org/ui-myprofile/pull/31 encountered an error where a component was attempting to access `stripes.user.user.username` when `stripes.user.user` was undefined.

This stripes property is populated via  the `Login` component either automatically or when manually logging in. When using `disableAuth` the `\login` route and `Login` component is never mounted, so the store's `currentUser` always ends up empty.

## Approach

Instead of using `disableAuth`, supply the initial state of the store with fake user data, including a fake token, and `perms.all`.

#### Questions

I assume `perms.all` should be the only permission necessary, but looking at dev and production admin accounts shows a lot more perms. Do I need to include any other permissions?