### PR TITLE
STCOR-222 error on stripes duplicates

### DIFF
--- a/webpack/stripes-duplicate-plugin.js
+++ b/webpack/stripes-duplicate-plugin.js
@@ -7,6 +7,11 @@ const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack
 // Module names that must not have duplicates
 const duplicatesNotAllowed = [
   'react',
+  'stripes-core',
+  'stripes-components',
+  'stripes-smart-components',
+  'stripes-form',
+  'stripes-connect',
 ];
 
 // Module names that are acceptable to have duplicates


### PR DESCRIPTION
This configures the `stripes-duplicate-plugin` to error when duplicate `stripes-*` modules are present in a bundle.  Doing so, for `stripes-components` at least, should catch one source of rendering errors before they make it into a bundle.  This has been run locally with success on `platform-core` and `platform-complete`.