### PR TITLE
STCOR-408: Adjust Route propTypes to accept lazy loaded components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.12.0 (IN PROGRESS)
 
 * Update Mirage library. Part of STCOR-407.
+* Adjust Route propTypes to accept lazy loaded components. Refs STCOR-408.
 
 ## [3.11.1](https://github.com/folio-org/stripes-core/tree/v3.11.1) (2019-12-10)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.11.0...v3.11.1)

--- a/src/components/NestedRouter.js
+++ b/src/components/NestedRouter.js
@@ -40,5 +40,8 @@ export function Route({ component: Component, children, ...props }) {
 
 Route.propTypes = {
   children: PropTypes.node,
-  component: PropTypes.func
+  component: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object,
+  ])
 };


### PR DESCRIPTION
## Purpose

Adjust Route propTypes to accept lazy-loaded components in the scope of [STCOR-408](https://issues.folio.org/browse/STCOR-408).