### PR TITLE
UIIN-678 provide React as devDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.8.0 (IN PROGRESS)
 
 * Receive React as a peerDependency (provide by `stripes`). One dep to rule them all. Refs UIIN-678.
+* Include React a devDependency since it no longer a direct dependency. Refs UIIN-678.
 
 ## [3.7.0](https://github.com/folio-org/stripes-core/tree/v3.7.0) (2019-07-22)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.6.0...v3.7.0)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "eslint": "^5.5.0",
     "mocha": "^6.1.3",
     "mocha-junit-reporter": "^1.17.0",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
     "stylelint": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mocha": "^6.1.3",
     "mocha-junit-reporter": "^1.17.0",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
     "stylelint": "^8.2.0",


### PR DESCRIPTION
Here's the thing: if React isn't a direct dependency, then it needs to
be provided as a devDependency so we can actually run tests. Duh.

Refs [UIIN-678](https://issues.folio.org/browse/UIIN-678)