### PR TITLE
STCOR-407: Move mirage deps to dependencies from devDependencies. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@bigtest/convergence": "^0.10.0",
     "@bigtest/interactor": "^0.7.2",
-    "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.0",
@@ -51,7 +50,6 @@
     "babel-register": "^6.16.3",
     "chai": "^4.1.2",
     "eslint": "^5.5.0",
-    "miragejs": "^0.1.32",
     "mocha": "^6.1.3",
     "mocha-junit-reporter": "^1.17.0",
     "react": "^16.8.6",
@@ -63,6 +61,7 @@
     "stylelint-junit-formatter": "^0.2.1"
   },
   "dependencies": {
+    "@bigtest/mirage": "^0.0.1",
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "~5.10.0",
     "@folio/stripes-connect": "~5.5.0",
@@ -105,6 +104,7 @@
     "lodash": "^4.17.11",
     "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "^0.4.0",
+    "miragejs": "^0.1.32",
     "moment": "^2.19.1",
     "moment-timezone": "^0.5.14",
     "node-object-hash": "^1.2.0",


### PR DESCRIPTION
So it's kind of complicated but since we want to provide backwards compatibility with the previous version of mirage we need to make sure both of them are included in each build.

We are currently seeing these errors from UI modules which are using the old version of mirage (from bigtest):

```
ERROR in ./node_modules/@folio/stripes-core/test/bigtest/network/start.js
Module not found: Error: Can't resolve 'miragejs' in '/home/jenkins/workspace/olio-org_ui-local-kb-admin_PR-69/project/node_modules/@folio/stripes-core/test/bigtest/network'
```

By moving both `@bigtest/mirage` and `miragejs` from `devDependencies`  to `dependencies` we hope we can resolve it (Thank you @zburke for your help with this!). 
