### PR TITLE
Revert "Load @folio/notes as both app and plugin STCOR-357"

### DIFF
--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -170,15 +170,6 @@ function parseAllModules(enabledModules, context, aliases) {
     if (moduleParser.warnings.length) {
       warnings = warnings.concat(moduleParser.warnings);
     }
-
-    // Interim measure to allow ui-notes to offer both an app and a plugin
-    // until STCOR-148 is complete. See STCOR-357
-    if (parsedModule.config.module === '@folio/notes') {
-      const notesConfig = Object.assign({}, parsedModule.config);
-      notesConfig.getModule = new Function([], `return require('${moduleName}/src/plugin').default;`); // eslint-disable-line no-new-func
-      notesConfig.pluginType = 'notes';
-      allModuleConfigs.plugin = appendOrSingleton(allModuleConfigs.plugin, notesConfig);
-    }
   });
 
   return {


### PR DESCRIPTION
Reverts folio-org/stripes-core#656

According to @Godlevskyi, the functionality planned for the plugin is instead being implemented via stripes-smart-components. This means we don't want this code that specifically looks for -- and cannot find -- the plugin directory in ui-notes. 