### PR TITLE
STCOR-267 Lean on react-intl FormattedTime for datetime construction

### DIFF
--- a/util/dateUtil.js
+++ b/util/dateUtil.js
@@ -18,10 +18,6 @@ export function formatDateTime(dateStr, timeZone) {
   if (!dateStr) return dateStr;
   const dateTime = moment.tz(dateStr, timeZone);
   return (
-    <span>
-      <FormattedDate value={dateTime} timeZone={timeZone} />
-      {' '}
-      <FormattedTime value={dateStr} timeZone={timeZone} />
-    </span>
+    <FormattedTime value={dateTime} timeZone={timeZone} day="numeric" month="numeric" year="numeric" />
   );
 }


### PR DESCRIPTION
Instead of constructing our own datetime string with a whitespace character, rely on `react-intl`'s construction with `<FormattedTime>`.

For US English, it will add a comma as a separator.