### PR TITLE
throw and log errors that prevent module load

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -41,12 +41,19 @@ class Settings extends React.Component {
       .filter(x => stripes.hasPerm(`settings.${x.module.replace(/^@folio\//, '')}.enabled`))
       .sort((x, y) => x.displayName.toLowerCase().localeCompare(y.displayName.toLowerCase()))
       .map((m) => {
-        const connect = connectFor(m.module, stripes.epics, stripes.logger);
-        return {
-          module: m,
-          Component: connect(m.getModule()),
-          moduleStripes: stripes.clone({ connect }),
-        };
+        try {
+          const connect = connectFor(m.module, stripes.epics, stripes.logger);
+          const module = m.getModule();
+
+          return {
+            module: m,
+            Component: connect(module),
+            moduleStripes: stripes.clone({ connect }),
+          };
+        } catch (error) {
+          console.error(error); // eslint-disable-line
+          throw Error(error);
+        }
       });
   }
 

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -24,7 +24,15 @@ function getModuleRoutes(stripes) {
           if (!stripes.hasPerm(perm)) return null;
 
           const connect = connectFor(module.module, stripes.epics, stripes.logger);
-          const Current = connect(module.getModule());
+
+          let Current;
+          try {
+            Current = connect(module.getModule());
+          } catch (error) {
+            console.error(error); // eslint-disable-line
+            throw Error(error);
+          }
+
           const moduleStripes = stripes.clone({ connect });
 
           return (


### PR DESCRIPTION
This PR logs the errors that are caught when parsing a module during `getModule()`. In tandem with https://github.com/folio-org/stripes-connect/pull/141, these errors become more easily fixable.

**Before:** Useless error message that doesn't say what the issue was.
<img width="864" alt="Screen Shot 2020-04-30 at 2 44 07 PM" src="https://user-images.githubusercontent.com/5324374/80748426-e6602200-8af2-11ea-9987-32532f2a0356.png">

**After:** A better chance at debugging the issue based on the error message.
<img width="1440" alt="Screen Shot 2020-04-30 at 3 09 08 PM" src="https://user-images.githubusercontent.com/5324374/80749528-908c7980-8af4-11ea-9736-f214c5276e61.png">

Throwing **and** logging seems excessive, but:
- We can't just `throw` because React swallows some of the exceptions for reasons I don't fully understand.
- We _shouldn't_ just log when there's a major problem like the module fails to parse.