### PR TITLE
Resolve RHL babel plugin ahead of time

### DIFF
--- a/webpack/babel-loader-rule.js
+++ b/webpack/babel-loader-rule.js
@@ -41,7 +41,7 @@ module.exports = {
       '@babel/plugin-proposal-numeric-separator',
       '@babel/plugin-proposal-throw-expressions',
       '@babel/plugin-syntax-import-meta',
-      ['react-hot-loader/babel'],
+      [require.resolve('react-hot-loader/babel')],
     ]
   },
 };


### PR DESCRIPTION
Resolution of the plugin via the standard definition (eg, as used by the various other `@babel/...` plugins in this file) sometimes fails during BigTest runs in an isolated UI module.

This seems to be due to a combination how deeply nested the RHL dependency is in node_modules and that the plugin is not the library itself, but nested within the library.

To sidestep this, we resolve the library path ahead of time before it hits Babel.