### PR TITLE
Minor app list dropdown update

### DIFF
--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -44,17 +44,17 @@
 }
 
 .navListDropdown > div {
-  padding: 10px 5px;
+  overflow-y: scroll;
 }
 
 .dropdownBody {
   width: 100%;
   outline: 0;
+  padding: 10px 5px;
 }
 
 .dropdownList {
   margin: 0;
-  overflow-y: auto;
   max-height: calc(100vh - var(--padding-for-header));
 }
 

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -224,7 +224,7 @@ class AppList extends Component {
             hasPadding={false}
           >
             {renderDropdownToggleButton()}
-            <DropdownMenu className="hello" data-role="menu" onToggle={toggleDropdown}>
+            <DropdownMenu data-role="menu" onToggle={toggleDropdown}>
               {focusTrap(focusDropdownToggleButton)}
               <AppListDropdown
                 listRef={dropdownListRef}

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -221,9 +221,10 @@ class AppList extends Component {
             open={open}
             id={dropdownId}
             onToggle={toggleDropdown}
+            hasPadding={false}
           >
             {renderDropdownToggleButton()}
-            <DropdownMenu data-role="menu" onToggle={toggleDropdown}>
+            <DropdownMenu className="hello" data-role="menu" onToggle={toggleDropdown}>
               {focusTrap(focusDropdownToggleButton)}
               <AppListDropdown
                 listRef={dropdownListRef}


### PR DESCRIPTION
I noticed that the app list dropdown had a bit too much padding, it was cropping active/focus styles and it would scroll the inner element instead of the outer element. In this PR I fixed that.

# Before
![screenshot 2018-12-11 16 21 39](https://user-images.githubusercontent.com/640976/49810279-305f3100-fd61-11e8-8bbf-66b387fb4de3.png)

# After
![screenshot 2018-12-11 16 17 23](https://user-images.githubusercontent.com/640976/49810290-35bc7b80-fd61-11e8-8904-e29d535bfe29.png)
