### PR TITLE
sort MainNav apps by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change history for stripes-core
 
-## 3.3.1 (IN-PROGRESS)
+## 3.4.0 (IN-PROGRESS)
 
 * Resolve memory leaks and improve performance in dev re-builds. Refs STCOR-296.
 * Reduce lodash footprint using [lodash-webpack-plugin](https://www.npmjs.com/package/lodash-webpack-plugin) and [babel-plugin-lodash](https://www.npmjs.com/package/babel-plugin-lodash). Refs STCOR-285.
+* Sort apps by name (for predictability until manual ordering is implemented).
 
 ## [3.3.0](https://github.com/folio-org/stripes-core/tree/v3.3.0) (2019-03-28)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.2.0...v3.3.0)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -142,7 +142,9 @@ class MainNav extends Component {
         name,
         ...entry,
       };
-    }).filter(app => app);
+    })
+      .filter(app => app)
+      .sort((a, b) => a.displayName.localeCompare(b.displayName));
 
     /**
      * Add Settings to apps array manually


### PR DESCRIPTION
Previously, apps were listed in whatever order they happened to be
returned by the discovery process, which is unpredictable, which is bad.
Manual ordering would be great, but we don't have that yet. Now, we at
least have predictable ordering.