### PR TITLE
Set current query to a correct value during initial page load. Fixes STCOR-339.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 3.0.4 In Progress
+
+* Set current query to a correct value during initial page load. Fixes STCOR-339.
+
 ## [3.0.3](https://github.com/folio-org/stripes-core/tree/v3.0.3) (2019-01-29)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.0.2...v3.0.3)
 

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -10,7 +10,13 @@ import { withModules } from '../Modules';
 import { LastVisitedContext } from '../LastVisited';
 import { clearOkapiToken, clearCurrentUser } from '../../okapiActions';
 import { resetStore } from '../../mainActions';
-import { updateQueryResource, updateLocation, getCurrentModule, isQueryResourceModule } from '../../locationService';
+import {
+  updateQueryResource,
+  getLocationQuery,
+  updateLocation,
+  getCurrentModule,
+  isQueryResourceModule
+} from '../../locationService';
 
 import css from './MainNav.css';
 import NavDivider from './NavDivider';
@@ -73,7 +79,7 @@ class MainNav extends Component {
   }
 
   componentDidMount() {
-    let curQuery = null;
+    let curQuery = getLocationQuery(this.props.location);
     this._unsubscribe = this.store.subscribe(() => {
       const { history, location } = this.props;
       const module = this.curModule;
@@ -85,7 +91,6 @@ class MainNav extends Component {
 
   componentDidUpdate(prevProps) {
     const { modules, location } = this.props;
-
     this.curModule = getCurrentModule(modules, location);
     if (this.curModule && !isEqual(location, prevProps.location)) {
       updateQueryResource(location, this.curModule, this.store);

--- a/src/locationService.js
+++ b/src/locationService.js
@@ -2,7 +2,7 @@ import { snakeCase, isEqual, forOwn, isEmpty, unset } from 'lodash';
 import queryString from 'query-string';
 import { replaceQueryResource } from './locationActions';
 
-function getLocationQuery(location) {
+export function getLocationQuery(location) {
   return location.query ? location.query : queryString.parse(location.search);
 }
 


### PR DESCRIPTION
This PR fixes the issue described in https://issues.folio.org/browse/STCOR-339:

It looks like every time we open FOLIO via direct link to any settings form and we try to cancel the form the navigation is not responding.

Steps to reproduce:

1. Open any form directly in the browser. For example: http://folio-testing.aws.indexdata.com/settings/organization/servicePoints?layer=add
2. Click 'X' to close the form 
3. The form stays open until second click on 'X'