### PR TITLE
STRIPES-678 pin moment to ~2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 4.2.0 (IN PROGRESS)
+
+* Pin `moment` at `~2.24.0`. Refs STRIPES-678.
+
 ## [4.1.0](https://github.com/folio-org/stripes-core/tree/v4.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v4.0.0...v4.1.0)
 

--- a/package.json
+++ b/package.json
@@ -167,5 +167,8 @@
     "react-intl": "^2.9.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1"
+  },
+  "resolutions": {
+    "moment": "~2.24.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "^0.4.0",
     "miragejs": "^0.1.32",
-    "moment": "^2.19.1",
+    "moment": "~2.24.0",
     "moment-timezone": "^0.5.14",
     "node-object-hash": "^1.2.0",
     "optimize-css-assets-webpack-plugin": "^5.0.0",


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0`
([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

Refs [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)