### PR TITLE
STCOM-461: Fixing app dropdown "jitter"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-core
 
 ## 3.0.4 In Progress
+* Fixed bug where additional scrollbars would appear when opening the app dropdown (STCOM-461)
 
 * Set current query to a correct value during initial page load. Fixes STCOR-339.
 

--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -90,14 +90,6 @@
 }
 
 /**
- * Focus trap
- */
-.focusTrap {
-  position: absolute;
-  clip: rect(1px, 1px, 1px, 1px);
-}
-
-/**
  * Responsive
  */
 

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -180,7 +180,7 @@ class AppList extends Component {
    * Insert hidden input to help trap focus
    */
   focusTrap(onFocus) {
-    return <input aria-hidden="true" className={css.focusTrap} onFocus={onFocus} />;
+    return <input aria-hidden="true" className="sr-only" onFocus={onFocus} />;
   }
 
   render() {


### PR DESCRIPTION
This PR fixes an odd issue of horizontal/vertical scrollbars appearing unnecessarily when opening the app list dropdown in browsers on Windows.

The issue turned out to be a bit of missing CSS in the class name that was responsible for hiding the focus traps (inputs) while still making them able to catch the focus.

I replaced the class with the global "sr-only" (screen reader only) class which offers the same functionality but slightly better and that fixed the issue.

## Before
![dropdown-before](https://user-images.githubusercontent.com/640976/53739673-9b1c9600-3e92-11e9-8945-6e8feaae991a.gif)

## After
![dropdown-after](https://user-images.githubusercontent.com/640976/53739677-9ce65980-3e92-11e9-9ec9-e5ddce58a65e.gif)