### PR TITLE
ManNav: Fixed bug where multiple apps could be selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.16.0 (IN PROGRESS)
 
 * Set `textComponent` on `<IntlProvider>`
+* Fixed `MainNav` not setting the correct app as `selected`.
 
 ## [2.15.5](https://github.com/folio-org/stripes-core/tree/v2.15.5) (2018-11-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.15.4...v2.15.5)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -119,7 +119,11 @@ class MainNav extends Component {
       }
 
       const id = `clickable-${name}-module`;
-      const active = pathname.startsWith(entry.route);
+
+      const pathRoot = pathname.split('/')[1];
+      const entryRoot = entry.route.split('/')[1];
+      const active = pathRoot === entryRoot;
+
       const href = lastVisited[name] || entry.home || entry.route;
 
       return {


### PR DESCRIPTION
In certain cases, `.startsWith` wasn't accurate enough to determine what app was open. 

### Example

- `ui-erm` is defined with its `route` as `/erm`. 
- `ui-erm-usage` is defined with its route as `/ermusage`
- When `ui-erm-usage` is opened, the code would check that the current pathname (`/ermusage/...`) started with the various app's routes to check which one was now open.
- Both `ui-erm` and `ui-erm-usage` will be marked as `active` when we loop through the modules.

### Fix
- Strictly compare the second token of the `.split('/')` pathname.
- Note that even when we load the root page (e.g., `localhost:3000`), the pathname will be `/`, and `'/'.split('/')` _does_ return an array of size two, so that `[1]` indexing will not fail and doesn't need to be checked. Perhaps, dear reader, you already knew this, but I did not. :) 