### PR TITLE
STCOR-299: remove typeface-source-sans-pro from webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "serialize-javascript": "^1.4.0",
     "style-loader": "^0.22.1",
     "tapable": "^1.0.0",
-    "typeface-source-sans-pro": "^0.0.54",
     "typescript": "^2.8.1",
     "uuid": "^3.0.0",
     "webpack": "^4.10.2",

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -3,7 +3,6 @@ import { setupAppForTesting, visit, location } from '@bigtest/react';
 import localforage from 'localforage';
 
 // load these styles for our tests
-import 'typeface-source-sans-pro';
 import '@folio/stripes-components/lib/global.css';
 
 import startMirage from '../network/start';

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -13,7 +13,6 @@ const specificReact = generateStripesAlias('react');
 
 module.exports = {
   entry: [
-    'typeface-source-sans-pro',
     '@folio/stripes-components/lib/global.css',
     path.join(__dirname, 'src', 'index'),
   ],


### PR DESCRIPTION
Since `typeface-source-sans-pro` package is not used after [this merge](https://github.com/folio-org/stripes-components/pull/765), it should be removed from our webpack config.
[Related story](https://issues.folio.org/browse/STCOR-299)