### PR TITLE
FOLIO-2097: Stop side effects from executing on unmount

### DIFF
--- a/src/configureEpics.js
+++ b/src/configureEpics.js
@@ -6,11 +6,19 @@ import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/throttleTime';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/takeUntil';
 import 'rxjs/add/operator/switchMap';
+
+import { actionTypes } from './mainActions';
 
 export default function configureEpics(...initialEpics) {
   const epic$ = new BehaviorSubject(combineEpics(...initialEpics));
-  const rootEpic = (action$, store) => epic$.mergeMap(epic => epic(action$, store));
+  const rootEpic = (action$, store) => {
+    return epic$
+      .mergeMap(epic => epic(action$, store))
+      .takeUntil(action$.ofType(actionTypes.DESTROY_STORE));
+  };
+
   const middleware = createEpicMiddleware(rootEpic);
 
   return {

--- a/src/mainActions.js
+++ b/src/mainActions.js
@@ -1,12 +1,20 @@
+const RESET_STORE = 'RESET_STORE';
+const DESTROY_STORE = 'DESTROY_STORE';
+
+const actionTypes = {
+  RESET_STORE,
+  DESTROY_STORE,
+};
+
 function resetStore() {
   return {
-    type: 'RESET_STORE',
+    type: RESET_STORE,
   };
 }
 
 function destroyStore() {
   return {
-    type: 'DESTROY_STORE',
+    type: DESTROY_STORE,
   };
 }
 
@@ -14,4 +22,8 @@ function destroyStore() {
 // export, to remain consistent with okapiActions.js
 //
 // eslint-disable-next-line import/prefer-default-export
-export { resetStore, destroyStore };
+export {
+  resetStore,
+  destroyStore,
+  actionTypes,
+};


### PR DESCRIPTION
It turned out that some of the side effects would still be executing causing to trigger actual fetches even after the app has been unmounted. This PR should prevent that.