### PR TITLE
Minor fix for <AppIcon> to prevent WCAG Color Checker from reporting a false negative

### DIFF
--- a/src/components/AppIcon/AppIcon.css
+++ b/src/components/AppIcon/AppIcon.css
@@ -37,6 +37,7 @@
   transition: none;
   border-radius: 25%;
   background-color: var(--color-icon) !important;
+  color: var(--bg);
 
   &::after {
     content: "";


### PR DESCRIPTION
We are currently in the process of checking up on all things accessibility related in FOLIO apps and we noticed that the WCAG Color Checker (a great tool for detecting color contrast ratio issues) was reporting that app icons had poor color contrast ratio.

This is a false negative because the icon itself doesn't contain text – only an icon as an image. And since there are a lot of AppIcon's in a FOLIO app it can lead to unnecessary noise when checking for color contrast issues.

A simple fix for this is to add a color of #FFF to the .icon element to make WCAG ignore this false negative. Nothing changes visually with this fix.

## Before
![image](https://user-images.githubusercontent.com/640976/76984013-952f1100-693e-11ea-94c7-d6eeb1a5c403.png)

## After
![image](https://user-images.githubusercontent.com/640976/76983503-d4109700-693d-11ea-9609-27d62ace1601.png)

