### PR TITLE
add missing discovery attribute to stripes

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -69,8 +69,8 @@ class RootWithIntl extends React.Component {
   }
 
   componentDidUpdate() {
-    const { user } = this.props.stripes;
-    this.stripes = this.stripes.clone({ user });
+    const { user, discovery } = this.props.stripes;
+    this.stripes = this.stripes.clone({ user, discovery });
   }
 
   render() {


### PR DESCRIPTION
The refactoring in #480 means the `this.stripes` object may not be fully
populated. This adds `discovery`, but a larger refactoring may be in
order here.

Refs [UIU-712](https://issues.folio.org/browse/UIU-712)