### PR TITLE
STCOR-401 bump serialize-javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.11.1] (In Progress)
 
 * Set to `autocomplete` attribute valid values. Refs UIU-1374.
+* Bump `serialize-javascript` to `v2.1.2` to avoid an XSS vulnerability (https://github.com/yahoo/serialize-javascript/security/advisories/GHSA-h9rv-jmmf-4pgx). 
 
 ## [3.11.0](https://github.com/folio-org/stripes-core/tree/v3.11.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.10.2...v3.10.3)

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "rimraf": "^2.5.4",
     "rtl-detect": "^1.0.2",
     "rxjs": "^5.4.3",
-    "serialize-javascript": "^1.4.0",
+    "serialize-javascript": "^2.1.2",
     "style-loader": "^1.0.0",
     "svgo": "^1.2.2",
     "svgo-loader": "^2.2.1",


### PR DESCRIPTION
Versions of `serialize-javascript` prior to `v2.1.1` suffer from an XSS
vulnerability related to their encoding of regular expressions.
[Details](https://github.com/yahoo/serialize-javascript/security/advisories/GHSA-h9rv-jmmf-4pgx).

Fixes [STCOR-401](https://issues.folio.org/browse/STCOR-401?jql=text%20~%20%22serialize%22)

Despite the major version bump, I believe this is a low-risk upgrade. The bump from v1 to v2 was really only because v1.something inadvertently changed a behavior, and they realized that, and saw fit to bump the major when they changed it back. 