### PR TITLE
provide default translations from en.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Sort the settings. Fixes STCOR-286.
 * Load region-specific translations if available. Fixes STCOR-261.
 * Updated webpack config to disable CSS variable preservation. Fixes STCOR-260.
+* Provide default translations from `en.json` to all localizations. Fixes STCOR-310.
 
 ## [2.17.1](https://github.com/folio-org/stripes-core/tree/v2.17.1) (2018-12-21)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.17.0...v2.17.1)

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -99,15 +99,12 @@ module.exports = class StripesTranslationPlugin {
     logger.log('loading translations from directory', dir);
     const moduleTranslations = {};
 
+    let enTranslations = {};
     const enPath = path.join(dir, 'en.json');
-    try {
-      fs.accessSync(enPath, fs.constants.R_OK);
-    } catch (err) {
-      throw new StripesBuildError(`StripesTranslationPlugin: Unable to access ${moduleName}'s default translations at ${enPath}.`);
+    if (fs.existsSync(enPath)) {
+      const rawEnTranslations = StripesTranslationPlugin.loadFile(enPath);
+      enTranslations = StripesTranslationPlugin.prefixModuleKeys(moduleName, rawEnTranslations);
     }
-
-    let enTranslations = StripesTranslationPlugin.loadFile(enPath);
-    enTranslations = StripesTranslationPlugin.prefixModuleKeys(moduleName, enTranslations);
 
     for (const translationFile of fs.readdirSync(dir)) {
       const language = translationFile.replace('.json', '');

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -4,8 +4,6 @@ const _ = require('lodash');
 const webpack = require('webpack');
 const modulePaths = require('./module-paths');
 const logger = require('./logger')('stripesTranslationsPlugin');
-const StripesBuildError = require('./stripes-build-error');
-
 
 function prefixKeys(obj, prefix) {
   const res = {};


### PR DESCRIPTION
Include `en.json` as the base for all translations so that keys missing
from a locale file but present in the `en.json` file will show the value
from the `en.json` file rather than the key. This will allow developers
to add pairs to the `en.json` file and have the values immediately show
up in the UI regardless of locale.

Fixes [STCOR-310](https://issues.folio.org/browse/STCOR-310)