### PR TITLE
Allow home-page welcome message to be customised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.7.0] (in progress)
 
 * Pass locale to Moment.js so weekdays, etc. are translated. (STCOM-512)
+* Allow home-page welcome message to be customised by setting `config.welcomeMessage` to the name of a translation tag.
 
 ## [3.6.0](https://github.com/folio-org/stripes-core/tree/v3.6.0) (2019-06-07)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.5.1...v3.6.0)

--- a/src/components/Front.js
+++ b/src/components/Front.js
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Headline from '@folio/stripes-components/lib/Headline';
@@ -8,18 +9,27 @@ import Pluggable from '../Pluggable';
 import css from './Front.css';
 import AddContext from '../AddContext';
 
-const Front = ({ stripes }) => (
-  <AddContext context={{ stripes }}>
-    <Pluggable type="frontpage">
-      <div className={css.frontWrap}>
-        <Headline faded tag="h1" margin="none" className={css.frontTitle}><FormattedMessage id="stripes-core.front.welcome" /></Headline>
-      </div>
-    </Pluggable>
-  </AddContext>
-);
+const Front = ({ stripes }) => {
+  const tag = get(stripes, 'config.welcomeMessage') || 'stripes-core.front.welcome';
+
+  return (
+    <AddContext context={{ stripes }}>
+      <Pluggable type="frontpage">
+        <div className={css.frontWrap}>
+          <Headline faded tag="h1" margin="none" className={css.frontTitle}><FormattedMessage id={tag} /></Headline>
+        </div>
+      </Pluggable>
+    </AddContext>
+  );
+};
+
 
 Front.propTypes = {
-  stripes: PropTypes.object.isRequired,
+  stripes: PropTypes.shape({
+    config: PropTypes.shape({
+      welcomeMessage: PropTypes.string,
+    }),
+  }),
 };
 
 export default Front;


### PR DESCRIPTION
You do this by setting `config.welcomeMessage` in your Stripes configuration, e.g. the `stripes.config.js` file. The value of this setting is the name of a translation tag, which is looked up and translated as usual.

In the absence of this setting, the old behaviour remains.