### PR TITLE
Added react-router and react-router-dom as devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "mocha-junit-reporter": "^1.17.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-router": "^5.1.2",
+    "react-router-dom": "^5.1.2",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
     "stylelint": "^8.2.0",


### PR DESCRIPTION
since these dependencies are now provided by the platform and tests run outside that context.