### PR TITLE
Stripes 564 verify tree shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "plugins": ["lodash"],
-  "presets": ["env", "stage-2", "react"]
+  "presets": [["env", { modules: false }], "stage-2", "react"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ OVERVIEW.html
 yarn.lock
 yarn-error.log
 artifacts
+dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Resolve memory leaks and improve performance in dev re-builds. Refs STCOR-296.
 * Reduce lodash footprint using [lodash-webpack-plugin](https://www.npmjs.com/package/lodash-webpack-plugin) and [babel-plugin-lodash](https://www.npmjs.com/package/babel-plugin-lodash). Refs STCOR-285.
+* Turned off sideEffects to enable tree-shaking for production builds. Refs STRIPES-564 and STRIPES-581.
 
 ## [3.3.0](https://github.com/folio-org/stripes-core/tree/v3.3.0) (2019-03-28)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.2.0...v3.3.0)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",
+  "sideEffects": ["*.css"],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -50,10 +50,10 @@ class Root extends Component {
   }
 
   componentDidMount() {
-    const { okapi, store, locale } = this.props;
+    const { okapi, store, locale, defaultTranslations } = this.props;
     if (this.withOkapi) checkOkapiSession(okapi.url, store, okapi.tenant);
     // TODO: remove this after we load locale and translations at start from a public endpoint
-    loadTranslations(store, locale);
+    loadTranslations(store, locale, defaultTranslations);
   }
 
   shouldComponentUpdate(nextProps) {
@@ -86,7 +86,7 @@ class Root extends Component {
   }
 
   render() {
-    const { logger, store, epics, config, okapi, actionNames, token, disableAuth, currentUser, currentPerms, locale, timezone, plugins, bindings, discovery, translations, history, serverDown } = this.props;
+    const { logger, store, epics, config, okapi, actionNames, token, disableAuth, currentUser, currentPerms, locale, defaultTranslations, timezone, plugins, bindings, discovery, translations, history, serverDown } = this.props;
 
     if (serverDown) {
       return <div>Error: server is down.</div>;
@@ -109,7 +109,7 @@ class Root extends Component {
       locale,
       timezone,
       metadata,
-      setLocale: (localeValue) => { loadTranslations(store, localeValue); },
+      setLocale: (localeValue) => { loadTranslations(store, localeValue, defaultTranslations); },
       setTimezone: (timezoneValue) => { store.dispatch(setTimezone(timezoneValue)); },
       plugins: plugins || {},
       setSinglePlugin: (key, value) => { store.dispatch(setSinglePlugin(key, value)); },
@@ -167,6 +167,7 @@ Root.propTypes = {
   currentUser: PropTypes.object,
   epics: PropTypes.object,
   locale: PropTypes.string,
+  defaultTranslations: PropTypes.object,
   timezone: PropTypes.string,
   translations: PropTypes.object,
   modules: PropTypes.shape({

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -33,7 +33,7 @@ function getHeaders(tenant, token) {
   };
 }
 
-export function loadTranslations(store, locale) {
+export function loadTranslations(store, locale, defaultTranslations = {}) {
   const parentLocale = locale.split('-')[0];
 
   // react-intl provides things like pt-BR.
@@ -51,11 +51,12 @@ export function loadTranslations(store, locale) {
     .then(intlData => addLocaleData(intlData.default || intlData))
     // fetch the region-specific translations, e.g. pt-BR, if available.
     // fall back to the generic locale, e.g. pt, if not available.
+    // default translations can be passed in if certain strings are not available.
     .then(() => fetch(translations[region] ? translations[region] : translations[parentLocale]))
     .then((response) => {
       if (response.ok) {
         response.json().then((stripesTranslations) => {
-          store.dispatch(setTranslations(stripesTranslations));
+          store.dispatch(setTranslations(Object.assign(stripesTranslations, defaultTranslations)));
           store.dispatch(setLocale(locale));
         });
       }

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -8,7 +8,6 @@ import '@folio/stripes-components/lib/global.css';
 import startMirage from '../network/start';
 
 import App from '../../../src/App';
-import * as actions from '../../../src/okapiActions';
 
 import {
   withModules,
@@ -54,7 +53,8 @@ export default function setupApplication({
       mountId: 'testing-root',
 
       props: {
-        initialState
+        initialState,
+        defaultTranslations: translations
       },
 
       setup: () => {
@@ -63,24 +63,9 @@ export default function setupApplication({
 
         withModules(modules);
         withConfig({ logCategories: '', ...stripesConfig });
-
-        assign(actions, {
-          _setTranslations: null,
-          setTranslations: incoming => {
-            return {
-              type: 'SET_TRANSLATIONS',
-              translations: assign(incoming, translations)
-            };
-          }
-        });
       },
 
       teardown: () => {
-        assign(actions, {
-          setTranslations: actions._setTranslations,
-          _setTranslations: null
-        });
-
         clearConfig();
         clearModules();
         localforage.clear();


### PR DESCRIPTION
- Fulfills [STRIPES-564](https://issues.folio.org/browse/STRIPES-564) and [STRIPES-581](https://issues.folio.org/browse/STRIPES-581).
- Turned off sideEffects for all non-CSS files and switched bundle output from commonJS to ES Modules to support tree-shaking.
- Since ES Modules don't allow overriding or stubbing imports, added `defaultTranslations` as a prop to allow BigTests to continue to pass.
- Added /dist directory to .gitignore.
- Ran bundle analyzer on a hello world UI app to compare bundle sizes.

Before:

![Screen Shot 2019-04-18 at 9 43 24 AM](https://user-images.githubusercontent.com/28395235/56384903-a4b45000-61eb-11e9-87ad-750edd55f057.png)

After:

![Screen Shot 2019-04-18 at 9 43 41 AM](https://user-images.githubusercontent.com/28395235/56384910-a8e06d80-61eb-11e9-9a1b-f12ff353a955.png)