### PR TITLE
Release v3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-core
 
+## [3.10.2](https://github.com/folio-org/stripes-core/tree/v3.10.2) (2019-10-02)
+[Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.10.1...v3.10.2)
+
+* No changes
+
 ## [3.10.1](https://github.com/folio-org/stripes-core/tree/v3.10.1) (2019-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.10.0...v3.10.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",


### PR DESCRIPTION
Exactly the same as `v3.10.1`, _exactly_, but we published a bug-fix
release in the `v3.7` line after we published `v3.10.1` and that seems
to have gotten npm's `latest` dist-tag. This is causing repositories
that have `^` dependencies to pull that non-latest "latest" release in
addition to the actual latest release that is included in the
`@folio/stripes` package with a `~` dependency.

So really this is just a retag of the existing `v3.10.1` release so that
tools like npm, yarn, and Jenkins will see the semantically-latest
release as the actual latest release. It sorta makes you wonder what the
point of semantic versioning is if `yarn` is going to ignore that in
favor of the `latest` dist-tag, doesn't it?