### PR TITLE
Upgrade style-loader to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "rtl-detect": "^1.0.2",
     "rxjs": "^5.4.3",
     "serialize-javascript": "^1.4.0",
-    "style-loader": "^0.22.1",
+    "style-loader": "^1.0.0",
     "svgo": "^1.2.2",
     "svgo-loader": "^2.2.1",
     "tapable": "^1.0.0",

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -32,10 +32,7 @@ devConfig.module.rules.push({
   test: /\.css$/,
   use: [
     {
-      loader: 'style-loader',
-      options: {
-        sourceMap: true,
-      },
+      loader: 'style-loader'
     },
     {
       loader: 'css-loader',


### PR DESCRIPTION
## Overview
As we approach solutions on treatment of global styles within the system, this will be a great upgrade with its treatment of the API (much nicer than pre-1.0.0)

## breakage
Our current webpack.config.cli.dev.js sets a `sourcemaps: true` option for the `style-loader` entry. This has been removed. We've narrowly used the API for this thus far, github search says the `!loader` statements present among the modules leave it at standard usage (no options)

### [Check out the options/API](https://github.com/webpack-contrib/style-loader/blob/master/README.md)
