### PR TITLE
correctly configure react-hot-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 4.1.0 (IN PROGRESS)
+
+* Correctly configure react-hot-loader.
+
 ## [4.0.0](https://github.com/folio-org/stripes-core/tree/v4.0.0) (2020-03-04)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v3.12.0...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "react-apollo": "^2.1.3",
     "react-cookie": "^2.1.4",
     "react-final-form": "^6.3.0",
+    "@hot-loader/react-dom": "^16.8.6",
     "react-hot-loader": "^4.3.10",
     "react-overlays": "^0.8.3",
     "react-redux": "^5.0.2",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -21,6 +21,7 @@ module.exports = {
   resolve: {
     alias: {
       'react': specificReact,
+      'react-dom': '@hot-loader/react-dom',
     },
     extensions: ['.js', '.json', '.tsx'],
   },


### PR DESCRIPTION
In local development, the console would report the following error:
```
07:28:59.865 react-hot-loader.development.js:2375 React-Hot-Loader: react-🔥-dom patch is not detected. React 16.6+ features may not work.
    AppContainer @ react-hot-loader.development.js:2375
    AppContainer @ VM2755:14
    constructClassInstance @ react-dom.development.js:14204
    updateClassComponent @ react-dom.development.js:18413
    beginWork$1 @ react-dom.development.js:20186
    beginWork$$1 @ react-dom.development.js:25756
...
```
That leads to https://github.com/gaearon/react-hot-loader/issues/1227
where it is noted over a series of comments that the configuration
instrucations are rather confusing:
> The readme is confusing about this. It says a Webpack plugin is required, then recommends using the Babel plugin instead. The Webpack plugin apparently patches React DOM for you to basically turn it into @hot-loader/react-dom, but it is unclear if it can be used in conjunction with the Babel plugin.
> ...
> Using the Webpack plugin in conjunction with the Babel plugin does not remove the warning. Solely using the Webpack plugin doesn't either. Only the Babel plugin combined with `@hot-loader/react-dom` and a Webpack config alias does.

And eventually leads to the following "this config seems to work" comment:
```
// App.jsx

import { hot } from 'react-hot-loader/root'

// ...

export default hot(App)
```

```
// .babelrc

{
  "plugins": ["react-hot-loader/babel"]
  // ...
}
```

```
// package.json

{
  "dependencies": {
    "react-hot-loader": "^4.8.3",
    "@hot-loader/react-dom": "^16.8.6"
    // ...
  }
  // ...
}
```

```
// webpack.config.js

{
  // ...
  resolve: {
    alias: {
      'react-dom': '@hot-loader/react-dom'
    }
  }
}
```