### PR TITLE
Remove HMR router hack

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -50,7 +50,7 @@ class RootWithIntl extends React.Component {
           <TitleManager>
             <HotKeys keyMap={stripes.bindings} noWrapper>
               <Provider store={stripes.store}>
-                <Router history={history} key={Math.random()}>
+                <Router history={history}>
                   { token || disableAuth ?
                     <MainContainer>
                       <OverlayContainer />


### PR DESCRIPTION
`key={Math.random()}` was preventing this from appearing in the console: `Warning: You cannot change <Router history>`; but that warning does not appear to actually affect any functionality.