### PR TITLE
prefer to over href in button links

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -188,11 +188,10 @@ class Login extends Component {
                       data-test-new-forgot-password-link
                     >
                       <Button
-                        href="/forgot-password"
+                        to="/forgot-password"
                         buttonClass={styles.link}
                         type="button"
                         buttonStyle="link"
-                        allowAnchorClick
                       >
                         <FormattedMessage id={`${this.translateNamespace}.button.forgotPassword`} />
                       </Button>
@@ -202,11 +201,10 @@ class Login extends Component {
                       data-test-new-forgot-username-link
                     >
                       <Button
-                        href="/forgot-username"
+                        to="/forgot-username"
                         buttonClass={styles.link}
                         type="button"
                         buttonStyle="link"
-                        allowAnchorClick
                       >
                         <FormattedMessage id={`${this.translateNamespace}.button.forgotUsername`} />
                       </Button>


### PR DESCRIPTION
Use `to` to generate a `<Link>`; `href` generates an `<a>` wrapper that
treats the target as an external link, refreshing the entire page.