### PR TITLE
Fix maximum update depth exceeded. Fixes STRIPES-562

### DIFF
--- a/src/locationActions.js
+++ b/src/locationActions.js
@@ -1,7 +1,7 @@
 function replaceQueryResource(module, payload) {
   return {
     type: '@@stripes-connect/LOCAL_REPLACE',
-    payload: Object.assign({ query: '' }, payload),
+    payload,
     meta: {
       module: module.module,
       resource: 'query',


### PR DESCRIPTION
@zburke this is a second attempt to fix this :). This one is a bit cleaner. I think we originally were defaulting to empty `query` when navigating from the codex search to a specific inventory item. It seems like everything is still working fine without the query present right now. Wonder if you could give  it a try again. 