### PR TITLE
UIIN-678 receive react via peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 3.8.0 (IN PROGRESS)
+
+* Receive React as a peerDependency (provide by `stripes`). One dep to rule them all. Refs UIIN-678.
+
 ## [3.7.0](https://github.com/folio-org/stripes-core/tree/v3.7.0) (2019-07-22)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.6.0...v3.7.0)
 

--- a/package.json
+++ b/package.json
@@ -115,10 +115,8 @@
     "postcss-url": "^8.0.0",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
-    "react": "^16.8.6",
     "react-apollo": "^2.1.3",
     "react-cookie": "^2.1.4",
-    "react-dom": "^16.8.6",
     "react-hot-loader": "^4.3.10",
     "react-intl": "^2.5.0",
     "react-overlays": "^0.8.3",
@@ -147,5 +145,9 @@
     "webpack-dev-middleware": "^3.1.3",
     "webpack-hot-middleware": "^2.22.2",
     "webpack-virtual-modules": "^0.1.10"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
   }
 }


### PR DESCRIPTION
We should only provide react in one place (stripes) and every other
library and app built with stripes should recieve it as a peer. This
reduces the chance of different modules using different minor version of
react with a `~` dependency and pulling multiple versions of it into the
bundle. Multiple versions of React === Bad Things.

Refs [UIIN-678](https://issues.folio.org/browse/UIIN-678)