### PR TITLE
STCOR-323 workspace node_modules fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0 (IN PROGRESS)
 
 * Provide parallel support for okapi interface users-bl 3 and 4.
+* Consider framework's node_modules directory from within a Yarn workspace, fixes STCOR-323
 
 ## [3.0.2](https://github.com/folio-org/stripes-core/tree/v3.0.2) (2019-01-24)
 * Add workspace path to stripes alias resolution. Part of STCOR-320.

--- a/webpack/module-paths.js
+++ b/webpack/module-paths.js
@@ -56,6 +56,9 @@ function locateStripesModule(context, moduleName, alias, ...segments) {
   if (moduleName.startsWith('@folio/stripes')) {
     tryPaths.unshift({
       request: path.join(context, 'node_modules', '@folio', 'stripes', 'node_modules', moduleName, ...segments),
+    }, {
+      // Yarn workspace fallback
+      request: path.join(context, '..', 'node_modules', '@folio', 'stripes', 'node_modules', moduleName, ...segments),
     });
   }
 


### PR DESCRIPTION
The previous work for STCOR-304 did not consider the need to locate Stripes framework in a workspace preventing some `stripes-*` modules from being located if yarn did not happen to hoist them.  This resulted in things like translations for stripes-smart-components not being found.

This solution extends the previous work by also considering the framework's node_modules path starting from one level up (in the workspace).  The whole path logic is due for review as a few issues brought about by workspaces and/or hoisting have come up recently.  Fortunately such path needs should already be funneled through this file simplifying a future refactor.
