### PR TITLE
Keep stripes user up to date. Fixes STRIPES-578

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Set `textComponent` on `<IntlProvider>`
 * Fixed `MainNav` not setting the correct app as `selected`.
+* Keep stripes user up to date after login. Fixes STRIPES-578.
 
 ## [2.15.5](https://github.com/folio-org/stripes-core/tree/v2.15.5) (2018-11-01)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.15.4...v2.15.5)

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -68,6 +68,11 @@ class RootWithIntl extends React.Component {
     this.connectedCreateResetPassword = this.stripes.connect(CreateResetPassword);
   }
 
+  componentDidUpdate() {
+    const { user } = this.props.stripes;
+    this.stripes = this.stripes.clone({ user });
+  }
+
   render() {
     const {
       token,


### PR DESCRIPTION
https://issues.folio.org/browse/STRIPES-578

It looks like based on the work in STCOR-273 (https://github.com/folio-org/stripes-core/commit/fed3d67d888160016aaaea1dcab00d5dd438a316#diff-88ca151ca66140fa7627a68e749b47e6) 

the `stripes` has been moved to the constructor.  Unfortunately `RootWithIntl` is being constructed before the user and permissions are available so the `this.stripes` ends up without them in `render`. 

This PR clones the `user` from current `stripes` object in `componentDidUpdate ` in order to fix it. 

@OleksandrAntonenko1 apologies for stepping on your toes here. We can improve this later but we want to cut a new release of stripes-core today with some other fixes in place.