### PR TITLE
Fix maximum update depth exceeded. Fixes STRIPES-562. 

### DIFF
--- a/src/locationService.js
+++ b/src/locationService.js
@@ -1,4 +1,4 @@
-import { snakeCase, isEqual, forOwn, isEmpty, unset } from 'lodash';
+import { snakeCase, isEqual, forOwn, isEmpty, unset, mergeWith } from 'lodash';
 import queryString from 'query-string';
 import { replaceQueryResource } from './locationActions';
 
@@ -56,9 +56,11 @@ export function updateLocation(module, curQuery, store, history, location) {
   const cleanStateQuery = removeEmpty(stateQuery);
   const cleanLocationQuery = removeEmpty(locationQuery);
 
-  if (isEqual(cleanStateQuery, cleanLocationQuery)) return curQuery;
+  if (isEqual(cleanStateQuery, cleanLocationQuery)) {
+    return curQuery;
+  }
 
-  const params = removeEmpty(Object.assign({}, locationQuery, stateQuery));
+  const params = mergeWith(locationQuery, stateQuery, (obj, src) => ((!src) ? obj : src));
 
   let url = params._path || location.pathname;
   unset(params, '_path');


### PR DESCRIPTION
This PR is an attempt to fix the "maximum update depth exceeded" when moving from the users settings module back to users module. More details can be found under [STRIPES-562](https://issues.folio.org/browse/STRIPES-562).

It looks like the `params` object was not constructed correctly in some cases for example when:

`locationQuery = { query: 'a', sort: 'Name' }`  
`stateQuery = { query '', sort: 'Name' }` 

the result of the previous implementation would return:

`{ sort: 'Name' }` 

instead of: 

`{ query: 'a', sort: 'Name' }` 

which was causing the infinitive loop.

The entire `locationService` implementation including `queryResource` looks like a hack. Hopefully we can transition to a better implementation at some point but for now I'm hoping this PR should fix STRIPES-562.

@aditya-matukumalli and @zburke would you mind giving it a try? The best way to reproduce it:

1. Navigate to users app and conduct a search, for example "a".
2. Navigate to settings > users
3. Navigate between two or three of the general categories (ex. patron groups > permission sets > profile pictures)
4. Navigate back to users app

Thanks!