### PR TITLE
sync master version with releases from branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",


### PR DESCRIPTION
The version on master must always be >= that of the version on a branch.
Otherwise, repos that update to a patch release (from a branch) may be
prevent from using the tip-of-master version provided in their
workspace.