### PR TITLE
FOLIO-2369: Handle the issue with tests upon the loading of translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Clear registered epics during BigTest app `teardown`. Part of STRIPES-659.
 * Refactor login form to final-form. Part of STCOR-395.
 * Add WebPack support for handlebars-loader.
+* Handle the issue with tests upon the loading of translations by downgrading the fake-xml-http-request which updated recently. Fixes FOLIO-2369.
 
 ## [3.10.3](https://github.com/folio-org/stripes-core/tree/v3.10.3) (2019-10-02)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.10.2...v3.10.3)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-register": "^6.16.3",
     "chai": "^4.1.2",
     "eslint": "^5.5.0",
+    "fake-xml-http-request": "2.0.0",
     "mocha": "^6.1.3",
     "mocha-junit-reporter": "^1.17.0",
     "react": "^16.8.6",
@@ -151,6 +152,9 @@
     "webpack-dev-middleware": "^3.1.3",
     "webpack-hot-middleware": "^2.22.2",
     "webpack-virtual-modules": "^0.1.10"
+  },
+  "resolutions": {
+    "fake-xml-http-request": "2.0.0"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
## Purpose

Handle the issue with tests upon the loading of translations by downgrading the [fake-xml-http-request](https://github.com/pretenderjs/FakeXMLHttpRequest) which updated [recently](https://github.com/pretenderjs/FakeXMLHttpRequest/releases/tag/v2.1.1) in the scope of [FOLIO-2369](https://issues.folio.org/browse/FOLIO-2369).