### PR TITLE
STCOR-407: Add miragejs dep and ability to choose mirage server implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.12.0 (IN PROGRESS)
 
+* Update Mirage library. Part of STCOR-407.
+
 ## [3.11.1](https://github.com/folio-org/stripes-core/tree/v3.11.1) (2019-12-10)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.11.0...v3.11.1)
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-register": "^6.16.3",
     "chai": "^4.1.2",
     "eslint": "^5.5.0",
+    "miragejs": "^0.1.32",
     "mocha": "^6.1.3",
     "mocha-junit-reporter": "^1.17.0",
     "react": "^16.8.6",

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -25,7 +25,7 @@ export default function setupApplication({
   translations = {},
   permissions = {},
   stripesConfig,
-  mirageOptions,
+  mirageOptions = {},
   scenarios,
   currentUser = {},
 } = {}) {

--- a/test/bigtest/helpers/setup-core-application.js
+++ b/test/bigtest/helpers/setup-core-application.js
@@ -1,0 +1,6 @@
+import setupApplication from './setup-application';
+
+export default function setupCoreApplication(options = {}) {
+  options.mirageOptions = { serverType: 'miragejs' };
+  setupApplication(options);
+}

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -1,5 +1,5 @@
 import { okapi } from 'stripes-config';
-import { Response } from '@bigtest/mirage';
+import { Response } from 'miragejs';
 
 // typical mirage config export
 export default function configure() {

--- a/test/bigtest/network/index.js
+++ b/test/bigtest/network/index.js
@@ -1,4 +1,4 @@
-import { camelize } from '@bigtest/mirage';
+import camelCase from 'lodash/camelCase';
 
 // auto-import all mirage submodules
 const req = require.context('./', true, /\.js$/);
@@ -8,7 +8,7 @@ const modules = req.keys().reduce((acc, modulePath) => {
   const moduleName = moduleParts[2];
 
   if (moduleName) {
-    const moduleKey = camelize(moduleName.replace('.js', ''));
+    const moduleKey = camelCase(moduleName.replace('.js', ''));
 
     return Object.assign(acc, {
       [moduleType]: {

--- a/test/bigtest/network/start.js
+++ b/test/bigtest/network/start.js
@@ -1,38 +1,58 @@
 /* eslint global-require: off, import/no-mutable-exports: off */
 import merge from 'lodash/merge';
 import flow from 'lodash/flow';
+import camelCase from 'lodash/camelCase';
 
 const environment = process.env.NODE_ENV || 'test';
 
 let start = () => {};
 
 if (environment !== 'production') {
-  const { default: Mirage, camelize } = require('@bigtest/mirage');
+  const { Server: MirageJsServer } = require('miragejs');
+  const { default: BigTestMirageServer } = require('@bigtest/mirage');
+
   const { default: coreModules } = require('./index');
   require('./force-fetch-polyfill');
   require('./patch-fake-xml-http-request');
+
+  const createServer = (Server, options, configName) => {
+    const {
+      baseConfig: coreConfig,
+      ...coreOpts
+    } = coreModules;
+
+    const {
+      baseConfig = () => {},
+      ...opts
+    } = options;
+
+    return new Server(merge({
+      [configName]: flow(coreConfig, baseConfig),
+      environment
+    }, coreOpts, opts));
+  };
 
   start = (scenarioNames, options = {}) => {
     const {
       scenarios: coreScenarios = {},
       factories: coreFactories = {},
       fixtures: coreFixtures = {},
-      baseConfig: coreConfig,
-      ...coreOpts
     } = coreModules;
 
     const {
+      serverType,
       scenarios = {},
       factories = {},
       fixtures = {},
-      baseConfig = () => {},
-      ...opts
     } = options;
 
-    const server = new Mirage(merge({
-      baseConfig: flow(coreConfig, baseConfig),
-      environment
-    }, coreOpts, opts));
+    // 'serverType' option can be used to control which mirage
+    // server implementation will be used.
+    // The BigTest mirage implementation is set as a default
+    // for backward compatibility.
+    const server = (serverType === 'miragejs') ?
+      createServer(MirageJsServer, options, 'routes') :
+      createServer(BigTestMirageServer, options, 'baseConfig');
 
     // mirage conditionally includes factories, we want to include
     // all of them unconditionally
@@ -54,7 +74,7 @@ if (environment !== 'production') {
     // so instead of providing all scenarios we run specific scenarios
     // after the mirage server is initialized.
     [].concat(scenarioNames || defaultScenario).filter(Boolean).forEach(name => {
-      const key = camelize(name);
+      const key = camelCase(name);
       const scenario = scenarios[key] || coreScenarios[key];
       if (scenario) scenario(server);
     });

--- a/test/bigtest/tests/about-test.js
+++ b/test/bigtest/tests/about-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 import React, { Component } from 'react';
 
-import setupApplication from '../helpers/setup-application';
+import setupApplication from '../helpers/setup-core-application';
 import AboutInteractor from '../interactors/about';
 
 describe('About', () => {

--- a/test/bigtest/tests/createResetPassword-test.js
+++ b/test/bigtest/tests/createResetPassword-test.js
@@ -6,7 +6,7 @@ import {
   beforeEach,
 } from '@bigtest/mocha';
 
-import setupApplication from '../helpers/setup-application';
+import setupApplication from '../helpers/setup-core-application';
 import CreateResetPasswordInteractor from '../interactors/CreateResetPassword';
 import ChangePasswordErrorPageInteractor from '../interactors/ChangePasswordErrorPage';
 import ChangePasswordConfirmationInteractor from '../interactors/ChangePasswordConfirmation';

--- a/test/bigtest/tests/forgotPassword-test.js
+++ b/test/bigtest/tests/forgotPassword-test.js
@@ -6,7 +6,7 @@ import {
 import { expect } from 'chai';
 
 import translations from '../../../translations/stripes-core/en';
-import setupApplication from '../helpers/setup-application';
+import setupApplication from '../helpers/setup-core-application';
 import ForgotPasswordInteractor from '../interactors/ForgotPassword';
 
 describe('forgot password form test', () => {

--- a/test/bigtest/tests/forgotUsername-test.js
+++ b/test/bigtest/tests/forgotUsername-test.js
@@ -6,7 +6,7 @@ import {
 import { expect } from 'chai';
 
 import translations from '../../../translations/stripes-core/en';
-import setupApplication from '../helpers/setup-application';
+import setupApplication from '../helpers/setup-core-application';
 import ForgotUsernameInteractor from '../interactors/ForgotUsername';
 
 describe('Forgot username form test', () => {

--- a/test/bigtest/tests/login-test.js
+++ b/test/bigtest/tests/login-test.js
@@ -6,7 +6,7 @@ import {
   beforeEach
 } from '@bigtest/mocha';
 
-import setupApplication from '../helpers/setup-application';
+import setupApplication from '../helpers/setup-core-application';
 import LoginInteractor from '../interactors/login';
 
 import translations from '../../../translations/stripes-core/en';

--- a/test/bigtest/tests/nav-test.js
+++ b/test/bigtest/tests/nav-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 import React, { Component } from 'react';
 
-import setupApplication from '../helpers/setup-application';
+import setupApplication from '../helpers/setup-core-application';
 import AppInteractor from '../interactors/app';
 
 describe('Nav', () => {

--- a/test/bigtest/tests/statusPage-test.js
+++ b/test/bigtest/tests/statusPage-test.js
@@ -2,7 +2,7 @@ import { beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
 import translations from '../../../translations/stripes-core/en';
-import setupApplication from '../helpers/setup-application';
+import setupApplication from '../helpers/setup-core-application';
 import StatusPageInteractor from '../interactors/StatusPage';
 
 describe('Forgot username form test', () => {
@@ -31,7 +31,7 @@ describe('Forgot username form test', () => {
       expect(heading.isPresent).to.be.true;
     });
 
-    it(`should have the header with an appropriate text content 
+    it(`should have the header with an appropriate text content
       equal to check email label in english translation`, () => {
       expect(heading.text).to.equal(translations['label.check.email']);
     });
@@ -40,7 +40,7 @@ describe('Forgot username form test', () => {
       expect(notificationParagraph.isPresent).to.be.true;
     });
 
-    it(`should have the paragraph with an appropriate text content 
+    it(`should have the paragraph with an appropriate text content
       equal to sent email precautions label in english translation`, () => {
       expect(notificationParagraph.text).to.equal(
         translations['label.your.email']
@@ -51,7 +51,7 @@ describe('Forgot username form test', () => {
       expect(cautionParagraph.isPresent).to.be.true;
     });
 
-    it(`should have the paragraph with an appropriate text content 
+    it(`should have the paragraph with an appropriate text content
       equal to check email precautions label in english translation`, () => {
       expect(cautionParagraph.text).to.equal(
         translations['label.caution.email']


### PR DESCRIPTION
This PR adds a new `miragejs` dependency and introduces a new `mirageOptions` option called `serverType` which allows for configuring which mirage server implementation will be used. The default implementation will be set to BigTest mirage for backwards compatibility (the current testing setup for existing ui modules will work as is - it's not a breaking change).

This PR also migrates `stripes-core` tests to `miragejs`.

In order to opt-in for the new miragejs implementation the `serverType` can be set to `miragejs` via `setupApplication` for example:  

https://github.com/folio-org/ui-users/pull/1127/files#diff-afc65168f7c0334e511aba82e26e9977R4

### Migration steps:

1.  `import { ... } from '@bigtest/mirage'` becomes `import { ...} from 'miragejs'`
2. The `faker` has to be installed as a separate dependency and imported directly:  `import faker from 'faker'` instead of `import { faker } from '@bigtest/mirage'`
3. Singular names should be used for factories and models and serializers otherwise miragejs will complain about not being able to find them
4. Add `mirageOptions.serverType = 'miragejs'` in order to opt-in for miragejs implementation:

https://github.com/folio-org/ui-users/pull/1127/files#diff-afc65168f7c0334e511aba82e26e9977R4

### Migration Example:

ui-users has been migrated so far and things seem to be stable there:

https://github.com/folio-org/ui-users/pull/1127