### PR TITLE
keep stripes object up to date after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-core
 
+
+## 2.17.0 (IN PROGRESS)
+
+* Keep all stripes attributes up to date after login. Refs STCOR-273, STRIPES-578, STCOR-283.
+
 ## [2.16.0](https://github.com/folio-org/stripes-core/tree/v2.16.0) (2018-11-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.15.5...v2.16.0)
 

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -51,28 +51,6 @@ class RootWithIntl extends React.Component {
     intl: intlShape.isRequired,
   };
 
-  constructor(props, context) {
-    super(props);
-
-    const { intl } = context;
-    const connect = connectFor(
-      '@folio/core',
-      props.stripes.epics,
-      props.stripes.logger,
-    );
-
-    this.stripes = props.stripes.clone({
-      intl,
-      connect,
-    });
-    this.connectedCreateResetPassword = this.stripes.connect(CreateResetPassword);
-  }
-
-  componentDidUpdate() {
-    const { user, discovery } = this.props.stripes;
-    this.stripes = this.stripes.clone({ user, discovery });
-  }
-
   render() {
     const {
       token,
@@ -80,25 +58,29 @@ class RootWithIntl extends React.Component {
       history,
     } = this.props;
 
+    const intl = this.context.intl;
+    const connect = connectFor('@folio/core', this.props.stripes.epics, this.props.stripes.logger);
+    const stripes = this.props.stripes.clone({ intl, connect });
+
     return (
-      <StripesContext.Provider value={this.stripes}>
+      <StripesContext.Provider value={stripes}>
         <ModuleTranslator>
           <TitleManager>
             <HotKeys
-              keyMap={this.stripes.bindings}
+              keyMap={stripes.bindings}
               noWrapper
             >
-              <Provider store={this.stripes.store}>
+              <Provider store={stripes.store}>
                 <Router history={history}>
                   { token || disableAuth ?
                     <MainContainer>
                       <OverlayContainer />
-                      <MainNav stripes={this.stripes} />
+                      <MainNav stripes={stripes} />
                       <HandlerManager
                         event={events.LOGIN}
-                        stripes={this.stripes}
+                        stripes={stripes}
                       />
-                      { (this.stripes.okapi !== 'object' || this.stripes.discovery.isFinished) && (
+                      { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
                         <ModuleContainer id="content">
                           <Switch>
                             <TitledRoute
@@ -106,20 +88,20 @@ class RootWithIntl extends React.Component {
                               path="/"
                               key="root"
                               exact
-                              component={<Front stripes={this.stripes} />}
+                              component={<Front stripes={stripes} />}
                             />
                             <TitledRoute
                               name="ssoRedirect"
                               path="/sso-landing"
                               key="sso-landing"
-                              component={<SSORedirect stripes={this.stripes} />}
+                              component={<SSORedirect stripes={stripes} />}
                             />
                             <TitledRoute
                               name="settings"
                               path="/settings"
-                              component={<Settings stripes={this.stripes} />}
+                              component={<Settings stripes={stripes} />}
                             />
-                            {getModuleRoutes(this.stripes)}
+                            {getModuleRoutes(stripes)}
                             <TitledRoute
                               name="notFound"
                               component={(
@@ -137,21 +119,21 @@ class RootWithIntl extends React.Component {
                       <TitledRoute
                         name="CreateResetPassword"
                         path="/(Create|Reset)Password/:token"
-                        component={<this.connectedCreateResetPassword stripes={this.stripes} />}
+                        component={<CreateResetPassword stripes={stripes} />}
                       />
                       <TitledRoute
                         name="ssoLanding"
                         exact
                         path="/sso-landing"
-                        component={<CookiesProvider><SSOLanding stripes={this.stripes} /></CookiesProvider>}
+                        component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>}
                         key="sso-landing"
                       />
                       <TitledRoute
                         name="login"
                         component={
                           <Login
-                            autoLogin={this.stripes.config.autoLogin}
-                            stripes={this.stripes}
+                            autoLogin={stripes.config.autoLogin}
+                            stripes={stripes}
                           />
                         }
                       />

--- a/src/components/CreateResetPassword/CreateResetPasswordControlWrapper.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControlWrapper.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import CreateResetPasswordControl from './CreateResetPasswordControl';
+
+class CreateResetPasswordControlWrapper extends Component {
+  static propTypes = {
+    authFailure: PropTypes.arrayOf(PropTypes.object),
+    mutator: PropTypes.shape({
+      changePassword: PropTypes.shape({
+        POST: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
+    stripes: PropTypes.object.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.connectedCreateResetPasswordControl = props.stripes.connect(CreateResetPasswordControl);
+  }
+
+  render() {
+    return <this.connectedCreateResetPasswordControl {...this.props} />;
+  }
+}
+
+export default CreateResetPasswordControlWrapper;

--- a/src/components/CreateResetPassword/index.js
+++ b/src/components/CreateResetPassword/index.js
@@ -1,1 +1,1 @@
-export { default } from './CreateResetPasswordControl';
+export { default } from './CreateResetPasswordControlWrapper';


### PR DESCRIPTION
The work done in support of STCOR-273 refactored how the `stripes`
object available in `render()` was initialized. By moving the
initialization and cloning up to the constructor, it wasn't updated when
user permissions, among other attributes, were added to the object.
Previously, because the object was cloned in `render()`, these
attributes were always available, but relocating the clone operation to
the constructor means these updates never trickled down.

This problem was captured in STRIPES-578 and patched, but there were
lingering issues as noted in STCOR-283. So _this_ refactor restores the
clone operation to `render()`, ensuring that all and any important
attributes, not just those called out in `componentDidUpdate()`, trickle
down to the `stripes` object used there.

It works by moving the `stripes.connect()` operation for
`<CreateResetPassword>` out of `RootWithIntl` and into a wrapper object
which receives the `stripes` object configured here. That allows
`<CreateResetPassword>` to get connected without restructuring
`<RootWithIntl>`.

Refs [STCOR-273](https://issues.folio.org/browse/STCOR-273), [STRIPES-578](https://issues.folio.org/browse/STRIPES-578), [STCOR-283](https://issues.folio.org/browse/STCOR-283)