### PR TITLE
Replace use of stripesShape with explicit propTypes list

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -34,12 +34,15 @@ import {
   ForgotUserNameCtrl,
   AppCtxMenuProvider,
 } from './components';
-import { stripesShape } from './Stripes';
 import { StripesContext } from './StripesContext';
 
 class RootWithIntl extends React.Component {
   static propTypes = {
-    stripes: stripesShape.isRequired,
+    stripes: PropTypes.shape({
+      epics: PropTypes.object,
+      logger: PropTypes.object.isRequired,
+      clone: PropTypes.func.isRequired,
+    }).isRequired,
     token: PropTypes.string,
     disableAuth: PropTypes.bool.isRequired,
     history: PropTypes.shape({}),


### PR DESCRIPTION
This is necessary to avoid a console error on the login page, where `user.id` (which is marked as required in stripesShape) is not defined.

The explicit propTypes list contains those three stripes-object properties that are necessary for stripes-core to continue linting cleanly.