### PR TITLE
support users-bl 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 3.1.0 (IN PROGRESS)
+
+* Provide parallel support for okapi interface users-bl 3, 4.
+
 ## [3.0.1](https://github.com/folio-org/stripes-core/tree/v3.0.1) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.0.0...v3.0.1)
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "stripes": {
     "okapiInterfaces": {
-      "users-bl": "3.0",
+      "users-bl": "3.0 4.0",
       "authtoken": "1.0 2.0",
       "configuration": "2.0"
     },


### PR DESCRIPTION
New features were added in users-bl that necessitated bumping its
interface, but without support for the new interface in the UI, we
couldn't build folio-snapshot. Providing parallel support for the old
interface (since no functionality here is changing) and the new
interface (so that backend dependencies can be satisfied) seems like the
least painful solution.