### PR TITLE
Turn off autoCapitalize on login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 2.16.0 (IN PROGRESS)
+
+* Turn off autoCapitalize on login form
+
 ## [2.15.4](https://github.com/folio-org/stripes-core/tree/v2.15.4) (2018-10-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.15.3...v2.15.4)
 

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -78,6 +78,7 @@ class Login extends Component {
                 validationEnabled={false}
                 hasClearIcon={false}
                 autoComplete="username"
+                autoCapitalize="none"
               />
             </div>
             <div className={authFormStyles.formGroup}>


### PR DESCRIPTION
## Before
When typing in a username on iOS, it would automatically capitalize the first letter:
![2018-10-12 08 23 56](https://user-images.githubusercontent.com/230597/46871943-52d3dd00-cdf8-11e8-8e25-fb6b8a539804.gif)

## After
`autoCapitalize="none"` turned that off.

![2018-10-12 08 23 08](https://user-images.githubusercontent.com/230597/46871957-60896280-cdf8-11e8-8996-f16eb342bdcb.gif)
