### PR TITLE
[STCOR-269] Fix dropdown behavior

### DIFF
--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -4,6 +4,10 @@
 
 @import '@folio/stripes-components/lib/variables.css';
 
+:root {
+  --padding-for-header: 66px;
+}
+
 .appList {
   display: flex;
 }
@@ -39,16 +43,19 @@
   z-index: 200;
 }
 
+.navListDropdown > div {
+  padding: 10px 5px;
+}
+
 .dropdownBody {
   width: 100%;
   outline: 0;
 }
 
-ul.dropdownList {
-  padding: 10px 5px;
+.dropdownList {
   margin: 0;
-  max-height: 225px;
   overflow-y: auto;
+  max-height: calc(100vh - var(--padding-for-header));
 }
 
 .dropdownListItem {

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -65,7 +65,7 @@ class AppList extends Component {
       // If there's an active app
       if (selectedApp) {
         this.focusSelectedItem();
-      // If not; focus first item in the list
+        // If not; focus first item in the list
       } else {
         this.focusFirstItemInList();
       }
@@ -131,7 +131,7 @@ class AppList extends Component {
           ref={this.dropdownToggleRef}
           noSelectedBar
         />
-        { open && this.focusTrap(this.focusFirstItemInList) }
+        {open && this.focusTrap(this.focusFirstItemInList)}
       </Fragment>
     );
   }
@@ -171,11 +171,25 @@ class AppList extends Component {
   }
 
   render() {
-    const { renderNavButtons, renderDropdownToggleButton, toggleDropdown } = this;
+    const {
+      renderNavButtons,
+      renderDropdownToggleButton,
+      toggleDropdown,
+      focusTrap,
+      focusDropdownToggleButton,
+      focusFirstItemInList,
+      dropdownListRef,
+      state: { open },
+    } = this;
+
     const { dropdownId, apps, dropdownToggleId } = this.props;
+
     const tether = {
       attachment: 'top right',
       targetAttachment: 'bottom right',
+      constraints: [{
+        to: 'target',
+      }],
     };
 
     // If no apps are installed
@@ -186,20 +200,26 @@ class AppList extends Component {
     return (
       <nav className={css.appList}>
         <ul className={css.navItemsList}>
-          { renderNavButtons() }
+          {renderNavButtons()}
         </ul>
         <div className={css.navListDropdownWrap}>
-          <Dropdown tether={tether} dropdownClass={css.navListDropdown} open={this.state.open} id={dropdownId} onToggle={toggleDropdown}>
-            { renderDropdownToggleButton() }
+          <Dropdown
+            tether={tether}
+            dropdownClass={css.navListDropdown}
+            open={open}
+            id={dropdownId}
+            onToggle={toggleDropdown}
+          >
+            {renderDropdownToggleButton()}
             <DropdownMenu data-role="menu" onToggle={toggleDropdown}>
-              { this.focusTrap(this.focusDropdownToggleButton) }
+              {focusTrap(focusDropdownToggleButton)}
               <AppListDropdown
-                listRef={this.dropdownListRef}
+                listRef={dropdownListRef}
                 apps={apps}
                 dropdownToggleId={dropdownToggleId}
                 toggleDropdown={toggleDropdown}
               />
-              { this.focusTrap(this.focusFirstItemInList) }
+              {focusTrap(focusFirstItemInList)}
             </DropdownMenu>
           </Dropdown>
         </div>


### PR DESCRIPTION
## Purpose
Regarding [STCOR-269](https://issues.folio.org/browse/STCOR-269) the dropdown with possible applications should not have a scroll till its height equals screen's height, the scroll should appear only if the dropdown's height more than screen's.

## Approach
- Remove set max-height, redefine paddings for the dropdown.
- Add constraints to tether props for fixing position of the dropdown.

## Screenshots
![2018-10-24 14 32 01](https://user-images.githubusercontent.com/43647240/47427704-d2b75b00-d799-11e8-881d-af13623eaaf4.gif)
