### PR TITLE
Minor AppIcon fix

### DIFF
--- a/src/components/AppIcon/AppIcon.css
+++ b/src/components/AppIcon/AppIcon.css
@@ -11,7 +11,6 @@
 .appIcon {
   display: inline-flex;
   align-items: center;
-  flex-shrink: 0;
 }
 
 /**
@@ -31,6 +30,7 @@
  */
 .icon {
   display: inline-block;
+  flex-shrink: 0;
   line-height: 1;
   position: relative;
   opacity: 1;


### PR DESCRIPTION
Moved flex-shrink: 0; to the icon itself instead of the wrapper element in AppIcon. 

This fixes a bug where long texts would stay on one line instead of expanding to multiple lines. This issue was apparent in the results list in various UI modules where text would cut off.

## Before
![image](https://user-images.githubusercontent.com/640976/58480270-52efd580-815a-11e9-888b-ce262c513143.png)

## After
![image](https://user-images.githubusercontent.com/640976/58480190-1623de80-815a-11e9-801a-3b29ac68cc83.png)
