### PR TITLE
UIOR-110 remove extra scrollbars

### DIFF
--- a/src/components/Root/Root.css
+++ b/src/components/Root/Root.css
@@ -1,5 +1,6 @@
 /* stylelint-disable */
 :global(#root) {
   height: 100%;
+  overflow: hidden;
 }
 /* stylelint-enable */


### PR DESCRIPTION
There is an issue when clicking on dropdown with Apps when extra scrollbars appear. Here screens with them and with the fix. Also it might help with @shaking@ issue from UIOR-110, but I was unable to reproduce all shaking, only partial moving elements due to extra scrollbars, so I suggest to apply this fix to improve UX. At the same time I need help to review it on its correctness, since it's a root element.
![extra-scrollbars-at-the-right](https://user-images.githubusercontent.com/43577432/51388780-7ca94800-1b3b-11e9-9577-53c1823498f8.png)
![no_extra_scrollbars](https://user-images.githubusercontent.com/43577432/51388675-348a2580-1b3b-11e9-8ad9-adab15223b18.png)
