### PR TITLE
restore one missing space

### DIFF
--- a/src/components/About/AboutEnabledModules.js
+++ b/src/components/About/AboutEnabledModules.js
@@ -34,6 +34,7 @@ class AboutEnabledModules extends React.Component {
       return (
         <li key={key} style={style}>
           {this.props.availableModules[key]}
+          {' '}
           <tt>{`(${key})`}</tt>
         </li>
       );


### PR DESCRIPTION
The missing space between the server-side module names and their
versions was a cause of great pain and suffering unlike the world has
ever known, a plague upon the landscape, a pox upon the screen. Children
wept when reading the 'Software versions' page. Animals cowered. A
maple outside my window dropped its leaves in August, and an evergreen
shed its needles.

You think you're hot stuff, ESLint, but I have only one word for you and
it's this: "open-curly-single-quote-space-single-quote-space-close-curly"
is not clearer than "space" and if you think it is then you better not
be bothered that this was more than one word.