### PR TITLE
Adjustments for settings <NavList>'s and apps dropdown

### DIFF
--- a/src/components/MainNav/AppList/AppList.css
+++ b/src/components/MainNav/AppList/AppList.css
@@ -63,6 +63,7 @@
 .dropdownBody {
   width: 100%;
   outline: 0;
+  padding: var(--gutter-static) 0;
 }
 
 .dropdownList {
@@ -76,17 +77,13 @@
 }
 
 .dropdownListItemLabel {
-  padding: 0 4px;
+  padding: 0 var(--gutter-static-one-third);
   min-width: 200px;
   font-weight: var(--text-weight-bold);
 }
 
 [dir="rtl"] .dropdownListItemLabel {
   text-align: right;
-}
-
-.dropdownHeader {
-  padding: 10px 10px 5px;
 }
 
 /**

--- a/src/components/MainNav/AppList/components/AppListDropdown/AppListDropdown.js
+++ b/src/components/MainNav/AppList/components/AppListDropdown/AppListDropdown.js
@@ -8,54 +8,46 @@ import sortBy from 'lodash/sortBy';
 import classnames from 'classnames';
 
 import NavListItem from '@folio/stripes-components/lib/NavListItem';
+import NavListSection from '@folio/stripes-components/lib/NavListSection';
 import NavListItemStyles from '@folio/stripes-components/lib/NavListItem/NavListItem.css';
 
 import AppIcon from '../../../../AppIcon';
 import css from '../../AppList.css';
 
 const AppListDropdown = ({ toggleDropdown, apps, listRef, selectedApp }) => (
-  <div className={css.dropdownBody} data-test-app-list-dropdown>
-    <ul
-      ref={listRef}
-      className={css.dropdownList}
-      role="menu"
-    >
-      {
-        sortBy(apps, app => app.displayName.toLowerCase()).map((app, index) => {
-          const isOddRow = !(index % 2);
-
-          return (
-            <li
-              role="none"
-              key={app.id}
-            >
-              <NavListItem
-                data-test-app-list-dropdown-item
-                data-test-app-list-dropdown-current-item={selectedApp && selectedApp.id === app.id}
-                key={index}
-                onClick={toggleDropdown}
-                to={app.href}
-                isActive={selectedApp && selectedApp.id === app.id}
-                className={classnames(css.dropdownListItem, { [NavListItemStyles.odd]: isOddRow })}
-                aria-label={app.displayName}
-                id={`app-list-dropdown-item-${app.id}`}
-                role="menuitem"
-              >
-                <AppIcon
-                  app={app.name}
-                  size="small"
-                  icon={app.iconData}
-                />
-                <span className={css.dropdownListItemLabel}>
-                  {app.displayName}
-                </span>
-              </NavListItem>
-            </li>
-          );
-        })
-      }
-    </ul>
-  </div>
+  <NavListSection
+    role="menu"
+    className={css.dropdownBody}
+    ref={listRef}
+    data-test-app-list-dropdown
+    striped
+  >
+    {
+      sortBy(apps, app => app.displayName.toLowerCase()).map(app => (
+        <NavListItem
+          key={app.id}
+          data-test-app-list-dropdown-item
+          data-test-app-list-dropdown-current-item={selectedApp && selectedApp.id === app.id}
+          onClick={toggleDropdown}
+          to={app.href}
+          isActive={selectedApp && selectedApp.id === app.id}
+          className={css.dropdownListItem}
+          aria-label={app.displayName}
+          id={`app-list-dropdown-item-${app.id}`}
+          role="menuitem"
+        >
+          <AppIcon
+            app={app.name}
+            size="small"
+            icon={app.iconData}
+          />
+          <span className={css.dropdownListItemLabel}>
+            {app.displayName}
+          </span>
+        </NavListItem>
+      ))
+    }
+  </NavListSection>
 );
 
 AppListDropdown.propTypes = {

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -1,9 +1,5 @@
 @import "@folio/stripes-components/lib/variables";
 
-.navListSection {
-  margin-bottom: 20px;
-}
-
 .panePlaceholder {
   background-color: var(--color-fill);
   flex: 1;

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -86,24 +86,34 @@ class Settings extends React.Component {
           defaultWidth="20%"
           paneTitle={<FormattedMessage id="stripes-core.settings" />}
         >
-          <NavList ariaLabel="stripes-core.settings">
-            <NavListSection
-              activeLink={activeLink}
-              label={<FormattedMessage id="stripes-core.settings" />}
-              className={css.navListSection}
-            >
-              {navLinks}
-            </NavListSection>
-          </NavList>
-          <NavListSection
-            label={<FormattedMessage id="stripes-core.settingSystemInfo" />}
-            activeLink={activeLink}
-            className={css.navListSection}
-          >
-            <NavListItem to="/settings/about">
-              <FormattedMessage id="stripes-core.front.about" />
-            </NavListItem>
-          </NavListSection>
+          <FormattedMessage id="stripes-core.settings">
+            { label => (
+              <NavList ariaLabel={label}>
+                <NavListSection
+                  activeLink={activeLink}
+                  label={label}
+                  className={css.navListSection}
+                >
+                  {navLinks}
+                </NavListSection>
+              </NavList>
+            )}
+          </FormattedMessage>
+          <FormattedMessage id="stripes-core.settingSystemInfo">
+            {label => (
+              <NavList aria-label={label}>
+                <NavListSection
+                  label={label}
+                  activeLink={activeLink}
+                  className={css.navListSection}
+                >
+                  <NavListItem to="/settings/about">
+                    <FormattedMessage id="stripes-core.front.about" />
+                  </NavListItem>
+                </NavListSection>
+              </NavList>
+            )}
+          </FormattedMessage>
         </Pane>
         <Switch>
           {routes}


### PR DESCRIPTION
This is a follow-up PR for the changes I made in:
https://github.com/folio-org/stripes-components/pull/1209

## Changes
- Updated `<NavList>`-implementation for settings
- Removed extra margin from `<NavList>`'s
- Added aria-label for `<NavList>`'s
- Updated app list dropdown to use `<NavListSection>` and striped styles

## To-do
- [x] These changes must be merged in for this PR to work: https://github.com/folio-org/stripes-components/pull/1217

## Before
![image](https://user-images.githubusercontent.com/640976/77423477-92656d80-6dcf-11ea-9735-032ab04fde74.png)

![image](https://user-images.githubusercontent.com/640976/77423494-9d200280-6dcf-11ea-9b10-d727f26f4ba6.png)

![image](https://user-images.githubusercontent.com/640976/77423635-f1c37d80-6dcf-11ea-9fa4-b757fbc7f4ac.png)

## After
![image](https://user-images.githubusercontent.com/640976/77423547-b759e080-6dcf-11ea-93c7-56bc408235a4.png)

![image](https://user-images.githubusercontent.com/640976/77423580-c6409300-6dcf-11ea-83e1-258d5cb3f27f.png)

![image](https://user-images.githubusercontent.com/640976/77423602-d48eaf00-6dcf-11ea-8565-31d449e3b783.png)