### PR TITLE
Slim down skeleton loader

### DIFF
--- a/src/components/SystemSkeleton/SystemSkeleton.js
+++ b/src/components/SystemSkeleton/SystemSkeleton.js
@@ -3,7 +3,6 @@
  */
 
 import React from 'react';
-import classnames from 'classnames';
 import css from './SystemSkeleton.css';
 
 const SystemSkeleton = () => (
@@ -14,14 +13,6 @@ const SystemSkeleton = () => (
         <span className={css.skeletonBar} />
       </section>
       <section className={css.skeletonHeaderEnd}>
-        <span className={classnames(css.skeletonAppIcon, css.hideOnSmallScreens)} />
-        <span className={classnames(css.skeletonAppIcon, css.hideOnSmallScreens)} />
-        <span className={classnames(css.skeletonAppIcon, css.hideOnSmallScreens)} />
-        <span className={classnames(css.skeletonAppIcon, css.hideOnSmallScreens)} />
-        <span className={classnames(css.skeletonAppIcon, css.hideOnSmallScreens)} />
-        <span className={classnames(css.skeletonAppIcon, css.hideOnSmallScreens)} />
-        <span className={classnames(css.skeletonDivider, css.hideOnSmallScreens)} />
-        <span className={css.skeletonCircle} />
         <span className={css.skeletonDivider} />
         <span className={css.skeletonCircle} />
       </section>


### PR DESCRIPTION
With changes to the FOLIO header, the skeleton loader was no longer very accurate to the shape of what was loading in.

I removed some of the icons and dividers.

### Before
![2018-10-08 07 31 38](https://user-images.githubusercontent.com/230597/46609125-8cd97200-cacc-11e8-8961-44ecbd182c4a.gif)

### After
![2018-10-08 07 32 10](https://user-images.githubusercontent.com/230597/46609130-8fd46280-cacc-11e8-9ce4-9ec09abf7f3e.gif)
