### PR TITLE
STCOR-305: email hidden on Check email screen

### DIFF
--- a/src/components/CheckEmailStatusPage/CheckEmailStatusPage.js
+++ b/src/components/CheckEmailStatusPage/CheckEmailStatusPage.js
@@ -25,9 +25,9 @@ const CheckEmailStatusPage = (props) => {
   const notificationText = isEmail
     ? `${labelNamespace}.sent.email`
     : `${labelNamespace}.your.email`;
-  const hiddenUserEmail = isEmail
-    ? hideEmail(userEmail)
-    : null;
+  const userEmailMessage = isEmail
+    ? { hiddenUserEmail: hideEmail(userEmail) }
+    : {};
 
   return (
     <div
@@ -52,7 +52,7 @@ const CheckEmailStatusPage = (props) => {
         >
           <FormattedMessage
             id={notificationText}
-            {...(isEmail && { values: { hiddenUserEmail } })}
+            values={userEmailMessage}
           />
         </Headline>
         <Headline

--- a/src/components/CheckEmailStatusPage/CheckEmailStatusPage.js
+++ b/src/components/CheckEmailStatusPage/CheckEmailStatusPage.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
@@ -7,6 +7,7 @@ import Headline from '@folio/stripes-components/lib/Headline';
 
 import OrganizationLogo from '../OrganizationLogo/OrganizationLogo';
 import validateEmail from '../../validators/validateEmail/validateEmail';
+import { hideEmail } from '../../helpers';
 
 import styles from './CheckEmailStatusPage.css';
 
@@ -18,51 +19,53 @@ const CheckEmailStatusPage = (props) => {
       },
     },
   } = props;
+
   const isEmail = validateEmail(userEmail);
   const labelNamespace = 'stripes-core.label';
   const notificationText = isEmail
     ? `${labelNamespace}.sent.email`
     : `${labelNamespace}.your.email`;
+  const hiddenUserEmail = isEmail
+    ? hideEmail(userEmail)
+    : null;
 
   return (
-    <Fragment>
-      <div
-        className={styles.wrap}
-        data-test-status-page
-      >
-        <div className={styles.centered}>
-          <OrganizationLogo />
-          <Headline
-            size="xx-large"
-            tag="h1"
-            data-test-h1
-          >
-            <FormattedMessage id={`${labelNamespace}.check.email`} />
-          </Headline>
-          <Headline
-            size="x-large"
-            tag="p"
-            bold={false}
-            faded
-            data-test-p-notification
-          >
-            <FormattedMessage
-              id={notificationText}
-              {...(isEmail && { values: { userEmail } })}
-            />
-          </Headline>
-          <Headline
-            size="x-large"
-            tag="p"
-            bold={false}
-            faded
-            data-test-p-caution
-          >
-            <FormattedMessage id={`${labelNamespace}.caution.email`} />
-          </Headline>
-        </div>
+    <div
+      className={styles.wrap}
+      data-test-status-page
+    >
+      <div className={styles.centered}>
+        <OrganizationLogo />
+        <Headline
+          size="xx-large"
+          tag="h1"
+          data-test-h1
+        >
+          <FormattedMessage id={`${labelNamespace}.check.email`} />
+        </Headline>
+        <Headline
+          size="x-large"
+          tag="p"
+          bold={false}
+          faded
+          data-test-p-notification
+        >
+          <FormattedMessage
+            id={notificationText}
+            {...(isEmail && { values: { hiddenUserEmail } })}
+          />
+        </Headline>
+        <Headline
+          size="x-large"
+          tag="p"
+          bold={false}
+          faded
+          data-test-p-caution
+        >
+          <FormattedMessage id={`${labelNamespace}.caution.email`} />
+        </Headline>
       </div>
-    </Fragment>
+    </div>
   );
 };
 

--- a/src/helpers/hideEmail/hideEmail.js
+++ b/src/helpers/hideEmail/hideEmail.js
@@ -1,0 +1,14 @@
+const signToShow = '*';
+
+const replacer = (string, pattern1, pattern2) => (
+  pattern1.concat(signToShow.repeat(pattern2.length))
+);
+
+const hideEmail = email => (
+  email
+    .replace(/(^.{2})(.+?)(?=@)/g, replacer)
+    .replace(/(^.+@.)(.+?)(?=\.)/g, replacer)
+    .replace(/(\.)(.+?)(?=$)/g, replacer)
+);
+
+export default hideEmail;

--- a/src/helpers/hideEmail/hideEmail.js
+++ b/src/helpers/hideEmail/hideEmail.js
@@ -4,6 +4,15 @@ const replacer = (string, pattern1, pattern2) => (
   pattern1.concat(signToShow.repeat(pattern2.length))
 );
 
+/**
+ * A function to hide the eternal user email and show it according to the following rules:
+ *  - show first two characters for the local-part
+ *  - show first character of the domain
+ *  - show the dot
+ * Each replacement step performs formatting as it mentioned above
+ * @param email      - an email to be formatted
+ * @returns {string} - a formatted email string
+ */
 const hideEmail = email => (
   email
     .replace(/(^.{2})(.+?)(?=@)/g, replacer)

--- a/src/helpers/hideEmail/index.js
+++ b/src/helpers/hideEmail/index.js
@@ -1,0 +1,1 @@
+export { default } from './hideEmail';

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,3 +1,2 @@
-// remove the suppression when more helper functions are added
-// eslint-disable-next-line
 export { default as parseJWT } from './parseJWT';
+export { default as hideEmail } from './hideEmail';

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -42,7 +42,7 @@
   "label.your.email": "An email has been sent to your email address",
   "label.check.email": "Check your email",
   "label.caution.email": "If you don't receive the email, check your spam, junk, social or other folders. Or contact your FOLIO system administrator",
-  "label.sent.email": "An email has been sent to {userEmail}",
+  "label.sent.email": "An email has been sent to {hiddenUserEmail}",
   "successfullyDeleted": "The {entry} <strong>{name}</strong> was successfully <strong>deleted</strong>.",
   "untitled": "Untitled",
   "label.congratulations": "Congratulations!",


### PR DESCRIPTION
<h1>Purpose</h1>
<li>To hide an email presented on Check email screen</li>
<h1>Approach</h1>
<li>To create a helper function which replaces all the required symbols with a default '*' sign</li>
<h1>Screenshots</h1>
<li>Expected behavior</li>

![check_email](https://user-images.githubusercontent.com/44602331/50439379-8e138180-08fa-11e9-82d2-b343a1a35f88.png)
