### PR TITLE
Fix memory leaks

### DIFF
--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -74,7 +74,7 @@ class MainNav extends Component {
 
   componentDidMount() {
     let curQuery = null;
-    this.store.subscribe(() => {
+    this._unsubscribe = this.store.subscribe(() => {
       const { history, location } = this.props;
       const module = this.curModule;
       if (module && isQueryResourceModule(module, location)) {
@@ -90,6 +90,10 @@ class MainNav extends Component {
     if (this.curModule && !isEqual(location, prevProps.location)) {
       updateQueryResource(location, this.curModule, this.store);
     }
+  }
+
+  componentWillUnmount() {
+    this._unsubscribe();
   }
 
   toggleUserMenu() {

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -1,7 +1,6 @@
 import { beforeEach } from '@bigtest/mocha';
 import { setupAppForTesting, visit, location } from '@bigtest/react';
 import localforage from 'localforage';
-import sinon from 'sinon';
 
 // load these styles for our tests
 import 'typeface-source-sans-pro';
@@ -18,6 +17,8 @@ import {
   withConfig,
   clearConfig
 } from './stripes-config';
+
+const { assign } = Object;
 
 export default function setupApplication({
   disableAuth = true,
@@ -63,20 +64,29 @@ export default function setupApplication({
         withModules(modules);
         withConfig({ logCategories: '', ...stripesConfig });
 
-        sinon.stub(actions, 'setTranslations').callsFake(incoming => {
-          return {
-            type: 'SET_TRANSLATIONS',
-            translations: Object.assign(incoming, translations)
-          };
+        assign(actions, {
+          _setTranslations: null,
+          setTranslations: incoming => {
+            return {
+              type: 'SET_TRANSLATIONS',
+              translations: assign(incoming, translations)
+            };
+          }
         });
       },
 
       teardown: () => {
-        actions.setTranslations.restore();
+        assign(actions, {
+          setTranslations: actions._setTranslations,
+          _setTranslations: null
+        });
+
         clearConfig();
         clearModules();
         localforage.clear();
         this.server.shutdown();
+        this.server = null;
+        this.app = null;
       }
     });
 


### PR DESCRIPTION
## Purpose 

[UIEH-570](https://issues.folio.org/browse/UIEH-570) - eHoldings tests are flakey due to memory issues.

After some investigating, this turned out to be caused by a few different things each retaining some amount of memory.

## Approach

1. The biggest memory leak which contributed the most was due to redux `store` subscribers not being properly cleaned up. This caused a _significant_ amount of memory to leak, as each subscriber held a reference to the component, which holds a reference to the entire react tree it is mounted in. So in turn, each call of this subscriber was leaking the entire stripes application including all submodules.

    The subscriber in `MainNav.js` was the location of the biggest leak. [Over in `stripes-connect` there is a similar leak](https://github.com/folio-org/stripes-connect/pull/66), but it isn't nearly as large as the leak that was happening here.

2. Sinon was being used to stub the translations endpoint so tests can add translations as needed. By default the sinon stub was holding onto references to any arguments it was given, and calling `restore` was not clearing previous references. This was replaced with a simple `assign` as we do not need to actually test anything about the arguments passed to this stub.

3. The testing context in mocha is cloned for each test so that they all receive clean versions of the context. When nesting suites, contexts like `server` and `app` are replaced. However, top-level sibling suites have their own contexts, and as such in eHoldings with many top-level suites, this was causing mocha to retain those contexts when they were no longer needed. These two contexts are now nullified during teardown.

4. The final leak appears to be coming from Mirage / Pretender. I've been tracking this one for a few days now, but I can't yet tell if it is user-error, or something leaking in those core libraries. I'll need to investigate this further to be able to determine where it is and what the fix could be. Since it doesn't appear to be stripes related and it isn't leaking too much memory in my trials, this one remains unfixed.

### Screenshots

The gray bars indicates how much memory is being allocated and the blue is how much is being retained. Blue bars towards the end of the timeline are objects that still hold actual references when the recording was stopped.

**Before any patches:** 

![control](https://user-images.githubusercontent.com/5005153/48095423-4dd93200-e1da-11e8-94b3-c55feb196cd1.png)

**After patching leak 1:**

![redux](https://user-images.githubusercontent.com/5005153/48095643-d526a580-e1da-11e8-89cc-9d0d60a10372.png)

**After patching leaks 2 & 3:**

![sinon](https://user-images.githubusercontent.com/5005153/48095714-0d2de880-e1db-11e8-9d04-85b8f2c1c331.png)

In this final screenshot you can see the last memory leak happening around 15-20 seconds. I was able to isolate this spike to [this test suite](https://github.com/folio-org/ui-eholdings/blob/master/test/bigtest/tests/custom-package-edit-proxy-test.js), but I need to investigate further to determine if it is mirage, or something else causing those mirage models to leak.