### PR TITLE
STCOR: okapi.authFailure cleared when the login form dismounts

### DIFF
--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -5,6 +5,7 @@ import { connect as reduxConnect } from 'react-redux';
 
 import processBadResponse from '../../processBadResponse';
 import { stripesShape } from '../../Stripes';
+import { setAuthError } from '../../okapiActions';
 
 import CreateResetPassword from './CreateResetPassword';
 import PasswordHasNotChanged from './components/PasswordHasNotChanged';
@@ -41,6 +42,7 @@ class CreateResetPasswordControl extends Component {
     }).isRequired,
     stripes: stripesShape.isRequired,
     handleBadResponse: PropTypes.func.isRequired,
+    clearAuthErrors: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -52,6 +54,10 @@ class CreateResetPasswordControl extends Component {
 
     this.state = { isSuccessfulPasswordChange: false };
     this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  componentWillUnmount() {
+    this.props.clearAuthErrors();
   }
 
   handleSuccessfulResponse = () => {
@@ -119,6 +125,9 @@ class CreateResetPasswordControl extends Component {
 }
 
 const mapStateToProps = state => ({ authFailure: state.okapi.authFailure });
-const mapDispatchToProps = dispatch => ({ handleBadResponse: error => processBadResponse(dispatch, error) });
+const mapDispatchToProps = dispatch => ({
+  handleBadResponse: error => processBadResponse(dispatch, error),
+  clearAuthErrors: () => dispatch(setAuthError([])),
+});
 
 export default withRouter(reduxConnect(mapStateToProps, mapDispatchToProps)(CreateResetPasswordControl));

--- a/src/components/ForgotPassword/ForgotPasswordCtrl.js
+++ b/src/components/ForgotPassword/ForgotPasswordCtrl.js
@@ -8,6 +8,8 @@ import PropTypes from 'prop-types';
 
 import { validateForgotUsernameForm } from '../../validators';
 import processBadResponse from '../../processBadResponse';
+import { setAuthError } from '../../okapiActions';
+
 import ForgotPasswordForm from './ForgotPasswordForm';
 
 class ForgotPasswordCtrl extends Component {
@@ -19,6 +21,7 @@ class ForgotPasswordCtrl extends Component {
       }).isRequired,
     }).isRequired,
     handleBadResponse: PropTypes.func.isRequired,
+    clearAuthErrors: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -48,6 +51,10 @@ class ForgotPasswordCtrl extends Component {
       userEmail: '',
     };
     this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  componentWillUnmount() {
+    this.props.clearAuthErrors();
   }
 
   async handleSubmit(values) {
@@ -115,6 +122,9 @@ class ForgotPasswordCtrl extends Component {
 }
 
 const mapStateToProps = state => ({ authFailure: state.okapi.authFailure });
-const mapDispatchToProps = dispatch => ({ handleBadResponse: error => processBadResponse(dispatch, error) });
+const mapDispatchToProps = dispatch => ({
+  handleBadResponse: error => processBadResponse(dispatch, error),
+  clearAuthErrors: () => dispatch(setAuthError([])),
+});
 
 export default withRouter(reduxConnect(mapStateToProps, mapDispatchToProps)(ForgotPasswordCtrl));

--- a/src/components/ForgotUserName/ForgotUserNameCtrl.js
+++ b/src/components/ForgotUserName/ForgotUserNameCtrl.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 
 import { validateForgotUsernameForm } from '../../validators';
 import processBadResponse from '../../processBadResponse';
+import { setAuthError } from '../../okapiActions';
 import ForgotUserNameForm from './ForgotUserNameForm';
 
 class ForgotUserNameCtrl extends Component {
@@ -19,6 +20,7 @@ class ForgotUserNameCtrl extends Component {
       }).isRequired,
     }).isRequired,
     handleBadResponse: PropTypes.func.isRequired,
+    clearAuthErrors: PropTypes.func.isRequired,
   };
 
     static defaultProps = {
@@ -48,6 +50,10 @@ class ForgotUserNameCtrl extends Component {
       userEmail: '',
     };
     this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  componentWillUnmount() {
+    this.props.clearAuthErrors();
   }
 
   async handleSubmit(values) {
@@ -114,6 +120,9 @@ class ForgotUserNameCtrl extends Component {
 }
 
 const mapStateToProps = state => ({ authFailure: state.okapi.authFailure });
-const mapDispatchToProps = dispatch => ({ handleBadResponse: error => processBadResponse(dispatch, error) });
+const mapDispatchToProps = dispatch => ({
+  handleBadResponse: error => processBadResponse(dispatch, error),
+  clearAuthErrors: () => dispatch(setAuthError([])),
+});
 
 export default withRouter(reduxConnect(mapStateToProps, mapDispatchToProps)(ForgotUserNameCtrl));

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import { connect as reduxConnect } from 'react-redux';
 import { SubmissionError } from 'redux-form';
 
-import { requestLogin, requestSSOLogin } from '../../loginServices';
+import {
+  requestLogin,
+  requestSSOLogin,
+} from '../../loginServices';
+import { setAuthError } from '../../okapiActions';
+
 import Login from './Login';
 
 class LoginCtrl extends Component {
@@ -14,6 +19,7 @@ class LoginCtrl extends Component {
       username: PropTypes.string.isRequired,
       password: PropTypes.string.isRequired,
     }),
+    clearAuthErrors: PropTypes.func.isRequired,
   };
 
   static contextTypes = {
@@ -31,6 +37,10 @@ class LoginCtrl extends Component {
     if (props.autoLogin && props.autoLogin.username) {
       this.handleSubmit(props.autoLogin);
     }
+  }
+
+  componentWillUnmount() {
+    this.props.clearAuthErrors();
   }
 
   handleSubmit(data) {
@@ -60,11 +70,12 @@ class LoginCtrl extends Component {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    authFailure: state.okapi.authFailure,
-    ssoEnabled: state.okapi.ssoEnabled,
-  };
-}
+const mapStateToProps = state => ({
+  authFailure: state.okapi.authFailure,
+  ssoEnabled: state.okapi.ssoEnabled,
+});
+const mapDispatchToProps = dispatch => ({
+  clearAuthErrors: () => dispatch(setAuthError([])),
+});
 
-export default reduxConnect(mapStateToProps)(LoginCtrl);
+export default reduxConnect(mapStateToProps, mapDispatchToProps)(LoginCtrl);


### PR DESCRIPTION
<h1>Purpose</h1>
<li>To clear the auth errors container when component dismounts</li>
<h1>Approach</h1>
<li>To dispatch a `setAuthError([])` action when all the login forms enter `componentWillUnmount` hook</li> 