### PR TITLE
correctly export AppIcon

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,3 +10,4 @@ export { default as TitleManager } from './src/components/TitleManager';
 export { default as HandlerManager } from './src/components/HandlerManager';
 export { default as coreEvents } from './src/events';
 export { default as IntlConsumer } from './src/components/IntlConsumer';
+export { default as AppIcon } from './src/components/AppIcon';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,4 @@
 export { default as About } from './About';
-export { default as AppIcon } from './AppIcon';
 export { default as AuthErrorsContainer } from './AuthErrorsContainer';
 export { default as CreateResetPassword } from './CreateResetPassword';
 export { default as HandlerManager } from './HandlerManager';


### PR DESCRIPTION
Public exports need to happen at the top level of the package.

#567 added `<AppIcon>` but only exports it within `src/components`. It needs to be a top-level export, like `<IfInterface>`, `<IfPermission>`, and `<Pluggable>` to be importable like 
```
import { AppIcon } from '@folio/stripes/core';
```
as suggested in folio-org/stripes-components/pull/826. 