### PR TITLE
FOLIO-1570 exclude folio/react-big-calendar

### DIFF
--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -3,6 +3,7 @@ const path = require('path');
 // These modules are already transpiled and should be excluded
 const folioScopeBlacklist = [
   'react-githubish-mentions',
+  'react-big-calendar',
 ].map(segment => path.join('@folio', segment));
 
 // We want to transpile files inside node_modules/@folio or outside


### PR DESCRIPTION
This excludes folio/react-big-calendar from being transpiled during a platform build, like we do with folio/react-githubish-mentions.