### PR TITLE
history location is PropTypes.object, not PropTypes.string

### DIFF
--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -197,7 +197,7 @@ Root.propTypes = {
   history: PropTypes.shape({
     action: PropTypes.string.isRequired,
     length: PropTypes.number.isRequired,
-    location: PropTypes.string,
+    location: PropTypes.object.isRequired,
     push: PropTypes.func.isRequired,
     replace: PropTypes.func.isRequired,
   }),


### PR DESCRIPTION
I guess this is the danger we run into when adding prop-types to satisfy ESLint: we do need to also check that the added prop-types are actually correct, otherwise we get big, ugly red messages on the JavaScript console:

> Warning: Failed prop type: Invalid prop `history.location` of type `object` supplied to `Root`, expected `string`.