### PR TITLE
Increase login form input font size

### DIFF
--- a/src/components/Login/AuthForm.css
+++ b/src/components/Login/AuthForm.css
@@ -62,21 +62,21 @@
 
 input.input {
   height: 60px;
-  font-size: 18px;
+  font-size: var(--font-size-medium);
   padding: 15px;
 }
 
 button.submitButton {
   height: 60px;
   max-height: 100%;
-  font-size: 22px;
+  font-size: var(--font-size-large);
 }
 
 .formMessage {
   line-height: 125%;
   padding: 10px;
   border-radius: var(--radius);
-  font-size: 18px;
+  font-size: var(--font-size-medium);
 
   &.error {
     color: #fff;
@@ -101,12 +101,12 @@ button.submitButton {
 
   button.submitButton {
     height: 44px;
-    font-size: 16px;
+    font-size: var(--font-size-medium);
   }
 
   input.input {
     height: 44px;
-    font-size: 14px;
+    font-size: var(--font-size-medium);
     padding: 8px;
   }
 


### PR DESCRIPTION
Increasing the input font size to at least 16px removes zoom-in on input focus with touch devices. Uses new `--font-size-medium` and `--font-size-large` variables from `stripes-components`.

### Before
![2018-10-08 07 22 23](https://user-images.githubusercontent.com/230597/46608736-65ce7080-cacb-11e8-832d-a4391f1bd518.gif)

### After
![2018-10-08 07 23 02](https://user-images.githubusercontent.com/230597/46608740-68c96100-cacb-11e8-981f-5f66021743b3.gif)
