### PR TITLE
Export BigTest helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 2.16.0 (IN PROGRESS)
+
+* Export BigTest helpers
+
 ## [2.15.1](https://github.com/folio-org/stripes-core/tree/v2.15.1) (2018-10-03)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.15.0...v2.15.1)
 

--- a/index.js
+++ b/index.js
@@ -7,3 +7,6 @@ export { setServicePoints, setCurServicePoint } from './src/loginServices';
 export { default as TitleManager } from './src/components/TitleManager';
 export { default as HandlerManager } from './src/components/HandlerManager';
 export { default as coreEvents } from './src/events';
+
+export { default as setupStripesCore } from './test/bigtest/helpers/setup-application';
+export { default as startMirage } from './test/bigtest/network/start';


### PR DESCRIPTION
### Purpose
With `@folio/stripes`, modules won't be able to import un-exported classes/functions from `@folio/stripes/core`.

### Questions
- Are these the names we want to export?
- Anything else we might need to export re: BigTesting?