### PR TITLE
STCOR-415 replace deprecated webapp-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "debug": "^4.0.1",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "express": "^4.14.0",
+    "favicons-webpack-plugin": "^3.0.1"
     "file-loader": "^1.1.11",
     "final-form": "^4.18.2",
     "graphql": "^0.11.7",
@@ -154,7 +155,6 @@
     "tapable": "^1.0.0",
     "typescript": "^2.8.1",
     "uuid": "^3.0.0",
-    "webapp-webpack-plugin": "^2.6.1",
     "webpack": "^4.10.2",
     "webpack-dev-middleware": "^3.1.3",
     "webpack-hot-middleware": "^2.22.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "debug": "^4.0.1",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "express": "^4.14.0",
-    "favicons-webpack-plugin": "^3.0.1"
+    "favicons-webpack-plugin": "^3.0.1",
     "file-loader": "^1.1.11",
     "final-form": "^4.18.2",
     "graphql": "^0.11.7",
@@ -103,7 +103,7 @@
     "hard-source-webpack-plugin": "^0.12.0",
     "history": "^4.6.3",
     "hoist-non-react-statics": "^3.3.0",
-    "html-webpack-plugin": "^3.2.0",
+    "html-webpack-plugin": "^4.0.0-beta.10",
     "isomorphic-fetch": "^2.2.1",
     "jwt-decode": "^2.2.0",
     "localforage": "^1.5.6",

--- a/test/webpack/stripes-branding-plugin.spec.js
+++ b/test/webpack/stripes-branding-plugin.spec.js
@@ -34,6 +34,9 @@ const compilerStub = {
     compilation: {
       tap: () => {},
     },
+    afterCompile: {
+      tapPromise: () => {},
+    },
     emit: {
       tapAsync: () => {},
     }

--- a/test/webpack/stripes-branding-plugin.spec.js
+++ b/test/webpack/stripes-branding-plugin.spec.js
@@ -1,7 +1,7 @@
 const expect = require('chai').expect;
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const FaviconsWebpackPlugin = require('webapp-webpack-plugin');
+const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const defaultBranding = require('../../default-assets/branding');
 const StripesBrandingPlugin = require('../../webpack/stripes-branding-plugin');
 
@@ -29,6 +29,7 @@ const compilerStub = {
     },
     make: {
       tapAsync: () => {},
+      tapPromise: () => {},
     },
     compilation: {
       tap: () => {},

--- a/webpack/stripes-branding-plugin.js
+++ b/webpack/stripes-branding-plugin.js
@@ -2,11 +2,11 @@
 // The virtual module contains require()'s needed for webpack to pull images into the bundle.
 
 const path = require('path');
-const FaviconsWebpackPlugin = require('webapp-webpack-plugin');
+const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const defaultBranding = require('../default-assets/branding');
 const logger = require('./logger')('stripesBrandingPlugin');
 
-// Minimal favicon settings for webapp-webpack-plugin
+// Minimal favicon settings for favicons-webpack-plugin
 const standardFaviconsOnly = {
   android: false,
   appleIcon: false,
@@ -18,7 +18,7 @@ const standardFaviconsOnly = {
   yandex: false,
 };
 
-// Complete favicon settings for webapp-webpack-plugin
+// Complete favicon settings for favicons-webpack-plugin
 const allFavicons = {
   android: true,
   appleIcon: true,
@@ -40,7 +40,7 @@ module.exports = class StripesBrandingPlugin {
   }
 
   apply(compiler) {
-    // webapp-webpack-plugin will inject the necessary html via HtmlWebpackPlugin
+    // favicons-webpack-plugin will inject the necessary html via HtmlWebpackPlugin
     const faviconOptions = this._getFaviconOptions();
     new FaviconsWebpackPlugin(faviconOptions).apply(compiler);
 


### PR DESCRIPTION
We replaced `favicons-webpack-plugin` with `webapp-webpack-plugin`
because the former had a memory leak, but the latter is now deprecated
and has been folded back into the former.

Refs [STCOR-415](https://issues.folio.org/browse/STCOR-415), [STCOR-232](https://issues.folio.org/browse/STCOR-232), [STCOR-296](https://issues.folio.org/browse/STCOR-296)