### PR TITLE
Add explicit dependency on handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "file-loader": "^1.1.11",
     "final-form": "^4.18.2",
     "graphql": "^0.11.7",
+    "handlebars": "^4.5.1",
     "handlebars-loader": "^1.7.1",
     "hard-source-webpack-plugin": "^0.12.0",
     "history": "^4.6.3",


### PR DESCRIPTION
I previously assumed this was not necessary, as the dependency on the WebPack loaded `handlebars-loader` would transitively pull in `handlebars` itself.

It turns out that the loader has the templating engine only as a peer-dependency, not a full dependency, which means that building stripes-core in the absence of a module that has its own full dependency on `handlebars` will fail due to the unfulfilled peer-dependency.

This will fix a persistent and mysterious build problem first encountered in ReShare, but which is sure to crop up again in other contexts if not addressed.