### PR TITLE
STRIPES-641: MainNav updates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 examples/trivial/node_modules/*
+dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.8.0 (IN PROGRESS)
 
 * Receive React as a peerDependency (provide by `stripes`). One dep to rule them all. Refs UIIN-678.
+* Updated MainNav design to improve color contrast (STCOR-378)
 
 ## [3.7.0](https://github.com/folio-org/stripes-core/tree/v3.7.0) (2019-07-22)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.6.0...v3.7.0)

--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -94,6 +94,14 @@
   display: none;
 }
 
+[dir=ltr] .navItem:not(:first-child) {
+  margin-left: var(--gutter-static-two-thirds);
+}
+
+[dir=rtl] .navItem:not(:first-child) {
+  margin-right: var(--gutter-static-two-thirds);
+}
+
 /**
  * Responsive
  */

--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -94,12 +94,12 @@
   display: none;
 }
 
-[dir=ltr] .navItem:not(:first-child) {
-  margin-left: var(--gutter-static-two-thirds);
+[dir=ltr] .navItem:not(:last-child) {
+  margin-right: var(--gutter-static-two-thirds);
 }
 
-[dir=rtl] .navItem:not(:first-child) {
-  margin-right: var(--gutter-static-two-thirds);
+[dir=rtl] .navItem:not(:last-child) {
+  margin-left: var(--gutter-static-two-thirds);
 }
 
 /**

--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -71,7 +71,7 @@
 .dropdownListItemLabel {
   padding: 0 4px;
   min-width: 200px;
-  font-weight: 600;
+  font-weight: var(--text-weight-bold);
 }
 
 [dir="rtl"] .dropdownListItemLabel {

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -84,7 +84,7 @@ class AppList extends Component {
           label={app.displayName}
           id={app.id}
           selected={app.active}
-          href={app.active ? null : app.href}
+          href={app.href}
           aria-label={app.displayName}
           iconKey={app.name}
           iconData={app.iconData}

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -6,16 +6,21 @@
 
 .button {
   opacity: 1;
+  padding: 0 var(--gutter-static-two-thirds);
 }
 
 .button .button__inner {
-  padding: 0 var(--gutter-static-one-third);
+  padding: 0;
 }
 
 [dir="ltr"] .button .button__label {
-  margin-left: var(--gutter-static-two-thirds);
+  margin-left: var(--gutter-static-one-third);
 }
 
 [dir="rtl"] .button .button__label {
-  margin-right: var(--gutter-static-two-thirds);
+  margin-right: var(--gutter-static-one-third);
+}
+
+.button .button__label__inner {
+  font-size: 1.86rem;
 }

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -4,13 +4,14 @@
 
 :root {
   --main-nav-current-app-label-font-weight: 900;
+  --main-nav-current-app-label-color: #fff;
   --main-nav-current-app-negative-margin: calc(var(--gutter-static-two-thirds) * -1);
 }
 
 button.button,
 a.button {
   font-weight: var(--main-nav-current-app-label-font-weight);
-  color: #FFF;
+  color: var(--main-nav-current-app-label-color);
 }
 
 [dir="ltr"] .button {

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -8,12 +8,6 @@
   --main-nav-current-app-negative-margin: calc(var(--gutter-static-two-thirds) * -1);
 }
 
-button.button,
-a.button {
-  font-weight: var(--main-nav-current-app-label-font-weight);
-  color: var(--main-nav-current-app-label-color);
-}
-
 [dir="ltr"] .button {
   margin-left: var(--main-nav-current-app-negative-margin);
 }
@@ -22,10 +16,11 @@ a.button {
   margin-right: var(--main-nav-current-app-negative-margin);
 }
 
-.button__inner {
+.button .button__inner {
   padding: 0;
 }
 
 .button .button__label {
   font-weight: var(--main-nav-current-app-label-font-weight);
+  color: var(--main-nav-current-app-label-color);
 }

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -2,19 +2,29 @@
  * CurrentApp
  */
 
+:root {
+  --main-nav-current-app-label-font-weight: 900;
+  --main-nav-current-app-negative-margin: calc(var(--gutter-static-two-thirds) * -1);
+}
+
 button.button,
 a.button {
+  font-weight: var(--main-nav-current-app-label-font-weight);
   color: #FFF;
 }
 
 [dir="ltr"] .button {
-  margin-left: calc(var(--gutter-static-two-thirds) * -1);
+  margin-left: var(--main-nav-current-app-negative-margin);
 }
 
 [dir="rtl"] .button {
-  margin-right: calc(var(--gutter-static-two-thirds) * -1);
+  margin-right: var(--main-nav-current-app-negative-margin);
 }
 
 .button__inner {
   padding: 0;
+}
+
+.button .button__label {
+  font-weight: var(--main-nav-current-app-label-font-weight);
 }

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -2,25 +2,20 @@
  * CurrentApp
  */
 
-:root {
-  --main-nav-current-app-label-font-weight: 900;
-  --main-nav-current-app-label-color: #fff;
-  --main-nav-current-app-negative-margin: calc(var(--gutter-static-two-thirds) * -1);
-}
+@import "@folio/stripes-components/lib/variables.css";
 
-[dir="ltr"] .button {
-  margin-left: var(--main-nav-current-app-negative-margin);
-}
-
-[dir="rtl"] .button {
-  margin-right: var(--main-nav-current-app-negative-margin);
+.button {
+  opacity: 1;
 }
 
 .button .button__inner {
-  padding: 0;
+  padding: 0 var(--gutter-static-one-third);
 }
 
-.button .button__label {
-  font-weight: var(--main-nav-current-app-label-font-weight);
-  color: var(--main-nav-current-app-label-color);
+[dir="ltr"] .button .button__label {
+  margin-left: var(--gutter-static-two-thirds);
+}
+
+[dir="rtl"] .button .button__label {
+  margin-right: var(--gutter-static-two-thirds);
 }

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -14,11 +14,11 @@
 }
 
 [dir="ltr"] .button .button__label {
-  margin-left: var(--gutter-static-one-third);
+  margin-left: 0.6rem;
 }
 
 [dir="rtl"] .button .button__label {
-  margin-right: var(--gutter-static-one-third);
+  margin-right: 0.6rem;
 }
 
 .button .button__label__inner {

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -1,0 +1,7 @@
+/**
+ * CurrentApp
+ */
+
+.button__inner {
+  padding: 0;
+}

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -5,7 +5,7 @@
 @import "@folio/stripes-components/lib/variables.css";
 
 .button {
-  opacity: 1;
+  opacity: 1 !important;
   padding: 0 var(--gutter-static-two-thirds);
 }
 

--- a/src/components/MainNav/CurrentApp/CurrentApp.css
+++ b/src/components/MainNav/CurrentApp/CurrentApp.css
@@ -2,6 +2,19 @@
  * CurrentApp
  */
 
+button.button,
+a.button {
+  color: #FFF;
+}
+
+[dir="ltr"] .button {
+  margin-left: calc(var(--gutter-static-two-thirds) * -1);
+}
+
+[dir="rtl"] .button {
+  margin-right: calc(var(--gutter-static-two-thirds) * -1);
+}
+
 .button__inner {
   padding: 0;
 }

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -43,7 +43,9 @@ const CurrentApp = ({ currentApp, id, intl, badge }) => {
       ariaLabel={ariaLabel}
       badge={badge}
       iconKey={name}
+      className={css.button}
       innerClassName={css.button__inner}
+      labelClassName={css.button__label}
       href={href}
       iconData={iconData}
     />

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import Headline from '@folio/stripes-components/lib/Headline';
 import NavButton from '../NavButton';
+import css from './CurrentApp.css';
 
 const propTypes = {
   currentApp: PropTypes.shape(
@@ -37,11 +38,12 @@ const CurrentApp = ({ currentApp, id, intl, badge }) => {
 
   return (
     <NavButton
-      label={<Headline tag="h1" size="small" margin="none">{displayName}</Headline>}
+      label={<Headline tag="h1" size="x-large" margin="none">{displayName}</Headline>}
       id={id}
       ariaLabel={ariaLabel}
       badge={badge}
       iconKey={name}
+      innerClassName={css.button__inner}
       href={href}
       iconData={iconData}
     />

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -38,14 +38,22 @@ const CurrentApp = ({ currentApp, id, intl, badge }) => {
 
   return (
     <NavButton
-      label={<Headline tag="h1" size="x-large" margin="none">{displayName}</Headline>}
+      label={
+        <Headline
+          tag="h1"
+          size="x-large"
+          margin="none"
+          className={css.button__label}
+        >
+          {displayName}
+        </Headline>
+      }
       id={id}
       ariaLabel={ariaLabel}
       badge={badge}
       iconKey={name}
       className={css.button}
       innerClassName={css.button__inner}
-      labelClassName={css.button__label}
       href={href}
       iconData={iconData}
     />

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -41,9 +41,9 @@ const CurrentApp = ({ currentApp, id, intl, badge }) => {
       label={
         <Headline
           tag="h1"
-          size="x-large"
           margin="none"
           weight="black"
+          className={css.button__label__inner}
         >
           {displayName}
         </Headline>

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -43,7 +43,7 @@ const CurrentApp = ({ currentApp, id, intl, badge }) => {
           tag="h1"
           size="x-large"
           margin="none"
-          className={css.button__label}
+          weight="black"
         >
           {displayName}
         </Headline>
@@ -54,6 +54,7 @@ const CurrentApp = ({ currentApp, id, intl, badge }) => {
       iconKey={name}
       className={css.button}
       innerClassName={css.button__inner}
+      labelClassName={css.button__label}
       href={href}
       iconData={iconData}
     />

--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -1,12 +1,13 @@
 @import '@folio/stripes-components/lib/variables.css';
 
 .navRoot {
+  background-color: #383838;
+  color: #FFF;
   display: flex;
   justify-content: space-between;
   align-content: stretch;
   width: 100%;
   border-bottom: 1px solid var(--color-border);
-  background-color: #f7f7f7;
   flex: 0 0 auto;
   padding: 0 6px;
   z-index: 99999;

--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -3,11 +3,12 @@
 :root {
   --main-nav-min-height: 50px;
   --main-nav-background-color: #383838;
+  --main-nav-text-color: #fff;
 }
 
 .navRoot {
   background-color: var(--main-nav-background-color);
-  color: #FFF;
+  color: var(--main-nav-text-color);
   display: flex;
   justify-content: space-between;
   align-content: stretch;

--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -3,8 +3,8 @@
 :root {
   --main-nav-min-height-desktop: 56px;
   --main-nav-min-height-mobile: 48px;
-  --main-nav-border-bottom-color: #131313;
-  --main-nav-background-color: #383838;
+  --main-nav-border-bottom-color: rgba(0, 0, 0, 0.9);
+  --main-nav-background-color: rgba(0, 0, 0, 0.8);
   --main-nav-text-color: #fff;
 }
 

--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -1,13 +1,16 @@
 @import '@folio/stripes-components/lib/variables.css';
 
 :root {
-  --main-nav-min-height: 50px;
+  --main-nav-min-height-desktop: 56px;
+  --main-nav-min-height-mobile: 48px;
+  --main-nav-border-bottom-color: #131313;
   --main-nav-background-color: #383838;
   --main-nav-text-color: #fff;
 }
 
 .navRoot {
   background-color: var(--main-nav-background-color);
+  border-bottom: 1px solid var(--main-nav-border-bottom-color);
   color: var(--main-nav-text-color);
   display: flex;
   justify-content: space-between;
@@ -16,7 +19,7 @@
   width: 100%;
   flex: 0 0 auto;
   padding: 0 var(--gutter-static-one-third);
-  min-height: var(--main-nav-min-height);
+  min-height: var(--main-nav-min-height-desktop);
   z-index: 99999;
   position: relative;
 }
@@ -41,5 +44,9 @@
 @media (--medium-down) {
   .brandingLabel {
     display: none;
+  }
+
+  .navRoot {
+    min-height: var(--main-nav-min-height-mobile);
   }
 }

--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -1,15 +1,21 @@
 @import '@folio/stripes-components/lib/variables.css';
 
+:root {
+  --main-nav-min-height: 50px;
+}
+
 .navRoot {
   background-color: #383838;
   color: #FFF;
   display: flex;
   justify-content: space-between;
   align-content: stretch;
+  align-items: center;
   width: 100%;
   border-bottom: 1px solid var(--color-border);
   flex: 0 0 auto;
-  padding: 0 6px;
+  padding: 0 var(--gutter-static-one-third);
+  min-height: var(--main-nav-min-height);
   z-index: 99999;
   position: relative;
 }

--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -2,17 +2,17 @@
 
 :root {
   --main-nav-min-height: 50px;
+  --main-nav-background-color: #383838;
 }
 
 .navRoot {
-  background-color: #383838;
+  background-color: var(--main-nav-background-color);
   color: #FFF;
   display: flex;
   justify-content: space-between;
   align-content: stretch;
   align-items: center;
   width: 100%;
-  border-bottom: 1px solid var(--color-border);
   flex: 0 0 auto;
   padding: 0 var(--gutter-static-one-third);
   min-height: var(--main-nav-min-height);

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -3,6 +3,7 @@
 :root {
   --main-nav-button-font-size: 1rem;
   --main-nav-button-label-spacing: 6px;
+  --main-nav-button-padding: 0.52rem;
   --main-nav-button-min-height: var(--control-min-size-touch);
   --main-nav-button-color: #fff;
 }
@@ -31,6 +32,10 @@
       background-color: var(--primary);
     }
   }
+}
+
+.isInteractable {
+  composes: interactionStyles from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
 }
 
 /* To make sure we overwrite default link colors */
@@ -76,11 +81,12 @@ button.navButton {
 
 .inner {
   position: relative;
-  padding: var(--gutter-static-one-third) 0;
+  padding: var(--main-nav-button-padding) 0;
 }
 
-.isInteractable {
-  composes: interactionStyles boxOffsetStartSmall boxOffsetEndSmall from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
+.navButton .inner::before {
+  left: calc(var(--main-nav-button-padding) * -1);
+  right: calc(var(--main-nav-button-padding) * -1);
 }
 
 /**

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -26,6 +26,7 @@
 
   &.selected {
     opacity: 1;
+
     & .inner::before {
       background-color: var(--primary);
     }

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -1,21 +1,22 @@
 @import '@folio/stripes-components/lib/variables.css';
 
+:root {
+  --main-nav-button-font-size: 1.05rem;
+  --main-nav-button-label-spacing: 6px;
+  --main-nav-button-min-height: var(--control-min-size-touch);
+  --main-nav-button-color: rgba(255, 255, 255, 0.75);
+  --main-nav-button-active-color: #FFF;
+}
+
 .navButton {
   composes: interactionStylesControl from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
-  padding: 0 var(--gutter-static-one-third);
-  height: var(--control-min-size-touch);
+  padding: 0 var(--gutter-static-two-thirds);
+  min-height: var(--main-nav-button-min-height);
+  font-size: var(--main-nav-button-font-size);
   outline: 0;
-  color: #FFF;
-  font-size: var(--font-size-medium);
 
   &::-moz-focus-inner {
     border: 0;
-  }
-
-  &.selected .label,
-  &:focus .label,
-  &:hover .label {
-    opacity: 1;
   }
 
   &.selected .inner:before {
@@ -26,11 +27,16 @@
 /* To make sure we overwrite default link colors */
 a.navButton,
 button.navButton {
-  color: #FFF;
+  color: var(--main-nav-button-color);
+
+  &.selected,
+  &:focus,
+  &:hover {
+    color: var(--main-nav-button-active-color);
+  }
 }
 
 .icon {
-  margin: 0 4px;
   display: flex;
 
   & svg {
@@ -52,20 +58,26 @@ button.navButton {
 }
 
 .label {
-  margin: 0 var(--gutter-static-one-third);
   font-weight: 600;
   display: flex;
   align-items: center;
-  opacity: 0.8;
+}
+
+[dir="ltr"] .label {
+  margin-left: var(--main-nav-button-label-spacing);
+}
+
+[dir="rtl"] .label {
+  margin-right: var(--main-nav-button-label-spacing);
 }
 
 .inner {
-  padding: var(--gutter-static-one-third);
   position: relative;
+  padding: var(--gutter-static-one-third) 0;
 }
 
 .isInteractable {
-  composes: interactionStyles from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
+  composes: interactionStyles boxOffsetStartSmall boxOffsetEndSmall from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
 }
 
 /**

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -58,7 +58,7 @@ button.navButton {
 }
 
 .label {
-  font-weight: 600;
+  font-weight: var(--text-weight-bold);
   display: flex;
   align-items: center;
 }

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -2,45 +2,31 @@
 
 .navButton {
   composes: interactionStylesControl from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
-  padding: 0 5px;
-  height: 44px;
+  padding: 0 var(--gutter-static-one-third);
+  height: var(--control-min-size-touch);
   outline: 0;
-  color: var(--color-text);
-  font-size: var(--font-size-small);
+  color: #FFF;
+  font-size: var(--font-size-medium);
 
   &::-moz-focus-inner {
     border: 0;
   }
 
-  /* Is selected */
-  &.selected {
-    &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      right: 5px;
-      left: 5px;
-      height: 4px;
-      background-color: var(--primary);
-      border-bottom-left-radius: 3px;
-      border-bottom-right-radius: 3px;
-    }
+  &.selected .label,
+  &:focus .label,
+  &:hover .label {
+    opacity: 1;
   }
-}
 
-.navButton:not(:active).selected .icon svg {
-  fill: var(--primary);
+  &.selected .inner:before {
+    background-color: var(--primary);
+  }
 }
 
 /* To make sure we overwrite default link colors */
 a.navButton,
 button.navButton {
-  color: var(--color-text);
-}
-
-/* No active bar - primarily used for popover icons with no label */
-.navButton.noSelectedBar::before {
-  display: none;
+  color: #FFF;
 }
 
 .icon {
@@ -48,7 +34,7 @@ button.navButton {
   display: flex;
 
   & svg {
-    fill: var(--color-icon);
+    fill: currentColor;
   }
 }
 
@@ -66,14 +52,15 @@ button.navButton {
 }
 
 .label {
-  margin: 0 4px;
+  margin: 0 var(--gutter-static-one-third);
   font-weight: 600;
   display: flex;
   align-items: center;
+  opacity: 0.8;
 }
 
 .inner {
-  padding: 4px 0;
+  padding: var(--gutter-static-one-third);
   position: relative;
 }
 

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -1,26 +1,34 @@
 @import '@folio/stripes-components/lib/variables.css';
 
 :root {
-  --main-nav-button-font-size: 1.05rem;
+  --main-nav-button-font-size: 1rem;
   --main-nav-button-label-spacing: 6px;
   --main-nav-button-min-height: var(--control-min-size-touch);
-  --main-nav-button-color: rgba(255, 255, 255, 0.75);
-  --main-nav-button-active-color: #fff;
+  --main-nav-button-color: #fff;
 }
 
 .navButton {
   composes: interactionStylesControl from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
-  padding: 0 var(--gutter-static-two-thirds);
+  padding: 0 var(--gutter-static-one-third);
   min-height: var(--main-nav-button-min-height);
   font-size: var(--main-nav-button-font-size);
   outline: 0;
+  opacity: 0.75;
 
   &::-moz-focus-inner {
     border: 0;
   }
 
-  &.selected .inner::before {
-    background-color: var(--primary);
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
+
+  &.selected {
+    opacity: 1;
+    & .inner::before {
+      background-color: var(--primary);
+    }
   }
 }
 
@@ -28,12 +36,6 @@
 a.navButton,
 button.navButton {
   color: var(--main-nav-button-color);
-
-  &.selected,
-  &:focus,
-  &:hover {
-    color: var(--main-nav-button-active-color);
-  }
 }
 
 .icon {

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -5,7 +5,7 @@
   --main-nav-button-label-spacing: 6px;
   --main-nav-button-min-height: var(--control-min-size-touch);
   --main-nav-button-color: rgba(255, 255, 255, 0.75);
-  --main-nav-button-active-color: #FFF;
+  --main-nav-button-active-color: #fff;
 }
 
 .navButton {
@@ -19,7 +19,7 @@
     border: 0;
   }
 
-  &.selected .inner:before {
+  &.selected .inner::before {
     background-color: var(--primary);
   }
 }
@@ -95,6 +95,6 @@ button.navButton {
  * AppIcon
  */
 
-.appIcon > span:after {
+.appIcon > span::after {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -90,3 +90,11 @@ button.navButton {
   right: -1px;
   z-index: 5;
 }
+
+/**
+ * AppIcon
+ */
+
+.appIcon > span:after {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -3,7 +3,7 @@
 :root {
   --main-nav-button-font-size: 1rem;
   --main-nav-button-label-spacing: 6px;
-  --main-nav-button-padding: 0.52rem;
+  --main-nav-button-padding: 0.53rem;
   --main-nav-button-min-height: var(--control-min-size-touch);
   --main-nav-button-color: #fff;
 }

--- a/src/components/MainNav/NavButton/NavButton.js
+++ b/src/components/MainNav/NavButton/NavButton.js
@@ -66,7 +66,19 @@ const NavButton = React.forwardRef(({
   /**
    * Icon
    */
-  const renderedIcon = (<span className={css.icon}>{icon || <AppIcon alt="" app={iconKey} icon={iconData} focusable={false} />}</span>);
+  const renderedIcon = (
+    <span className={css.icon}>
+      {icon || (
+        <AppIcon
+          alt=""
+          app={iconKey}
+          icon={iconData}
+          focusable={false}
+          className={css.appIcon}
+        />
+      )}
+    </span>
+  );
 
   let Element = 'span';
   let clickableProps = {};

--- a/src/components/MainNav/NavButton/NavButton.js
+++ b/src/components/MainNav/NavButton/NavButton.js
@@ -20,6 +20,7 @@ const propTypes = {
   icon: PropTypes.oneOfType([
     PropTypes.element,
   ]),
+  innerClassName: PropTypes.string,
   labelClassName: PropTypes.string,
   badge: PropTypes.oneOfType([
     PropTypes.string,
@@ -34,7 +35,24 @@ const defaultProps = {
   noSelectedBar: false,
 };
 
-const NavButton = React.forwardRef(({ ariaLabel, label, title, selected, onClick, href, icon, noSelectedBar, className, labelClassName, badge, id, iconKey, iconData, ...rest }, ref) => {
+const NavButton = React.forwardRef(({
+  ariaLabel,
+  label,
+  title,
+  selected,
+  onClick,
+  href,
+  icon,
+  innerClassName,
+  noSelectedBar,
+  className,
+  labelClassName,
+  badge,
+  id,
+  iconKey,
+  iconData,
+  ...rest
+}, ref) => {
   /**
    * Root classes
    */
@@ -75,7 +93,7 @@ const NavButton = React.forwardRef(({ ariaLabel, label, title, selected, onClick
 
   return (
     <Element ref={ref} id={id} aria-label={ariaLabel || title} className={rootClasses} {...rest} {...clickableProps}>
-      <span className={classNames(css.inner, { [css.isInteractable]: href || onClick })}>
+      <span className={classNames(css.inner, { [css.isInteractable]: href || onClick }, innerClassName)}>
         { badge && (<Badge color="red" className={css.badge}>{badge}</Badge>) }
         { renderedIcon }
         { label && <span className={classNames(css.label, labelClassName)}>{label}</span>}

--- a/src/components/MainNav/NavDivider/NavDivider.css
+++ b/src/components/MainNav/NavDivider/NavDivider.css
@@ -1,7 +1,7 @@
 @import '@folio/stripes-components/lib/variables.css';
 
 .navDivider {
-  border-left: 1px solid var(--color-border-p2);
+  border-left: 1px solid rgba(255, 255, 255, 0.2);
   height: 24px;
   margin: 0 5px;
 }

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.css
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.css
@@ -16,7 +16,7 @@
 }
 
 /* Avatar */
-.avatar {
+.button .avatar {
   border: 0;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
   background-color: rgba(255, 255, 255, 0.4);

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.css
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.css
@@ -18,5 +18,6 @@
 /* Avatar */
 .avatar {
   border: 0;
-  box-shadow: inset 0 0 0 1px var(--color-border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.4);
 }

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -229,6 +229,7 @@ class ProfileDropdown extends Component {
                 data-role="toggle"
                 ariaLabel={intl.formatMessage({ id: 'stripes-core.mainnav.myProfileAriaLabel' })}
                 selected={dropdownOpen}
+                className={css.button}
                 icon={this.getProfileImage()}
               />
               <NavDropdownMenu data-role="menu" onToggle={this.toggleDropdown}>

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -227,7 +227,7 @@ class ProfileDropdown extends Component {
             <Dropdown open={dropdownOpen} id="profileDropdown" onToggle={this.toggleDropdown} pullRight hasPadding>
               <NavButton
                 data-role="toggle"
-                ariaLabel={intl.formatMessage({ id: 'stripes-core.mainnav.myProfileAriaLabel' })} 
+                ariaLabel={intl.formatMessage({ id: 'stripes-core.mainnav.myProfileAriaLabel' })}
                 selected={dropdownOpen} 
                 icon={this.getProfileImage()} 
               />

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -220,15 +220,24 @@ class ProfileDropdown extends Component {
     const { dropdownOpen, HandlerComponent } = this.state;
 
     return (
-      <Fragment>
-        { HandlerComponent && <HandlerComponent stripes={this.props.stripes} /> }
-        <Dropdown open={dropdownOpen} id="profileDropdown" onToggle={this.toggleDropdown} pullRight hasPadding>
-          <NavButton data-role="toggle" ariaLabel="My Profile" selected={dropdownOpen} icon={this.getProfileImage()} noSelectedBar />
-          <NavDropdownMenu data-role="menu" onToggle={this.toggleDropdown}>
-            {this.getDropdownContent()}
-          </NavDropdownMenu>
-        </Dropdown>
-      </Fragment>
+      <IntlConsumer>
+        {intl => (
+          <Fragment>
+            { HandlerComponent && <HandlerComponent stripes={this.props.stripes} /> }
+            <Dropdown open={dropdownOpen} id="profileDropdown" onToggle={this.toggleDropdown} pullRight hasPadding>
+              <NavButton
+                data-role="toggle"
+                ariaLabel={intl.formatMessage({ id: 'stripes-core.mainnav.myProfileAriaLabel' })} 
+                selected={dropdownOpen} 
+                icon={this.getProfileImage()} 
+              />
+              <NavDropdownMenu data-role="menu" onToggle={this.toggleDropdown}>
+                {this.getDropdownContent()}
+              </NavDropdownMenu>
+            </Dropdown>
+          </Fragment>
+        )}
+      </IntlConsumer>
     );
   }
 }

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -228,8 +228,8 @@ class ProfileDropdown extends Component {
               <NavButton
                 data-role="toggle"
                 ariaLabel={intl.formatMessage({ id: 'stripes-core.mainnav.myProfileAriaLabel' })}
-                selected={dropdownOpen} 
-                icon={this.getProfileImage()} 
+                selected={dropdownOpen}
+                icon={this.getProfileImage()}
               />
               <NavDropdownMenu data-role="menu" onToggle={this.toggleDropdown}>
                 {this.getDropdownContent()}

--- a/src/components/SystemSkeleton/SystemSkeleton.css
+++ b/src/components/SystemSkeleton/SystemSkeleton.css
@@ -82,6 +82,7 @@
   .hideOnSmallScreens {
     display: none;
   }
+
   .skeletonHeader {
     height: 48px;
   }

--- a/src/components/SystemSkeleton/SystemSkeleton.css
+++ b/src/components/SystemSkeleton/SystemSkeleton.css
@@ -64,7 +64,7 @@
 
 .skeletonHeader {
   padding: 0 8px;
-  height: 43px;
+  height: 50px;
   background-color: var(--color-fill);
   border-bottom: 1px solid var(--color-border-p2);
   justify-content: space-between;

--- a/src/components/SystemSkeleton/SystemSkeleton.css
+++ b/src/components/SystemSkeleton/SystemSkeleton.css
@@ -64,7 +64,7 @@
 
 .skeletonHeader {
   padding: 0 8px;
-  height: 50px;
+  height: 56px;
   background-color: var(--color-fill);
   border-bottom: 1px solid var(--color-border-p2);
   justify-content: space-between;
@@ -81,5 +81,8 @@
 @media (--medium-down) {
   .hideOnSmallScreens {
     display: none;
+  }
+  .skeletonHeader {
+    height: 48px;
   }
 }

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -95,6 +95,7 @@
   "mainnav.topLevelLabel": "Primary",
   "mainnav.applicationListLabel": "Application List",
   "mainnav.appContextMenu": "Application context dropdown",
+  "mainnav.myProfileAriaLabel": "My profile",
 
   "errors.default.error": "Sorry, the information entered does not match our records.",
   "errors.username.incorrect": "Error verifying user existence: No user found by username {username}",


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/STRIPES-641

Additional information here:
https://issues.folio.org/browse/UX-328

## Changes
- Updated `<MainNav>` styling
- Updated `<NavButton>` styling
  - New active style
  - Larger font size
- Updated `<CurrentApp>` styling
  - Larger and bold font
- Added aria-label for `<ProfileDropdown>`
- Added `dist`-folder to .eslintignore (if present, the contents of the folder can make the linting process stall)

## Screenshots
![image](https://user-images.githubusercontent.com/640976/62008970-a4681100-b159-11e9-8650-264f7bb42e0d.png)

![image](https://user-images.githubusercontent.com/640976/62008972-ad58e280-b159-11e9-9bf3-15a6b0d0da55.png)

![image](https://user-images.githubusercontent.com/640976/62008977-b944a480-b159-11e9-8fa0-96164deebfb3.png)
