### PR TITLE
Set textComponent on IntlProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 2.16.0 (IN PROGRESS)
+
+* Set `textComponent` on `<IntlProvider>`
+
 ## [2.15.5](https://github.com/folio-org/stripes-core/tree/v2.15.5) (2018-11-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.15.4...v2.15.5)
 

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { combineReducers } from 'redux';
 import { connect } from 'react-redux';
@@ -128,8 +128,19 @@ class Root extends Component {
       <ErrorBoundary>
         <RootContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store }}>
           <ApolloProvider client={createApolloClient(okapi)}>
-            <IntlProvider locale={locale} key={locale} timeZone={timezone} messages={translations}>
-              <RootWithIntl stripes={stripes} token={token} disableAuth={disableAuth} history={history} />
+            <IntlProvider
+              locale={locale}
+              key={locale}
+              timeZone={timezone}
+              messages={translations}
+              textComponent={Fragment}
+            >
+              <RootWithIntl
+                stripes={stripes}
+                token={token}
+                disableAuth={disableAuth}
+                history={history}
+              />
             </IntlProvider>
           </ApolloProvider>
         </RootContext.Provider>


### PR DESCRIPTION
By setting the `textComponent` prop on the `IntlProvider` to `Fragment`, internationalized strings using `<FormattedMessage>`, etc. will render as `<Fragment>` instead of `<span>`. Should make for much easier DOM to work with (and make passing a `<FormattedMessage />` to an `<option />` possible).