### PR TITLE
Calling PRUNE Redux reducer

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -71,7 +71,7 @@ class RootWithIntl extends React.Component {
               <Provider store={stripes.store}>
                 <Router history={history}>
                   { token || disableAuth ?
-                    <MainContainer>
+                    <MainContainer stripes={stripes}>
                       <OverlayContainer />
                       <AppCtxMenuProvider>
                         <MainNav stripes={stripes} />

--- a/src/components/LastVisited/withLastVisited.js
+++ b/src/components/LastVisited/withLastVisited.js
@@ -29,12 +29,25 @@ function withLastVisited(WrappedComponent) {
       });
 
       this.cachePreviousUrl = this.cachePreviousUrl.bind(this);
+      this.previousModule = '';
       this.lastVisited = {};
       this.previous = {};
 
       history.listen((location) => {
         const module = this.getCurrentModule(location);
         if (!module) return;
+
+        if (this.previousModule && this.previousModule !== module.module) {
+          this.props.stripes.store.dispatch({
+            type: '@@stripes-connect/PRUNE',
+            meta: {
+              resource: 'records',
+              module: this.previousModule,
+            }
+          });
+        }
+
+        this.previousModule = module.module;
         const name = module.module.replace(/^@folio\//, '');
         this.previous[name] = this.lastVisited[name];
         this.lastVisited[name] = `${location.pathname}${location.search}`;

--- a/src/components/LastVisited/withLastVisited.js
+++ b/src/components/LastVisited/withLastVisited.js
@@ -37,6 +37,7 @@ function withLastVisited(WrappedComponent) {
         const module = this.getCurrentModule(location);
         if (!module) return;
 
+        // When switching modules, clear the record cache to keep memory from growing unbounded. Refs UIIN-687.
         if (this.previousModule && this.previousModule !== module.module) {
           this.props.stripes.store.dispatch({
             type: '@@stripes-connect/PRUNE',

--- a/src/components/LastVisited/withLastVisited.js
+++ b/src/components/LastVisited/withLastVisited.js
@@ -29,7 +29,7 @@ function withLastVisited(WrappedComponent) {
       });
 
       this.cachePreviousUrl = this.cachePreviousUrl.bind(this);
-      this.previousModule = '';
+      this.previousModules = [];
       this.lastVisited = {};
       this.previous = {};
 
@@ -37,18 +37,23 @@ function withLastVisited(WrappedComponent) {
         const module = this.getCurrentModule(location);
         if (!module) return;
 
-        // When switching modules, clear the record cache to keep memory from growing unbounded. Refs UIIN-687.
-        if (this.previousModule && this.previousModule !== module.module) {
-          this.props.stripes.store.dispatch({
-            type: '@@stripes-connect/PRUNE',
-            meta: {
-              resource: 'records',
-              module: this.previousModule,
-            }
-          });
+        // When switching modules, clear the record cache older than previous module to keep memory from growing unbounded. Refs UIIN-687.
+        if (this.previousModules.length > 1) {
+          if (this.previousModules.indexOf(module.module) < 0) {
+            this.props.stripes.store.dispatch({
+              type: '@@stripes-connect/PRUNE',
+              meta: {
+                resource: 'records',
+                module: this.previousModules[0],
+              }
+            });
+          }
+
+          // Remove the oldest module from future pruning
+          this.previousModules.shift();
         }
 
-        this.previousModule = module.module;
+        this.previousModules.push(module.module);
         const name = module.module.replace(/^@folio\//, '');
         this.previous[name] = this.lastVisited[name];
         this.lastVisited[name] = `${location.pathname}${location.search}`;


### PR DESCRIPTION
whenever switching modules so that application doesn't continuously fill the store (which can lead to eventual degraded performance).

This is to address https://issues.folio.org/browse/UIIN-687 where performance slowly degrades over long periods of time.

NOTE: this PR relies on https://github.com/folio-org/stripes-connect/pull/102 being merged first.

The approach here is to reset stored records when moving between modules since they do take up space in memory and can grow unbounded as you visit more modules and run additional searches. By calling PRUNE whenever switching modules, we ensure that at most only 1 set of records is stored in Redux at any given time, thus making memory usage more reasonable and more predictable.

We will still be retaining search queries and other light pieces of metadata in Redux, so when moving back to a previously accessed module, the search is quickly re-run adding only a slight pause in user experience.

In testing, I observed considerably more memory being released when switching modules vs. the current Chalmers prod environment. That put memory usage closer to around 200MB-300MB on average vs. growing upwards of 700MB and holding.
