### PR TITLE
STCOR-391 Keep and use existing token

### DIFF
--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -248,8 +248,8 @@ function handleLoginError(dispatch, resp) {
   dispatch(setOkapiReady());
 }
 
-function processOkapiSession(okapiUrl, store, tenant, resp) {
-  const token = resp.headers.get('X-Okapi-Token');
+function processOkapiSession(okapiUrl, store, tenant, resp, origToken) {
+  const token = resp.headers.get('X-Okapi-Token') || origToken || store.getState().okapi.token;
   const { dispatch } = store;
 
   if (resp.status >= 400) {
@@ -282,7 +282,7 @@ export function requestLogin(okapiUrl, store, tenant, data) {
 export function requestUserWithPerms(okapiUrl, store, tenant, token) {
   fetch(`${okapiUrl}/bl-users/_self?expandPermissions=true&fullPermissions=true`,
     { headers: getHeaders(tenant, token) })
-    .then(resp => processOkapiSession(okapiUrl, store, tenant, resp));
+    .then(resp => processOkapiSession(okapiUrl, store, tenant, resp, token));
 }
 
 export function requestSSOLogin(okapiUrl, tenant) {

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -248,8 +248,8 @@ function handleLoginError(dispatch, resp) {
   dispatch(setOkapiReady());
 }
 
-function processOkapiSession(okapiUrl, store, tenant, resp, origToken) {
-  const token = resp.headers.get('X-Okapi-Token') || origToken || store.getState().okapi.token;
+function processOkapiSession(okapiUrl, store, tenant, resp, ssoToken) {
+  const token = resp.headers.get('X-Okapi-Token') || ssoToken;
   const { dispatch } = store;
 
   if (resp.status >= 400) {


### PR DESCRIPTION
Store SSO token as Okapi token and reuse token if needed. 

Fixes [STCOR-391](https://issues.folio.org/browse/STCOR-391)