### PR TITLE
Allow top-left "FOLIO" caption to be configured

### DIFF
--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -10,6 +10,10 @@ import NavButton from '../NavButton';
 import css from './CurrentApp.css';
 
 const propTypes = {
+  config: PropTypes.shape({
+    platformName: PropTypes.string,
+    platformDescription: PropTypes.string,
+  }),
   currentApp: PropTypes.shape(
     {
       displayName: PropTypes.string,
@@ -27,12 +31,13 @@ const propTypes = {
   ]),
 };
 
-const defaultProps = {
-  currentApp: { displayName: 'FOLIO', description: 'FOLIO platform' },
-};
+const CurrentApp = ({ config, currentApp, id, intl, badge }) => {
+  const actualCurrentApp = currentApp || {
+    displayName: config.platformName || 'FOLIO',
+    description: config.platformDescription || 'FOLIO platform',
+  };
 
-const CurrentApp = ({ currentApp, id, intl, badge }) => {
-  const { displayName, iconData, name, home, route } = currentApp;
+  const { displayName, iconData, name, home, route } = actualCurrentApp;
   const href = home || route;
   const ariaLabel = href ? intl.formatMessage({ id: 'stripes-core.mainnav.currentAppAriaLabel' }, { appName: displayName }) : displayName;
 
@@ -62,6 +67,5 @@ const CurrentApp = ({ currentApp, id, intl, badge }) => {
 };
 
 CurrentApp.propTypes = propTypes;
-CurrentApp.defaultProps = defaultProps;
 
 export default injectIntl(CurrentApp);

--- a/src/components/MainNav/CurrentApp/CurrentAppGroup.js
+++ b/src/components/MainNav/CurrentApp/CurrentAppGroup.js
@@ -9,7 +9,7 @@ import AppContextDropdown from './AppContextDropdown';
 import { withAppCtxMenu } from './AppCtxMenuContext';
 import CurrentApp from './CurrentApp';
 
-const CurrentAppGroup = ({ displayDropdownButton, selectedApp }) => {
+const CurrentAppGroup = ({ displayDropdownButton, selectedApp, config }) => {
   if (displayDropdownButton) {
     return (
       <AppContextDropdown selectedApp={selectedApp} />
@@ -19,12 +19,14 @@ const CurrentAppGroup = ({ displayDropdownButton, selectedApp }) => {
   return (
     <CurrentApp
       id="ModuleMainHeading"
+      config={config}
       currentApp={selectedApp}
     />
   );
 };
 
 CurrentAppGroup.propTypes = {
+  config: PropTypes.object.isRequired,
   displayDropdownButton: PropTypes.bool,
   selectedApp: PropTypes.shape(
     {

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -188,7 +188,7 @@ class MainNav extends Component {
                     <polygon style={{ fill: '#999' }} points="13 24.8 1.2 13.5 3.2 11.3 13 20.6 22.8 11.3 24.8 13.5 " />
                   </svg>
                 </a>
-                <CurrentAppGroup selectedApp={selectedApp} />
+                <CurrentAppGroup selectedApp={selectedApp} config={stripes.config} />
               </NavGroup>
               <nav aria-labelledby="main_navigation_label">
                 <h2 className="sr-only" id="main_navigation_label">


### PR DESCRIPTION
Fixes STCOR-385.

If the `stripes.congig.js` file's `config` section contains `platformName` or `platformDescription`, then the corresponding values will be used for the name and description of the top-level caption.

If these values are not provided, the code defaults to the old behaviour of using a hardwired "FOLIO" caption and "FOLIO Platform" description (i.e. this change is backwards-compatible).

--

Note that I had to set "Fix version" for https://issues.folio.org/browse/STCOR-385 to 3.8.0, since there is no 3.9.0 currently configured in Jira and it seems I have lost the ability to create new versions. Arguably this should have been created when the version-number in the package-file was bumped in d5614bcb. When it is created, could whoever does this please update STCOR-385 accordingly?