### PR TITLE
STCOR-398: Fixed "last visited" state for apps in nav bar

### DIFF
--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -70,20 +70,20 @@ class AppList extends Component {
    * Get the nav buttons that is displayed
    * in the app header on desktop
    */
-  renderNavButtons = (items, hiddenItemIds, itemWidths) => {
-    const { selectedApp } = this.props;
+  renderNavButtons = (refs, hiddenItemIds, itemWidths) => {
+    const { selectedApp, apps } = this.props;
 
     return (
       <ul className={css.navItemsList}>
         {
-          items.map(app => {
+          apps.map(app => {
             const hidden = hiddenItemIds.includes(app.id);
 
             return (
               <li
                 className={classnames(css.navItem, { [css.hidden]: hidden })}
                 key={app.id}
-                ref={app.ref}
+                ref={refs[app.id]}
                 aria-hidden={hidden}
                 style={{ width: itemWidths[app.id] }}
               >
@@ -165,7 +165,7 @@ class AppList extends Component {
   /**
    * App list dropdown
    */
-  renderNavDropdown = (items, hiddenItemIds) => {
+  renderNavDropdown = (hiddenItemIds) => {
     const {
       renderDropdownToggleButton,
       toggleDropdown,
@@ -176,7 +176,7 @@ class AppList extends Component {
       state: { open },
     } = this;
 
-    const { dropdownId, dropdownToggleId, selectedApp } = this.props;
+    const { apps, dropdownId, dropdownToggleId, selectedApp } = this.props;
 
     if (!hiddenItemIds.length) {
       return null;
@@ -207,7 +207,7 @@ class AppList extends Component {
                 <DropdownMenu data-role="menu" onToggle={toggleDropdown}>
                   {focusTrap(focusDropdownToggleButton)}
                   <AppListDropdown
-                    apps={items.filter(item => hiddenItemIds.includes(item.id))}
+                    apps={apps.filter(item => hiddenItemIds.includes(item.id))}
                     dropdownToggleId={dropdownToggleId}
                     listRef={dropdownListRef}
                     selectedApp={selectedApp}
@@ -267,14 +267,14 @@ class AppList extends Component {
 
     return (
       <ResizeContainer items={apps} hideAllWidth={767}>
-        {({ items, hiddenItems, itemWidths }) => {
+        {({ refs, hiddenItems, itemWidths }) => {
           return (
             <nav className={css.appList} aria-labelledby="main_app_list_label" data-test-app-list>
               <h3 className="sr-only" id="main_app_list_label">
                 <FormattedMessage id="stripes-core.mainnav.applicationListLabel" />
               </h3>
-              {this.renderNavButtons(items, hiddenItems, itemWidths)}
-              {this.renderNavDropdown(items, hiddenItems)}
+              {this.renderNavButtons(refs, hiddenItems, itemWidths)}
+              {this.renderNavDropdown(hiddenItems)}
             </nav>
           );
         }

--- a/test/bigtest/tests/ResizeContainer/ResizeContainer-test.js
+++ b/test/bigtest/tests/ResizeContainer/ResizeContainer-test.js
@@ -6,7 +6,6 @@ import React from 'react';
 import times from 'lodash/times';
 import { beforeEach, it, describe } from '@bigtest/mocha';
 import { expect } from 'chai';
-import setupApplication from '../../helpers/setup-application';
 import { mount } from '../../helpers/render-helpers';
 
 import ResizeContainer from '../../../../src/components/MainNav/AppList/components/ResizeContainer';
@@ -24,30 +23,30 @@ const ITEM_OFFSET = 0;
 // This would be determined by the window width in a real app
 const WRAPPER_WIDTH = 800;
 
-const ITEMS = times(10).map(no => ({
-  id: no,
-  ref: null // Ref gets added for each item by ResizeContainer
-}));
+const ITEMS = times(10).map(id => ({ id: id.toString() }));
 
 // Since we have no offset and fixed wrapper/item width, we can predict the expected outcome
 const EXPECTED_VISIBLE_ITEMS = WRAPPER_WIDTH / ITEM_WIDTH;
 const EXPECTED_HIDDEN_ITEMS = ITEMS.length - EXPECTED_VISIBLE_ITEMS;
 
+/**
+ * A mock ResizeContainer component that mimics a real app example
+ */
 const ResizeContainerMock = ({ items, wrapperWidth, itemWidth, hideAllWidth, offset, withRTL }) => {
   return (
     <div dir={withRTL ? 'rtl' : 'ltr'}>
       <div style={{ maxWidth: wrapperWidth, backgroundColor: 'green', height: 100 }}>
         <ResizeContainer className="my-test-interactor" items={items} hideAllWidth={hideAllWidth} offset={offset}>
-          {({ items: allItems, hiddenItems }) => (
+          {({ refs, hiddenItems }) => (
             <div style={{ display: 'flex', flex: 1, minWidth: 0, justifyContent: 'flex-end' }}>
-              {allItems.map(item => {
+              {items.map(item => {
                 const isHidden = hiddenItems.includes(item.id);
 
                 return (
                   <span
                     {...{ [!isHidden ? 'data-test-resize-container-visible-item' : 'data-test-resize-container-hidden-item']: true }}
                     key={item.id}
-                    ref={item.ref}
+                    ref={refs[item.id]}
                     style={{
                       width: itemWidth,
                       flexShrink: 0,
@@ -71,8 +70,6 @@ const ResizeContainerMock = ({ items, wrapperWidth, itemWidth, hideAllWidth, off
 
 describe('ResizeContainer', () => {
   const resizeContainer = new ResizeContainerInteractor('.my-test-interactor');
-
-  setupApplication();
 
   beforeEach(async () => {
     await mount(


### PR DESCRIPTION
Updated `<ResizeContainer>` to receive an array of items and return an object of refs mapped by ID which is then applied on the items to determine the widths of the items.

This fixes an issue where the "last visited" app states weren't being preserved because the items were cached by `<ResizeContainer>`. Instead, the original array will be used to map out the items so that any changes to that array will be rendered out.

Updated the tests to work with the new changes.