### PR TITLE
STRIPES-614: Fixed logout throwing errors

### DIFF
--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -113,7 +113,7 @@ class MainNav extends Component {
     this.store.dispatch(clearCurrentUser());
     this.store.dispatch(resetStore());
     localforage.removeItem('okapiSess');
-    this.context.router.history.push('/');
+    this.props.history.push('/');
   }
 
   getAppList(lastVisited) {


### PR DESCRIPTION
`context.router` doesn't exist and apparently it was meant to be a private API so we shouldn't have ever been using it.

Instead, use `props.history` provided by [`withRouter`](https://reacttraining.com/react-router/web/api/withRouter)