### PR TITLE
Allow modules to be of more than one type. (STCOR-148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 3.6.0 (IN PROGRESS)
+
+* Allow modules to be ingested by stripes-core as more than one type -- the `type` property of the `stripes` section is now replaced by `actsAs` which can be a module type string or an array of them. Also removes redundant copies of the icons, Okapi interfaces, and permissions in the `modules.<type>` structure exposed by the `ModulesContext` as they are kept elsewhere. (STCOR-148)
+
 ## [3.5.1](https://github.com/folio-org/stripes-core/tree/v3.5.1) (2019-05-13)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.5.0...v3.5.1)
 

--- a/src/Pluggable.js
+++ b/src/Pluggable.js
@@ -20,7 +20,7 @@ const Pluggable = (props) => {
 
     if (best) {
       const Child = props.stripes.connect(best.getModule());
-      return <Child {...props} />;
+      return <Child {...props} actAs="plugin" />;
     }
   }
 

--- a/src/components/HandlerManager/HandlerManager.js
+++ b/src/components/HandlerManager/HandlerManager.js
@@ -25,7 +25,7 @@ class HandlerManager extends React.Component {
   render() {
     const { stripes, data, props } = this.props;
     return (this.components.map(Component => (
-      <Component key={Component.name} stripes={stripes} data={data} {...props} />
+      <Component key={Component.name} stripes={stripes} actAs="handler" data={data} {...props} />
     )));
   }
 }

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -19,13 +19,6 @@ import { stripesShape } from '../../Stripes';
 
 import css from './Settings.css';
 
-const getSettingsModules = (modules) => (
-  [].concat(
-    (modules.app || []).filter(m => m.hasSettings),
-    (modules.settings || []),
-  )
-);
-
 class Settings extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
@@ -42,7 +35,7 @@ class Settings extends React.Component {
     super(props);
 
     const { stripes, modules } = props;
-    const settingsModules = getSettingsModules(modules);
+    const settingsModules = modules.settings || [];
 
     this.connectedModules = settingsModules
       .filter(x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`))
@@ -75,7 +68,7 @@ class Settings extends React.Component {
         render={(props2) => (
           <StripesContext.Provider value={moduleStripes}>
             <AddContext context={{ stripes: moduleStripes }}>
-              <Component {...props2} stripes={moduleStripes} showSettings />
+              <Component {...props2} stripes={moduleStripes} showSettings actAs="settings" />
             </AddContext>
             {props2.match.isExact ? <div className={css.panePlaceholder} /> : null}
           </StripesContext.Provider>

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -44,7 +44,7 @@ function getModuleRoutes(stripes) {
                       <div id={`${name}-module-display`} data-module={module.module} data-version={module.version}>
                         <ErrorBoundary>
                           <TitleManager page={displayName}>
-                            <Current {...props} connect={connect} stripes={moduleStripes} />
+                            <Current {...props} connect={connect} stripes={moduleStripes} actAs="app" />
                           </TitleManager>
                         </ErrorBoundary>
                       </div>

--- a/test/webpack/stripes-module-parser.spec.js
+++ b/test/webpack/stripes-module-parser.spec.js
@@ -33,14 +33,14 @@ const welcomePageEntries = [
 ];
 let mockPackageJson;
 
-function getMockPackageJson(type = 'app') {
+function getMockPackageJson(actsAs = 'app') {
   return function (mod) {
     return {
       name: mod,
       description: `description for ${mod}`,
       version: '1.0.0',
       stripes: {
-        type,
+        actsAs,
         displayName: `display name for ${mod}`,
         route: `/${mod}`,
         permissionSets: [],
@@ -75,30 +75,10 @@ describe('The stripes-module-parser', function () {
     });
 
     describe('parseStripesConfig', function () {
-      it('throws StripesBuildError when stripes is missing', function () {
-        delete this.packageJson.stripes;
-        try {
-          this.sut.parseStripesConfig('@folio/users', this.packageJson);
-          expect('never to be called').to.equal(true);
-        } catch (err) {
-          expect(err.message).to.match(/does not have a "stripes" key/);
-        }
-      });
-
-      it('throws StripesBuildError when stripes.type is missing', function () {
-        delete this.packageJson.stripes.type;
-        try {
-          this.sut.parseStripesConfig('@folio/users', this.packageJson);
-          expect('never to be called').to.equal(true);
-        } catch (err) {
-          expect(err.message).to.match(/does not specify stripes\.type/);
-        }
-      });
-
       it('returns a parsed config', function () {
         const result = this.sut.parseStripesConfig('@folio/users', this.packageJson);
         expect(result).to.be.an('object').with.keys(
-          'module', 'getModule', 'description', 'version', 'displayName', 'route', 'permissionSets', 'icons', 'welcomePageEntries',
+          'module', 'getModule', 'description', 'version', 'displayName', 'route', 'welcomePageEntries',
         );
       });
 
@@ -121,6 +101,28 @@ describe('The stripes-module-parser', function () {
           'name', 'version', 'description', 'license', 'feedback', 'type', 'shortTitle', 'fullTitle',
           'defaultPopoverSize', 'defaultPreviewWidth', 'helpPage', 'icons', 'welcomePageEntries',
         );
+      });
+    });
+
+    describe('parseModule', function () {
+      it('throws StripesBuildError when stripes is missing', function () {
+        delete this.sut.packageJson.stripes;
+        try {
+          this.sut.parseModule();
+          expect('never to be called').to.equal(true);
+        } catch (err) {
+          expect(err.message).to.match(/does not have a "stripes" key/);
+        }
+      });
+
+      it('throws StripesBuildError when stripes.actsAs is missing', function () {
+        delete this.sut.packageJson.stripes.actsAs;
+        try {
+          this.sut.parseModule();
+          expect('never to be called').to.equal(true);
+        } catch (err) {
+          expect(err.message).to.match(/does not specify stripes\.actsAs/);
+        }
       });
     });
 
@@ -229,7 +231,7 @@ describe('parseAllModules function', function () {
       const result = this.sut(enabledModules, context, aliases);
       expect(result.config).to.be.an('object').with.property('app').that.is.an('array');
       expect(result.config.app[0]).to.be.an('object').with.keys(
-        'module', 'getModule', 'description', 'version', 'displayName', 'route', 'permissionSets', 'icons', 'welcomePageEntries',
+        'module', 'getModule', 'description', 'version', 'displayName', 'route', 'welcomePageEntries',
       );
     });
 
@@ -247,21 +249,23 @@ describe('parseAllModules function', function () {
     });
   });
 
-  describe('module type is "settings"', function () {
+  describe('module acts as "settings" and "plugin"', function () {
     beforeEach(function () {
-      mockPackageJson = getMockPackageJson('settings');
+      mockPackageJson = getMockPackageJson(['settings', 'plugin']);
       this.sandbox.stub(StripesModuleParser.prototype, 'loadModulePackageJson').callsFake(mockPackageJson);
       this.sandbox.stub(modulePaths, 'tryResolve').returns(true); // Mocks finding all the icon files
       this.sut = parseAllModules;
     });
 
-    it('has empty app as array if there is no app modules provided', function () {
+    it('actsAs settings and plugin produces the expected config of 1 settings, 1 plugin and 0 apps', function () {
       const modules = {
         '@folio/myprofile': {},
       };
 
       const result = this.sut(modules, context, aliases);
       expect(result.config.app).to.be.an('array').with.lengthOf(0);
+      expect(result.config.settings).to.be.an('array').with.lengthOf(1);
+      expect(result.config.plugin).to.be.an('array').with.lengthOf(1);
     });
   });
 });

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -49,8 +49,16 @@ class StripesModuleParser {
     if (!Array.isArray(actsAs)) {
       if (typeof actsAs === 'string') actsAs = [actsAs];
       else if (typeof stripes.type === 'string') {
+        this.warnings.push(`Module ${this.moduleName} uses deprecated "type" property. Prefer "actsAs".`);
         actsAs = [stripes.type];
-        if (stripes.hasSettings) actsAs.push('settings');
+        if (stripes.hasSettings) {
+          this.warnings.push(`Module ${this.moduleName} uses deprecated "hasSettings" property. Instead, add "settings" to the "actsAs" array and render your settings component when your main component is passed the prop 'actAs="settings"'.`);
+          actsAs.push('settings');
+        }
+        if (stripes.handlerName) {
+          this.warnings.push(`Module ${this.moduleName} uses deprecated "handlerName" property. Instead, add "handler" to the "actsAs" array and render your handler component when your main component is passed the prop 'actAs="handler"'.`);
+          actsAs.push('settings');
+        }
       } else {
         throw new StripesBuildError(`Included module ${this.moduleName} does not specify stripes.actsAs in package.json`);
       }

--- a/webpack/stripes-module-parser.js
+++ b/webpack/stripes-module-parser.js
@@ -4,6 +4,9 @@ const modulePaths = require('./module-paths');
 const StripesBuildError = require('./stripes-build-error');
 const logger = require('./logger')('stripesModuleParser');
 
+// These config keys do not get exported with type-specific config
+const TOP_LEVEL_ONLY = ['permissions', 'icons', 'okapiInterfaces', 'permissionSets', 'actsAs', 'type', 'hasSettings'];
+
 function appendOrSingleton(maybeArray, newValue) {
   const singleton = [newValue];
   if (Array.isArray(maybeArray)) return maybeArray.concat(singleton);
@@ -36,9 +39,26 @@ class StripesModuleParser {
 
   // Wrapper to source data and transform into collections (config and metadata)
   parseModule() {
+    const stripes = this.packageJson.stripes;
+    if (!_.isObject(stripes)) {
+      throw new StripesBuildError(`Included module ${this.moduleName} does not have a "stripes" key in package.json`);
+    }
+
+    // Upgrade string actsAs to singleton array and provide compatibility for deprecated options
+    let actsAs = stripes.actsAs;
+    if (!Array.isArray(actsAs)) {
+      if (typeof actsAs === 'string') actsAs = [actsAs];
+      else if (typeof stripes.type === 'string') {
+        actsAs = [stripes.type];
+        if (stripes.hasSettings) actsAs.push('settings');
+      } else {
+        throw new StripesBuildError(`Included module ${this.moduleName} does not specify stripes.actsAs in package.json`);
+      }
+    }
+
     return {
       name: this.nameOnly,
-      type: this.packageJson.stripes.type,
+      actsAs,
       config: this.config || this.parseStripesConfig(this.moduleName, this.packageJson),
       metadata: this.metadata || this.parseStripesMetadata(this.packageJson),
     };
@@ -50,20 +70,12 @@ class StripesModuleParser {
   parseStripesConfig(moduleName, packageJson) {
     const { stripes, description, version } = packageJson;
 
-    if (!_.isObject(stripes)) {
-      throw new StripesBuildError(`Included module ${moduleName} does not have a "stripes" key in package.json`);
-    }
-    if (!_.isString(stripes.type)) {
-      throw new StripesBuildError(`Included module ${moduleName} does not specify stripes.type in package.json`);
-    }
-
-    const stripeConfig = Object.assign({}, stripes, this.overrideConfig, {
+    const stripeConfig = _.omit(Object.assign({}, stripes, this.overrideConfig, {
       module: moduleName,
       getModule: new Function([], `return require('${moduleName}').default;`), // eslint-disable-line no-new-func
       description,
       version,
-    });
-    delete stripeConfig.type;
+    }), TOP_LEVEL_ONLY);
     logger.log('config:', stripeConfig);
     return stripeConfig;
   }
@@ -165,7 +177,9 @@ function parseAllModules(enabledModules, context, aliases) {
   _.forOwn(enabledModules, (overrideConfig, moduleName) => {
     const moduleParser = new StripesModuleParser(moduleName, overrideConfig, context, aliases);
     const parsedModule = moduleParser.parseModule();
-    allModuleConfigs[parsedModule.type] = appendOrSingleton(allModuleConfigs[parsedModule.type], parsedModule.config);
+    parsedModule.actsAs.forEach(type => {
+      allModuleConfigs[type] = appendOrSingleton(allModuleConfigs[parsedModule.actsAs], parsedModule.config);
+    });
     allMetadata[parsedModule.name] = parsedModule.metadata;
     if (moduleParser.warnings.length) {
       warnings = warnings.concat(moduleParser.warnings);


### PR DESCRIPTION
Allow modules to be ingested by stripes-core as more than one type -- the `type` property of the `stripes` section is now replaced by `actsAs` which can be a module type string or an array of them. Also removes redundant copies of the icons, Okapi interfaces, and permissions in the `modules.<type>` structure exposed by the `ModulesContext` as they are kept elsewhere.