### PR TITLE
STCOM-399 Intl approach

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,3 +9,4 @@ export { default as IfPermission } from './src/components/IfPermission';
 export { default as TitleManager } from './src/components/TitleManager';
 export { default as HandlerManager } from './src/components/HandlerManager';
 export { default as coreEvents } from './src/events';
+export { default as IntlConsumer } from './src/components/IntlConsumer';

--- a/src/components/IntlConsumer/IntlConsumer.js
+++ b/src/components/IntlConsumer/IntlConsumer.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
+
+const IntlConsumer = ({ intl, children }) => (
+  children(intl)
+);
+
+IntlConsumer.propTypes = {
+  children: PropTypes.func,
+  intl: intlShape,
+};
+
+export default injectIntl(IntlConsumer);

--- a/src/components/IntlConsumer/index.js
+++ b/src/components/IntlConsumer/index.js
@@ -1,0 +1,1 @@
+export { default } from './IntlConsumer';


### PR DESCRIPTION
There are still some cases where `intl.formatMessage()` is necessary for translating strings. in-step with react-intl's hopeful transition to React's updated context API, we can make things a bit cleaner for parts of our UI to access intl in a declarative way without having to dress up in the injectIntl HOC. MCL Column mapping is the primary use-case where `<FormattedMessage>` leaves us hanging since multiple strings are necessary.

The `<IntlConsumer>` component helps with this issue. ex: 
```
import { IntlConsumer } from '@folio/stripes/core';

<IntlConsumer>
 { intl => (
  <MultiColumnList
     { ...other }
     columnMapping={{
         status: intl.formatMessage({ id: 'ui-users.active' }),
         name: intl.formatMessage({ id: 'ui-users.information.name' }),
         barcode: intl.formatMessage({ id: 'ui-users.information.barcode' }),
         patronGroup: intl.formatMessage({ id: 'ui-users.information.patronGroup' }),
         username: intl.formatMessage({ id: 'ui-users.information.username' }),
         email: intl.formatMessage({ id: 'ui-users.contact.email' }),
      }}
    }>
)
}
</IntlConsumer>
```

Other similar, more specific approaches were considered, like a `<FormattedMessageList>`, but the code for this is dead simple and the transition for existing code is minimal. My initial thoughts are stripes-core as a home for this since it will have proximity to the IntlProvider should we have to do much modification with that relationship or context.
