### PR TITLE
Prevent <AppIcon> from shrinking

### DIFF
--- a/src/components/AppIcon/AppIcon.css
+++ b/src/components/AppIcon/AppIcon.css
@@ -11,6 +11,7 @@
 .appIcon {
   display: inline-flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 /**


### PR DESCRIPTION
I noticed that the AppIcon would shrink/crop when placed among other elements with a lot of content and therefore competing for space. The AppIcon should never shrink in size so I added flex-shrink: 0; and that fixed it!

## Before
<img width="646" alt="Screenshot 2019-04-29 14 21 55" src="https://user-images.githubusercontent.com/640976/56895982-d4d0de00-6a8a-11e9-9f5a-91cbb92c79ec.png">

## After
<img width="646" alt="Screenshot 2019-04-29 14 22 56" src="https://user-images.githubusercontent.com/640976/56895986-d8fcfb80-6a8a-11e9-9601-1c70ce1fa344.png">
