### PR TITLE
Update CSS for hidden navigation headline

### DIFF
--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -30,6 +30,14 @@
   }
 }
 
+.navigationHeadline {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  clip-path: polygon(0 0, 0 0, 0 0);
+  overflow: hidden;
+}
+
 @media (--medium-down) {
   .brandingLabel {
     display: none;

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
 import { compose } from 'redux';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
-import Headline from '@folio/stripes-components/lib/Headline';
 import { withRouter } from 'react-router';
 import localforage from 'localforage';
 
@@ -180,9 +179,9 @@ class MainNav extends Component {
                 />
               </NavGroup>
               <nav>
-                <Headline tag="h2" className="sr-only">
+                <h2 className={css.navigationHeadline}>
                   <FormattedMessage id="stripes-core.mainNavigation" />
-                </Headline>
+                </h2>
                 <NavGroup>
                   <NavGroup>
                     <NavDivider md="hide" />


### PR DESCRIPTION
## Problem
On small screens there's white space to the right of the layout:
![2018-10-08 07 39 31](https://user-images.githubusercontent.com/230597/46609515-c9f23400-cacd-11e8-8a57-32d7802cae6d.gif)

Upon investigation, it was an `<h2>` only meant for screen reader consumption:
<img width="362" alt="screen shot 2018-10-08 at 7 40 00 am" src="https://user-images.githubusercontent.com/230597/46609528-d9717d00-cacd-11e8-8028-3ac0fa582552.png">

It still had some layout, so it pushed out the width of the page.

## Approach
I tried a different CSS approach for hiding the "Main Navigation" headline while keeping it in the screen reader context. It also didn't need to use the `stripes-components` `<Headline>`.