### PR TITLE
Suppress react-intl errors for unset permissions

### DIFF
--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -137,6 +137,15 @@ class Root extends Component {
               currency={currency}
               messages={translations}
               textComponent={Fragment}
+              // The filtering that follows in onError was added as part of resolving UIU-488.
+              // We should remove it by May 15 2020 per STCOR-424.
+              onError={error => {
+                if (/React.Intl.*Missing.message.*\.permission\..*using.default.message/.test(error)) {
+                  return;
+                }
+
+                console.error(error); // eslint-disable-line
+              }}
             >
               <RootWithIntl
                 stripes={stripes}


### PR DESCRIPTION
As part of https://github.com/folio-org/ui-users/pull/1240, we've introduced an unavoidable amount of console errors by default. This PR suppresses those errors.

This PR is intended to be reverted by May 15 as per [STCOR-424](https://issues.folio.org/browse/STCOR-424).