### PR TITLE
Load @folio/notes as both app and plugin STCOR-357

### DIFF
--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -172,7 +172,7 @@ function parseAllModules(enabledModules, context, aliases) {
     }
 
     // Interim measure to allow ui-notes to offer both an app and a plugin
-    // until STRIPES-148 is complete. See STRIPES-357
+    // until STCOR-148 is complete. See STCOR-357
     if (parsedModule.config.module === '@folio/notes') {
       const notesConfig = Object.assign({}, parsedModule.config);
       notesConfig.getModule = new Function([], `return require('${moduleName}/src/plugin').default;`); // eslint-disable-line no-new-func

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -170,6 +170,15 @@ function parseAllModules(enabledModules, context, aliases) {
     if (moduleParser.warnings.length) {
       warnings = warnings.concat(moduleParser.warnings);
     }
+
+    // Interim measure to allow ui-notes to offer both an app and a plugin
+    // until STRIPES-148 is complete. See STRIPES-357
+    if (parsedModule.config.module === '@folio/notes') {
+      const notesConfig = Object.assign({}, parsedModule.config);
+      notesConfig.getModule = new Function([], `return require('${moduleName}/src/plugin').default;`); // eslint-disable-line no-new-func
+      notesConfig.pluginType = 'notes';
+      allModuleConfigs.plugin = appendOrSingleton(allModuleConfigs.plugin, notesConfig);
+    }
   });
 
   return {


### PR DESCRIPTION
This is some temporary hardcoding until we have STRIPES-148 providing
this in general for all modules.