### PR TITLE
Clear registered epics during BigTest app teardown. Part of STRIPES-659

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 3.10.4 IN PROGRESS
+
+* Clear registered epics during BigTest app `teardown`. Part of STRIPES-659.
+
 ## [3.10.3](https://github.com/folio-org/stripes-core/tree/v3.10.3) (2019-10-02)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.10.2...v3.10.3)
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "~5.9.0",
-    "@folio/stripes-connect": "~5.4.0",
+    "@folio/stripes-connect": "~5.4.2",
     "@folio/stripes-logger": "~1.0.0",
     "apollo-cache-inmemory": "^1.1.1",
     "apollo-client": "^2.0.3",

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -1,7 +1,7 @@
 import { beforeEach } from '@bigtest/mocha';
 import { setupAppForTesting, visit, location } from '@bigtest/react';
 import localforage from 'localforage';
-import { clearRegisteredEpics } from '@folio/stripes-connect';
+import { reset } from '@folio/stripes-connect';
 
 // load these styles for our tests
 import '@folio/stripes-components/lib/global.css';
@@ -69,7 +69,7 @@ export default function setupApplication({
       teardown: () => {
         clearConfig();
         clearModules();
-        clearRegisteredEpics();
+        reset();
         localforage.clear();
         this.server.shutdown();
         this.server = null;

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -1,6 +1,7 @@
 import { beforeEach } from '@bigtest/mocha';
 import { setupAppForTesting, visit, location } from '@bigtest/react';
 import localforage from 'localforage';
+import { clearRegisteredEpics } from '@folio/stripes-connect';
 
 // load these styles for our tests
 import '@folio/stripes-components/lib/global.css';
@@ -68,6 +69,7 @@ export default function setupApplication({
       teardown: () => {
         clearConfig();
         clearModules();
+        clearRegisteredEpics();
         localforage.clear();
         this.server.shutdown();
         this.server = null;


### PR DESCRIPTION
https://issues.folio.org/browse/STRIPES-659

Please refer to https://github.com/folio-org/stripes-connect/pull/107 for more details about it. 

This PR will keep failing until 107 is merged in stripes-connect.