### PR TITLE
onHome function calls toggleDropdown

### DIFF
--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -144,6 +144,7 @@ class ProfileDropdown extends Component {
   }
 
   onHome = () => {
+    this.toggleDropdown();
     this.navigateByUrl({ route: '/' });
   };
 


### PR DESCRIPTION
When the `showHomeLink` configuration item is set, as is often the
case in development setups, the top right menu with the "Logout" link
also has a "Home" link that goes back to the FOLIO home page. This
link works, but a while back developed the wrinkle that clicking it
did not dismiss the dropdown menu that the link is on. The present
one-line commit fixes that by having the navigate-to-home function
also toggle the menu.