### PR TITLE
Patch response url in mirage for stripes-connect

### DIFF
--- a/test/bigtest/network/patch-response-url.js
+++ b/test/bigtest/network/patch-response-url.js
@@ -1,0 +1,25 @@
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+import FakeXMLHttpRequest from 'fake-xml-http-request';
+
+/**
+ * Stripes connect relies on the response.url property that is part of
+ * the `fetch` API. The fetch polyfill we use to simulate network
+ * requests keys off of the `responseURL` property of the underlying
+ * XMLHttpRequest. However, there the XHR polyfill used by mirage
+ * under the hood does not set this property, and so as a result the
+ * response.url property is not set.
+ *
+ * This monkey-patches the polyfill until such time as this pull
+ * request to accomplish the same is released and integrated.
+ * https://github.com/pretenderjs/FakeXMLHttpRequest/pull/43
+*/
+
+const original = FakeXMLHttpRequest.prototype.open;
+
+function open(method, url, async, username, password) {
+  const result = original.call(this, method, url, async, username, password);
+  this.responseURL = url;
+  return result;
+}
+
+FakeXMLHttpRequest.prototype.open = open;

--- a/test/bigtest/network/start.js
+++ b/test/bigtest/network/start.js
@@ -10,6 +10,7 @@ if (environment !== 'production') {
   const { default: Mirage, camelize } = require('@bigtest/mirage');
   const { default: coreModules } = require('./index');
   require('./force-fetch-polyfill');
+  require('./patch-response-url');
 
   start = (scenarioNames, options = {}) => {
     const {


### PR DESCRIPTION
## Purpose

`stripes-connect` uses `response.url` to validate requests. Pretender, which is used by Mirage, does not add the `responseURL` property so that the fetch polyfill works correctly.

The previous workaround was to use the `X-Request-URL` header in the response, this patch makes it so that is no longer necessary.

## Approach

Took @cowboyd's work over on `ui-inventory` to patch this property and included it here so all modules can use it until [these changes](https://github.com/pretenderjs/FakeXMLHttpRequest/pull/43) make it back to `bigtest/mirage`.