### PR TITLE
STCOR-277: Remove description from App header dropdown

### DIFF
--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -116,10 +116,6 @@
     display: block;
   }
 
-  .dropdownBody {
-    width: 600px;
-  }
-
   .dropdownToggleLabel {
     display: flex;
   }

--- a/src/components/MainNav/AppList/List.js
+++ b/src/components/MainNav/AppList/List.js
@@ -15,9 +15,12 @@ import css from './AppList.css';
 const List = React.forwardRef(({ apps, onItemClick }, ref) => {
   const renderNavItems = apps.map((app, index) => {
     const isOddRow = !(index % 2);
-    return (
 
-      <li role="none" key={app.id}>
+    return (
+      <li
+        role="none"
+        key={app.id}
+      >
         <NavListItem
           key={index}
           onClick={onItemClick}
@@ -28,17 +31,26 @@ const List = React.forwardRef(({ apps, onItemClick }, ref) => {
           id={`app-list-item-${app.id}`}
           role="menuitem"
         >
-          <AppIcon app={app.name} size="small" icon={app.iconData} />
-          <span className={css.dropdownListItemLabel}>{ app.displayName }</span>
-          { app.description && <span className={css.dropdownListItemDescription}>{ app.description }</span>}
+          <AppIcon
+            app={app.name}
+            size="small"
+            icon={app.iconData}
+          />
+          <span className={css.dropdownListItemLabel}>
+            {app.displayName}
+          </span>
         </NavListItem>
       </li>
     );
   });
 
   return (
-    <ul ref={ref} className={css.dropdownList} role="menu">
-      { renderNavItems }
+    <ul
+      ref={ref}
+      className={css.dropdownList}
+      role="menu"
+    >
+      {renderNavItems}
     </ul>
   );
 });


### PR DESCRIPTION
## Purpose
According to [STCOR-277](https://issues.folio.org/browse/STCOR-277), descriptions in app header dropdown do not provide a vague explanation of the app, therefore they should be removed, taking into account the dropdown still should stay responsive.

## Screenshots
![2018-11-15 15 57 22](https://user-images.githubusercontent.com/43647240/48557360-2f1c1f00-e8ef-11e8-8619-5d3fad4deac7.gif)