### PR TITLE
don't use react-router's private API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 3.2.0 (IN PROGRESS)
+
+* Don't use react-router's private history API. Refs STRIPES-614. 
+
 ## [3.1.0](https://github.com/folio-org/stripes-core/tree/v3.1.0) (2019-03-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.0.4...v3.1.0)
 

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -35,6 +35,9 @@ class ProfileDropdown extends Component {
       }),
       okapi: PropTypes.object,
     }).isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   static contextTypes = {
@@ -131,7 +134,7 @@ class ProfileDropdown extends Component {
   }
 
   navigateByUrl(link) {
-    this.context.router.history.push(link.route);
+    this.props.history.push(link.route);
   }
 
   onHome = () => {

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -1,5 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { isFunction, kebabCase } from 'lodash';
+import { compose } from 'redux';
+import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Dropdown } from '@folio/stripes-components/lib/Dropdown';
@@ -226,4 +228,7 @@ class ProfileDropdown extends Component {
   }
 }
 
-export default withModules(ProfileDropdown);
+export default compose(
+  withRouter,
+  withModules,
+)(ProfileDropdown);


### PR DESCRIPTION
Pulling `router.history` off `context` is a bad idea. As noted at
https://github.com/ReactTraining/react-router/issues/6630#issuecomment-473946064,
that's the internal API, not intended for public consumption, and it
caused Nightmare 3.x to barf.

Refs [STCOR-355](https://issues.folio.org/browse/STCOR-355)