### PR TITLE
Minor padding adjustment for app list dropdown

### DIFF
--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -50,7 +50,7 @@
 .dropdownBody {
   width: 100%;
   outline: 0;
-  padding: 10px 5px;
+  padding: var(--gutter-static-one-third) var(--gutter-static);
 }
 
 .dropdownList {


### PR DESCRIPTION
After an update in stripes-components the padding inside the app list dropdown was a bit off.

## Before
<img width="445" alt="screenshot 2019-02-05 12 54 20" src="https://user-images.githubusercontent.com/640976/52271902-4e05dc80-2945-11e9-8148-ddc008d65da8.png">

## After
<img width="447" alt="screenshot 2019-02-05 12 53 23" src="https://user-images.githubusercontent.com/640976/52271907-52ca9080-2945-11e9-9828-33df6d4e338c.png">

