### PR TITLE
make stripes dependencies more strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 3.0.4 (IN PROGRESS)
+
+* Make stripes dependencies more strict with ~ instead of ^. Refs STRIPES-608.
+
 ## [3.0.3](https://github.com/folio-org/stripes-core/tree/v3.0.3) (2019-01-29)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.0.2...v3.0.3)
 

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
-    "@folio/stripes-components": "^5.0.0",
-    "@folio/stripes-connect": "^4.0.0",
-    "@folio/stripes-logger": "^1.0.0",
+    "@folio/stripes-components": "~5.0.0",
+    "@folio/stripes-connect": "~4.0.1",
+    "@folio/stripes-logger": "~1.0.0",
     "apollo-cache-inmemory": "^1.1.1",
     "apollo-client": "^2.0.3",
     "apollo-link-http": "^1.2.0",


### PR DESCRIPTION
Caret dependencies are too loose in the context of releasing a platform
and allow new minor release to "leak" up into a platform where the
differing versions can cause duplication errors.

Refs [STRIPES-608](https://issues.folio.org/browse/STRIPES-608)