### PR TITLE
STCOR-405 do not render twice given non-English locale

### DIFF
--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -51,9 +51,12 @@ class Root extends Component {
 
   componentDidMount() {
     const { okapi, store, locale, defaultTranslations } = this.props;
-    if (this.withOkapi) checkOkapiSession(okapi.url, store, okapi.tenant);
-    // TODO: remove this after we load locale and translations at start from a public endpoint
-    loadTranslations(store, locale, defaultTranslations);
+    if (this.withOkapi) {
+      checkOkapiSession(okapi.url, store, okapi.tenant, () => loadTranslations(store, locale || 'en-US', defaultTranslations));
+    } else {
+      // TODO: remove this after we load locale and translations at start from a public endpoint
+      loadTranslations(store, locale, defaultTranslations);
+    }
   }
 
   shouldComponentUpdate(nextProps) {
@@ -92,7 +95,7 @@ class Root extends Component {
       return <div>Error: server is down.</div>;
     }
 
-    if (!translations) {
+    if (!locale || !translations) {
       // We don't know the locale, so we use English as backup
       return (<SystemSkeleton />);
     }
@@ -206,7 +209,7 @@ Root.propTypes = {
 Root.defaultProps = {
   history: createBrowserHistory(),
   // TODO: remove after locale is accessible from a global config / public url
-  locale: 'en-US',
+  locale: '',
   timezone: 'UTC',
   currency: 'USD',
   okapiReady: false,


### PR DESCRIPTION
The issue with the locale when the user has a locale other than en-US one about two initiations of components on page load which I mentioned on one of the previous stripes-architecture meetings. 

This causes
- weird stuff when `accumulate` is set to `true` in the resource manifest setup and it is initialized in `componentDidMount`. As a result, the same data will be fetched twice and be displayed on the UI twice (for example MCL list with duplicated data);
- UI rerenders twice;
- Flash when a user initially has English translations for some time which then switches to user locale translations;

See before and after videos and observe console logs.
https://epam-my.sharepoint.com/:f:/p/victor_soroka1/Egyp66RoBhVHk3wWJRtKTFEBviKu9e42xNaxK0rMwbZZ8A?e=i2nby8

The code does not look pretty and I did not spend much time on it and I believe I might something important did not take into account. The tricky part to keep in mind - the case when a user logs in for the first time. So the code in the PR about trying to not load translations with defaults when the user is logged in in some way. In this case, then their locale data is received from the backend, upon which translations are fetched only once.