### PR TITLE
STCOR-260: Disable css variable preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Sort the settings. Fixes STCOR-286.
 * Load region-specific translations if available. Fixes STCOR-261.
+* Updated webpack config to disable CSS variable preservation. Fixes STCOR-260.
 
 ## [2.17.0](https://github.com/folio-org/stripes-core/tree/v2.17.0) (2018-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.16.0...v2.17.0)

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -49,7 +49,9 @@ devConfig.module.rules.push({
         plugins: () => [
           postCssImport(),
           autoprefixer(),
-          postCssCustomProperties(),
+          postCssCustomProperties({
+            preserve: false
+          }),
           postCssCalc(),
           postCssNesting(),
           postCssCustomMedia(),

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -45,7 +45,9 @@ prodConfig.module.rules.push({
         plugins: () => [
           postCssImport(),
           autoprefixer(),
-          postCssCustomProperties(),
+          postCssCustomProperties({
+            preserve: false
+          }),
           postCssCalc(),
           postCssNesting(),
           postCssCustomMedia(),


### PR DESCRIPTION
**Issue:** https://issues.folio.org/browse/STCOR-260

CSS variables were preserved in the CSS output which was causing issues with CSS variables that were using color-functions since these aren't supported in browsers natively and it would overwrite with invalid values.

Setting `preserve: false` in the config of PostCSS plugin `postcss-custom-properties` we only get the transpiled output.

## Before
![image](https://user-images.githubusercontent.com/640976/49460004-a22efc00-f7f0-11e8-8a96-3855b8b45427.png)

## After
![image](https://user-images.githubusercontent.com/640976/49459902-698f2280-f7f0-11e8-99a5-52ace11019bb.png)

## Note
This would need to be turned on again if/when we, later on, want to introduce theming using CSS variables. 

For this to work, however, we would either need to stop using color functions in our CSS _or_ update the webpack setup to make sure that the values of CSS variables that are using the color functions are transpiled.

