### PR TITLE
STCOR-289: Move Forgot username and Forgot password links below the L…

### DIFF
--- a/src/components/Login/Login.css
+++ b/src/components/Login/Login.css
@@ -20,15 +20,16 @@
 }
 
 .formGroup {
-  margin-bottom: 10px;
+  margin-bottom: 1rem;
 
   &:last-child {
     margin-bottom: 0;
   }
 }
 
+.linksWrapper,
 .authErrorsWrapper {
-  margin-top: 10px;
+  margin-top: 1rem;
 }
 
 input.input {
@@ -47,10 +48,9 @@ button.submitButton {
 .link {
   display: block;
   width: 100%;
-  text-align: right;
   font-size: var(--font-size-large);
   font-weight: var(--text-weight-headline-basis);
-  margin: 0 0 0.25rem;
+  margin: 0;
 }
 
 @media (--medium-up) {

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -29,21 +29,21 @@ import styles from './Login.css';
 
 class Login extends Component {
   static propTypes = {
-    handleSubmit: PropTypes.func.isRequired,
-    onSubmit: PropTypes.func.isRequired,
-    submitting: PropTypes.bool,
+    ssoActive: PropTypes.bool,
     authErrors: PropTypes.arrayOf(PropTypes.object),
     formValues: PropTypes.object,
-    handleSSOLogin: PropTypes.func.isRequired,
-    ssoActive: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+    submitting: PropTypes.bool,
     submitSucceeded: PropTypes.bool,
+    onSubmit: PropTypes.func.isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    handleSSOLogin: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
-    submitting: false,
     authErrors: [],
     formValues: {},
     ssoActive: false,
+    submitting: false,
     submitSucceeded: false,
   };
 
@@ -106,17 +106,6 @@ class Login extends Component {
                           <FormattedMessage id={`${this.translateNamespace}.username`} />
                         </FieldLabel>
                       </Col>
-                      <Col data-test-new-forgot-username-link>
-                        <Button
-                          href="/forgot-username"
-                          buttonClass={styles.link}
-                          type="button"
-                          buttonStyle="link"
-                          allowAnchorClick
-                        >
-                          <FormattedMessage id={`${this.translateNamespace}.button.forgotUsername`} />
-                        </Button>
-                      </Col>
                     </Row>
                   </Col>
                 </Row>
@@ -150,17 +139,6 @@ class Login extends Component {
                         <FieldLabel htmlFor="password">
                           <FormattedMessage id={`${this.translateNamespace}.password`} />
                         </FieldLabel>
-                      </Col>
-                      <Col data-test-new-forgot-password-link>
-                        <Button
-                          href="/forgot-password"
-                          buttonClass={styles.link}
-                          type="button"
-                          buttonStyle="link"
-                          allowAnchorClick
-                        >
-                          <FormattedMessage id={`${this.translateNamespace}.button.forgotPassword`} />
-                        </Button>
                       </Col>
                     </Row>
                   </Col>
@@ -197,6 +175,43 @@ class Login extends Component {
                       <FormattedMessage id={`${this.translateNamespace}.${buttonLabel}`} />
                     </Button>
                   </div>
+                </Col>
+              </Row>
+              <Row
+                className={styles.linksWrapper}
+                center="xs"
+              >
+                <Col xs={6}>
+                  <Row between="xs">
+                    <Col
+                      xs={5}
+                      data-test-new-forgot-password-link
+                    >
+                      <Button
+                        href="/forgot-password"
+                        buttonClass={styles.link}
+                        type="button"
+                        buttonStyle="link"
+                        allowAnchorClick
+                      >
+                        <FormattedMessage id={`${this.translateNamespace}.button.forgotPassword`} />
+                      </Button>
+                    </Col>
+                    <Col
+                      xs={5}
+                      data-test-new-forgot-username-link
+                    >
+                      <Button
+                        href="/forgot-username"
+                        buttonClass={styles.link}
+                        type="button"
+                        buttonStyle="link"
+                        allowAnchorClick
+                      >
+                        <FormattedMessage id={`${this.translateNamespace}.button.forgotUsername`} />
+                      </Button>
+                    </Col>
+                  </Row>
                 </Col>
               </Row>
               <Row center="xs">


### PR DESCRIPTION
…og in button
# Purpose
When attempting to log in to FOLIO, the location of the "Forgot password?" link places it in the tab order between the username and password fields. This creates a clunky experience when using solely the keyboard to input the username / password.
# Screenshots
![screen shot 2018-12-10 at 1 21 45 pm](https://user-images.githubusercontent.com/42577309/49726588-6af09d00-fc7f-11e8-84ed-1473774f332d.png)