### PR TITLE
Revert "provide default translations from en.json"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Sort the settings. Fixes STCOR-286.
 * Load region-specific translations if available. Fixes STCOR-261.
 * Updated webpack config to disable CSS variable preservation. Fixes STCOR-260.
-* Provide default translations from `en.json` to all localizations. Fixes STCOR-310.
 
 ## [2.17.1](https://github.com/folio-org/stripes-core/tree/v2.17.1) (2018-12-21)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v2.17.0...v2.17.1)

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -96,20 +96,12 @@ module.exports = class StripesTranslationPlugin {
   loadTranslationsDirectory(moduleName, dir) {
     logger.log('loading translations from directory', dir);
     const moduleTranslations = {};
-
-    let enTranslations = {};
-    const enPath = path.join(dir, 'en.json');
-    if (fs.existsSync(enPath)) {
-      const rawEnTranslations = StripesTranslationPlugin.loadFile(enPath);
-      enTranslations = StripesTranslationPlugin.prefixModuleKeys(moduleName, rawEnTranslations);
-    }
-
     for (const translationFile of fs.readdirSync(dir)) {
       const language = translationFile.replace('.json', '');
       // When filter is set, skip other languages. Otherwise loads all
       if (!this.languageFilter.length || this.languageFilter.includes(language)) {
         const translations = StripesTranslationPlugin.loadFile(path.join(dir, translationFile));
-        moduleTranslations[language] = Object.assign(enTranslations, StripesTranslationPlugin.prefixModuleKeys(moduleName, translations));
+        moduleTranslations[language] = StripesTranslationPlugin.prefixModuleKeys(moduleName, translations);
       }
     }
     return moduleTranslations;


### PR DESCRIPTION
Reverts folio-org/stripes-core#559

I'm not yet sure how, but this PR seems to have caused a tiny little itty bitty problem with the UI where translation values for all locales were written out in Chinese. All of them. ALL OF THEM. 

Maybe this was array iteration goof with the final element, zh_CN, overwriting the rest? I can't see how that happened, and yet: 

![screen shot 2019-01-14 at 4 44 07 pm](https://user-images.githubusercontent.com/199241/51144039-0694a080-181e-11e9-99fe-211c86dd6c0e.png)
