### PR TITLE
STCOR-301: reset submit button on Change Password page

### DIFF
--- a/src/components/CreateResetPassword/CreateResetPassword.js
+++ b/src/components/CreateResetPassword/CreateResetPassword.js
@@ -37,10 +37,11 @@ class CreateResetPassword extends Component {
     stripes: stripesShape.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
+    onPasswordInputFocus: PropTypes.func.isRequired,
     submitting: PropTypes.bool,
     errors: PropTypes.arrayOf(PropTypes.object),
     formValues: PropTypes.object,
-    submitSucceeded: PropTypes.bool,
+    submitIsFailed: PropTypes.bool,
     token: PropTypes.string.isRequired,
   };
 
@@ -48,7 +49,7 @@ class CreateResetPassword extends Component {
     submitting: false,
     errors: [],
     formValues: {},
-    submitSucceeded: false,
+    submitIsFailed: false,
   };
 
   constructor(props) {
@@ -143,7 +144,8 @@ class CreateResetPassword extends Component {
       handleSubmit,
       submitting,
       onSubmit,
-      submitSucceeded,
+      onPasswordInputFocus,
+      submitIsFailed,
       formValues: {
         newPassword,
         confirmPassword,
@@ -151,10 +153,10 @@ class CreateResetPassword extends Component {
       token,
     } = this.props;
     const { passwordMasked } = this.state;
-    const submissionStatus = submitting || submitSucceeded;
+    const submissionStatus = submitting || submitIsFailed;
     const buttonDisabled = !isEmpty(errors) || submissionStatus || !(newPassword && confirmPassword);
     const passwordType = passwordMasked ? 'password' : 'text';
-    const buttonLabelId = `${this.translationNamespaces.module}.${submissionStatus ? 'settingPassword' : 'setPassword'}`;
+    const buttonLabelId = `${this.translationNamespaces.module}.${submitting ? 'settingPassword' : 'setPassword'}`;
     const passwordToggleLabelId = `${this.translationNamespaces.button}.${passwordMasked ? 'show' : 'hide'}Password`;
     const username = this.getUsernameFromToken(token);
 
@@ -226,6 +228,7 @@ class CreateResetPassword extends Component {
                       passwordMeterColProps={this.passwordMeterColProps}
                       validationHandler={this.newPasswordFieldValidation}
                       validate={this.validators.newPassword}
+                      onFocus={() => onPasswordInputFocus(submitIsFailed)}
                     />
                   </Col>
                 </Row>

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -40,7 +40,10 @@ class CreateResetPasswordControl extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { isSuccessfulPasswordChange: false };
+    this.state = {
+      isSuccessfulPasswordChange: false,
+      submitIsFailed: false,
+    };
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
@@ -59,9 +62,11 @@ class CreateResetPasswordControl extends Component {
         this.handleSuccessfulResponse();
         break;
       case 401:
+        this.setState({ submitIsFailed: true });
         setDefaultAuthError([defaultErrors.INVALID_LINK_ERROR]);
         break;
       default:
+        this.setState({ submitIsFailed: true });
         handleBadResponse(response);
     }
   };
@@ -108,6 +113,13 @@ class CreateResetPasswordControl extends Component {
     }
   }
 
+  clearErrorsAfterSubmit = (submissionCompleted) => {
+    if (submissionCompleted) {
+      this.setState({ submitIsFailed: false });
+      this.props.clearAuthErrors();
+    }
+  };
+
   render() {
     const {
       authFailure,
@@ -124,7 +136,10 @@ class CreateResetPasswordControl extends Component {
       },
     } = this.props;
 
-    const { isSuccessfulPasswordChange } = this.state;
+    const {
+      isSuccessfulPasswordChange,
+      submitIsFailed,
+    } = this.state;
 
     if (isSuccessfulPasswordChange) {
       return <PasswordSuccessfullyChanged />;
@@ -140,6 +155,8 @@ class CreateResetPasswordControl extends Component {
         errors={authFailure}
         stripes={this.props.stripes}
         onSubmit={this.handleSubmit}
+        onPasswordInputFocus={this.clearErrorsAfterSubmit}
+        submitIsFailed={submitIsFailed}
       />
     );
   }


### PR DESCRIPTION
<h1>Purpose</h1>
<li>To reset the submit button after submission was failed on Change Password Page</li>
<h1>Approach</h1>
<li>To pass a `submitIsFailed` property to the presentational component</li>
<h1>Screenshots</h1>
<li>Existing behavior</li>

![change_password_bug](https://user-images.githubusercontent.com/44602331/50220403-ebf41680-039a-11e9-83dd-623336e82521.PNG)

