### PR TITLE
don't interpolate FormattedMessage

### DIFF
--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -44,7 +44,9 @@ const About = (props) => {
 
       return (
         <li key={key} style={style}>
-          {`${key} ${text}`}
+          {key}
+          {' '}
+          {text}
         </li>
       );
     };


### PR DESCRIPTION
This looks like another victim of ESLint appeasement where something
totally reasonable like

    return (<li>{foo} ({bar})</li>)

got mangled trying to appease ESLint. If bar is a FormattedMessage and
the string got changed to `<li>${foo} (${bar})</li>` then bar would
appear as `[object Object]` because it's a FormattedMessage object, not
a string. YAY ESLint you stupid little something something.