### PR TITLE
Added 'iconAlignment'-prop for <AppIcon>

### DIFF
--- a/src/components/AppIcon/AppIcon.css
+++ b/src/components/AppIcon/AppIcon.css
@@ -58,6 +58,17 @@
 }
 
 /**
+ * Icon alignment
+ */
+.icon-alignment-center {
+  align-items: center;
+}
+
+.icon-alignment-baseline {
+  align-items: baseline;
+}
+
+/**
  * Sizes
  */
 .large .icon {

--- a/src/components/AppIcon/AppIcon.js
+++ b/src/components/AppIcon/AppIcon.js
@@ -13,6 +13,7 @@ import { withStripes } from '../../StripesContext';
 import css from './AppIcon.css';
 
 const AppIcon = ({
+  iconAlignment,
   iconAriaHidden,
   size,
   icon,
@@ -88,6 +89,8 @@ const AppIcon = ({
     css.appIcon,
     /* Icon size */
     css[size],
+    /* Icon alignment */
+    css[`icon-alignment-${iconAlignment}`],
     /* Custom ClassName */
     className,
   );
@@ -120,6 +123,7 @@ AppIcon.propTypes = {
     src: PropTypes.string.isRequired,
   }),
   iconAriaHidden: PropTypes.bool,
+  iconAlignment: PropTypes.oneOf(['center', 'baseline']),
   iconKey: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   src: PropTypes.string,
@@ -131,10 +135,11 @@ AppIcon.propTypes = {
 };
 
 AppIcon.defaultProps = {
+  iconAlignment: 'center',
+  iconAriaHidden: true,
   iconKey: 'app',
   size: 'medium',
   tag: 'span',
-  iconAriaHidden: true,
 };
 
 export default withStripes(AppIcon);

--- a/src/components/AppIcon/readme.md
+++ b/src/components/AppIcon/readme.md
@@ -50,6 +50,7 @@ app | string | The lowercased name of an app, e.g. "users" or "inventory". It wi
 children | node | Add content next to the icon - e.g. a label | undefined
 className | string | For adding custom class to component | undefined
 icon | object | Icon in form of an object. E.g. { src, alt } | undefined
+iconAligment | string | Sets the vertical alignment of the icon. Can be set to either "center" or "baseline". Setting it to "baseline" will align the icon relative to the first line of the label text (useful if the label spans over several lines). Setting it to "center" will render the icon vertically centered. | center
 iconAriaHidden | bool | Applies aria-hidden to the icon element. Since `<AppIcon>`'s mostly are rendered in proximity of a label or inside an element with a label (e.g. a button), we set aria-hidden to true per default to avoid screen readers reading the alt attribute of the icon img | true
 iconKey | string | A specific icon-key for apps with multiple icons. Defaults to "app" which corresponds to the required default app-icon of an app. | app
 size | string | Determines the size of the icon. (small, medium, large) | medium


### PR DESCRIPTION
Added `iconAlignment`-prop for `<AppIcon>` which makes it possible to control the alignment of the icon relative to the label.

This change was originally requested in [UIIN-719](https://issues.folio.org/browse/UIIN-719) but I decided to update the `<AppIcon>` so that other modules can benefit from this update as well.

## Before
This is how iconAlignment="center" aligns the icon (default).

![image](https://user-images.githubusercontent.com/640976/66055878-8bebec80-e536-11e9-940d-ff618a72e296.png)

## After
This is how iconAlignment="baseline" aligns the icon.

![image](https://user-images.githubusercontent.com/640976/66055994-bb9af480-e536-11e9-9b9d-6df92e563e0f.png)
