### PR TITLE
STCOR-267 Deprecate stripes intl utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.16.0 (IN PROGRESS)
 
 * Turn off autoCapitalize on login form
+* Deprecate stripes intl utilities, STCOR-267
 
 ## [2.15.4](https://github.com/folio-org/stripes-core/tree/v2.15.4) (2018-10-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.15.3...v2.15.4)

--- a/util/dateUtil.js
+++ b/util/dateUtil.js
@@ -3,18 +3,33 @@ import moment from 'moment-timezone';
 import { FormattedDate, FormattedTime } from 'react-intl';
 
 export function formatDate(dateStr, timeZone) {
+  console.warn(
+    '\nWarning: formatDate() is deprecated and will be removed in the\n' +
+         'next major version of @folio/stripes-core.\n\n' +
+         'Use react-intl <FormattedDate> instead: https://github.com/yahoo/react-intl/wiki/Components\n'
+  );
   if (!dateStr) return dateStr;
   const dateTime = moment.tz(dateStr, timeZone);
   return (<FormattedDate value={dateTime} timeZone={timeZone} />);
 }
 
 export function formatTime(dateStr, timeZone) {
+  console.warn(
+    '\nWarning: formatTime() is deprecated and will be removed in the\n' +
+         'next major version of @folio/stripes-core.\n\n' +
+         'Use react-intl <FormattedTime> instead: https://github.com/yahoo/react-intl/wiki/Components\n'
+  );
   if (!dateStr) return dateStr;
   const dateTime = moment.tz(dateStr, timeZone);
   return (<FormattedTime value={dateTime} timeZone={timeZone} />);
 }
 
 export function formatDateTime(dateStr, timeZone) {
+  console.warn(
+    '\nWarning: formatDateTime() is deprecated and will be removed in the\n' +
+         'next major version of @folio/stripes-core.\n\n' +
+         'Use react-intl <FormattedTime> instead, with day/month/year props: https://github.com/yahoo/react-intl/wiki/Components\n'
+  );
   if (!dateStr) return dateStr;
   const dateTime = moment.tz(dateStr, timeZone);
   return (


### PR DESCRIPTION
The `stripes` god object duplicates functionality that can be used directly from `react-intl`. We should lean on the community-supported solution instead of our own tunnel of it.