### PR TITLE
Update import of createBrowserHistory to avoid deprecation

### DIFF
--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { combineReducers } from 'redux';
 import { connect } from 'react-redux';
-import createBrowserHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 import { IntlProvider } from 'react-intl';
 import queryString from 'query-string';
 import { ApolloProvider } from 'react-apollo';


### PR DESCRIPTION
This addresses this warning:
```
Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.
```
