### PR TITLE
load region-specific translations if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 2.18.0 (IN PROGRESS)
 
 * Sort the settings. Fixes STCOR-286.
+* Load region-specific translations if available. Fixes STCOR-261.
 
 ## [2.17.0](https://github.com/folio-org/stripes-core/tree/v2.17.0) (2018-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.16.0...v2.17.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -34,9 +34,18 @@ function getHeaders(tenant, token) {
 
 export function loadTranslations(store, locale) {
   const parentLocale = locale.split('-')[0];
+
+  // react-intl provides things like pt-BR.
+  // lokalise provides things like pt_BR.
+  // so we have to translate '-' to '_' because the translation libraries
+  // don't know how to talk to each other. sheesh.
+  const region = locale.replace('-', '_');
+
   return import(`react-intl/locale-data/${parentLocale}`)
     .then(intlData => addLocaleData(intlData.default || intlData))
-    .then(() => fetch(translations[parentLocale]))
+    // fetch the region-specific translations, e.g. pt-BR, if available.
+    // fall back to the generic locale, e.g. pt, if not available.
+    .then(() => fetch(translations[region] ? translations[region] : translations[parentLocale]))
     .then((response) => {
       if (response.ok) {
         response.json().then((stripesTranslations) => {


### PR DESCRIPTION
react-intl expects locales to look like `pt-BR`, i.e. a locale, a hyphen,
and a region code. lokalise.com provides translation files with names
like `pt_BR.json`, i.e. a locale, an underscore, and a region code. In
other words, the two systems we use for managing translations DON'T KNOW
HOW TO TALK TO EACH OTHER. For reals.

Regardless, the old code threw away region codes altogether, so it
didn't really matter that they couldn't talk because they weren't even
trying. Now, we translate the dash to an underscore in order to look up
the locale + region and use that if available, and fall back to the
locale-only, which is what we used to do, otherwise.

Fixes [STCOR-261](https://issues.folio.org/browse/STCOR-261)