### PR TITLE
heave ho! hoist non-react statics

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "graphql": "^0.11.7",
     "hard-source-webpack-plugin": "^0.12.0",
     "history": "^4.6.3",
+    "hoist-non-react-statics": "^3.3.0",
     "html-webpack-plugin": "^3.2.0",
     "isomorphic-fetch": "^2.2.1",
     "jwt-decode": "^2.2.0",

--- a/src/StripesContext.js
+++ b/src/StripesContext.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 export const StripesContext = React.createContext();
 
@@ -22,5 +23,6 @@ export function withStripes(WrappedComponent) {
     }
   }
   WithStripes.displayName = `WithStripes(${getDisplayName(WrappedComponent)})`;
-  return WithStripes;
+
+  return hoistNonReactStatics(WithStripes, WrappedComponent);
 }

--- a/src/components/LastVisited/withLastVisited.js
+++ b/src/components/LastVisited/withLastVisited.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { withRouter } from 'react-router';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { withModules } from '../Modules';
 import LastVisitedContext from './LastVisitedContext';
@@ -65,7 +66,7 @@ function withLastVisited(WrappedComponent) {
     }
   }
 
-  return LastVisited;
+  return hoistNonReactStatics(LastVisited, WrappedComponent);
 }
 
 export default compose(

--- a/src/components/MainNav/CurrentApp/AppCtxMenuContext.js
+++ b/src/components/MainNav/CurrentApp/AppCtxMenuContext.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 export const AppCtxMenuContext = React.createContext();
 
@@ -12,5 +13,5 @@ export function withAppCtxMenu(Component) {
       </AppCtxMenuContext.Consumer>
     );
   };
-  return WrappedComponent;
+  return hoistNonReactStatics(WrappedComponent, Component);
 }

--- a/src/components/Modules/withModule.js
+++ b/src/components/Modules/withModule.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import ModulesContext from '../../ModulesContext';
 
 const getDisplayName = (WrappedComponent) => {
@@ -33,6 +34,6 @@ export default function withModule(moduleName) {
       }
     }
     WithModule.displayName = `WithModule(${getDisplayName(WrappedComponent)})`;
-    return WithModule;
+    return hoistNonReactStatics(WithModule, WrappedComponent);
   };
 }

--- a/src/components/Modules/withModules.js
+++ b/src/components/Modules/withModules.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import ModulesContext from '../../ModulesContext';
 
 function getDisplayName(WrappedComponent) {
@@ -16,5 +17,5 @@ export default function withModules(WrappedComponent) {
     }
   }
   WithModules.displayName = `WithModules(${getDisplayName(WrappedComponent)})`;
-  return WithModules;
+  return hoistNonReactStatics(WithModules, WrappedComponent);
 }

--- a/src/stripesConnect.js
+++ b/src/stripesConnect.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import { withStripes } from './StripesContext';
 import { stripesShape } from './Stripes';
 
@@ -18,5 +19,5 @@ export default function stripesConnect(WrappedComponent, options) {
     }
   }
 
-  return withStripes(ConnectedComponent);
+  return withStripes(hoistNonReactStatics(ConnectedComponent, WrappedComponent));
 }


### PR DESCRIPTION
Hoist static assignments from the wrapped component to the exported one.
Huh? Hoist the whatnow? Now hear this:

https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over

> Sometimes it’s useful to define a static method on a React component. For example, Relay containers expose a static method getFragment to facilitate the composition of GraphQL fragments.
> 
> When you apply a HOC to a component, though, the original component is wrapped with a container component. That means the new component does not have any of the static methods of the original component.…
>
> You can use [hoist-non-react-statics](https://github.com/mridgway/hoist-non-react-statics) to automatically copy all non-React static methods:

Refs [UIREQ-256](https://issues.folio.org/browse/UIREQ-256)