### PR TITLE
provide default translations from en.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Sort the settings. Fixes STCOR-286.
 * Load region-specific translations if available. Fixes STCOR-261.
 * Updated webpack config to disable CSS variable preservation. Fixes STCOR-260.
+* Provide default translations from `en.json` to all localizations. Fixes STCOR-310.
 * Stop exposing stripes.intl
 
 ## [2.17.1](https://github.com/folio-org/stripes-core/tree/v2.17.1) (2018-12-21)

--- a/webpack/stripes-translations-plugin.js
+++ b/webpack/stripes-translations-plugin.js
@@ -96,12 +96,20 @@ module.exports = class StripesTranslationPlugin {
   loadTranslationsDirectory(moduleName, dir) {
     logger.log('loading translations from directory', dir);
     const moduleTranslations = {};
+
+    let enTranslations = {};
+    const enPath = path.join(dir, 'en.json');
+    if (fs.existsSync(enPath)) {
+      const rawEnTranslations = StripesTranslationPlugin.loadFile(enPath);
+      enTranslations = StripesTranslationPlugin.prefixModuleKeys(moduleName, rawEnTranslations);
+    }
+
     for (const translationFile of fs.readdirSync(dir)) {
       const language = translationFile.replace('.json', '');
       // When filter is set, skip other languages. Otherwise loads all
       if (!this.languageFilter.length || this.languageFilter.includes(language)) {
         const translations = StripesTranslationPlugin.loadFile(path.join(dir, translationFile));
-        moduleTranslations[language] = StripesTranslationPlugin.prefixModuleKeys(moduleName, translations);
+        moduleTranslations[language] = Object.assign({}, enTranslations, StripesTranslationPlugin.prefixModuleKeys(moduleName, translations));
       }
     }
     return moduleTranslations;


### PR DESCRIPTION
Include `en.json` as the base for all translations so that keys missing
from a locale file but present in the `en.json` file will show the value
from the `en.json` file rather than the key. This will allow developers
to add pairs to the `en.json` file and have the values immediately show
up in the UI regardless of locale.

And this time, do it without merging all translations into those English
translations, thus causing the values from the last locale in the
iteration to overwrite the values from all locales. Ahem. #559. * cough *

Fixes [STCOR-310](https://issues.folio.org/browse/STCOR-310)