### PR TITLE
Add ability to configure current user. Refs UICHKIN-53.

### DIFF
--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -26,7 +26,8 @@ export default function setupApplication({
   permissions = {},
   stripesConfig,
   mirageOptions,
-  scenarios
+  scenarios,
+  currentUser = {},
 } = {}) {
   beforeEach(async function () {
     const initialState = {};
@@ -35,7 +36,7 @@ export default function setupApplication({
     if (disableAuth) {
       initialState.okapi = {
         token: 'test',
-        currentUser: {
+        currentUser: assign({
           id: 'test',
           username: 'testuser',
           firstName: 'Test',
@@ -43,7 +44,7 @@ export default function setupApplication({
           email: 'user@folio.org',
           addresses: [],
           servicePoints: []
-        },
+        }, currentUser),
         currentPerms: permissions
       };
     }


### PR DESCRIPTION
In UICHKIN-53 I need to be able to switch between different service points as a logged in user. This PR allows for extending currentUser object by passing it to BigTest's `setupApplication` as a param. 