### PR TITLE
STCON-76 Option #2 - use ConnectContext Provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-export { RootContext } from './src/components/Root/RootContext';
 export { stripesShape } from './src/Stripes';
 export { withStripes } from './src/StripesContext';
 
@@ -12,3 +11,4 @@ export { default as HandlerManager } from './src/components/HandlerManager';
 export { default as coreEvents } from './src/events';
 export { default as IntlConsumer } from './src/components/IntlConsumer';
 export { default as AppIcon } from './src/components/AppIcon';
+export { ConnectContext as RootContext, withConnect as withRoot } from '@folio/stripes-connect';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "~5.1.0",
-    "@folio/stripes-connect": "~4.1.0",
+    "@folio/stripes-connect": "~5.0.0",
     "@folio/stripes-logger": "~1.0.0",
     "apollo-cache-inmemory": "^1.1.1",
     "apollo-client": "^2.0.3",

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -9,7 +9,8 @@ import { ApolloProvider } from 'react-apollo';
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
 import { metadata } from 'stripes-config';
 
-import { RootContext } from './RootContext';
+import { ConnectContext } from '@folio/stripes-connect';
+// import { RootContext } from './RootContext';
 import initialReducers from '../../initialReducers';
 import enhanceReducer from '../../enhanceReducer';
 import createApolloClient from '../../createApolloClient';
@@ -121,7 +122,7 @@ class Root extends Component {
 
     return (
       <ErrorBoundary>
-        <RootContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store }}>
+        <ConnectContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store }}>
           <ApolloProvider client={createApolloClient(okapi)}>
             <IntlProvider
               locale={locale}
@@ -138,7 +139,7 @@ class Root extends Component {
               />
             </IntlProvider>
           </ApolloProvider>
-        </RootContext.Provider>
+        </ConnectContext.Provider>
       </ErrorBoundary>
     );
   }

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -9,8 +9,11 @@ import { ApolloProvider } from 'react-apollo';
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
 import { metadata } from 'stripes-config';
 
+/* ConnectContext - formerly known as RootContext, now comes from stripes-connect, so stripes-connect
+* is providing the infrastructure for store connectivity to the system. This eliminates a circular
+* dependency between stripes-connect and stripes-core. STCON-76
+*/
 import { ConnectContext } from '@folio/stripes-connect';
-// import { RootContext } from './RootContext';
 import initialReducers from '../../initialReducers';
 import enhanceReducer from '../../enhanceReducer';
 import createApolloClient from '../../createApolloClient';

--- a/src/components/Root/RootContext.js
+++ b/src/components/Root/RootContext.js
@@ -1,24 +1,3 @@
-// import React from 'react';
-
-// export const RootContext = React.createContext();
-
-// function getDisplayName(WrappedComponent) {
-//   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
-// }
-
+// The context that lived here mainly provided a courier for redux-centric elements.
 
 export { ConnectContext as RootContext, withConnect as withRoot } from '@folio/stripes-connect';
-
-// export function withRoot(WrappedComponent) {
-//   class WithRoot extends React.Component {
-//     render() {
-//       return (
-//         <RootContext.Consumer>
-//           {root => <WrappedComponent {...this.props} root={root} /> }
-//         </RootContext.Consumer>
-//       );
-//     }
-//   }
-//   WithRoot.displayName = `WithRoot(${getDisplayName(WrappedComponent)})`;
-//   return WithRoot;
-// }

--- a/src/components/Root/RootContext.js
+++ b/src/components/Root/RootContext.js
@@ -1,3 +1,6 @@
-// The context that lived here mainly provided a courier for redux-centric elements.
+/* The context that lived here mainly provided a courier for redux-centric elements.
+* it now is provided by stripes-connect. This is a temporary location of the export while some modules still import withRoot
+* directly from this file.
+*/
 
 export { ConnectContext as RootContext, withConnect as withRoot } from '@folio/stripes-connect';

--- a/src/components/Root/RootContext.js
+++ b/src/components/Root/RootContext.js
@@ -1,21 +1,24 @@
-import React from 'react';
+// import React from 'react';
 
-export const RootContext = React.createContext();
+// export const RootContext = React.createContext();
 
-function getDisplayName(WrappedComponent) {
-  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
-}
+// function getDisplayName(WrappedComponent) {
+//   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+// }
 
-export function withRoot(WrappedComponent) {
-  class WithRoot extends React.Component {
-    render() {
-      return (
-        <RootContext.Consumer>
-          {root => <WrappedComponent {...this.props} root={root} /> }
-        </RootContext.Consumer>
-      );
-    }
-  }
-  WithRoot.displayName = `WithRoot(${getDisplayName(WrappedComponent)})`;
-  return WithRoot;
-}
+
+export { ConnectContext as RootContext, withConnect as withRoot } from '@folio/stripes-connect';
+
+// export function withRoot(WrappedComponent) {
+//   class WithRoot extends React.Component {
+//     render() {
+//       return (
+//         <RootContext.Consumer>
+//           {root => <WrappedComponent {...this.props} root={root} /> }
+//         </RootContext.Consumer>
+//       );
+//     }
+//   }
+//   WithRoot.displayName = `WithRoot(${getDisplayName(WrappedComponent)})`;
+//   return WithRoot;
+// }


### PR DESCRIPTION
# Circular Dependencies option 2
We don't like circ-deps. The changes in this PR are much smaller than that of #644 But the downside is the necessity that only one `stripes-connect` exist in a bundle.

On the stripes-core side, this merely means importing the ConnectContext from `stripes-connect`, and using its `Provider` in place of its own `RootContext.Provider`.
