### PR TITLE
STRIPES-672 provide react-intl as devdep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 5.0.0 (IN PROGRESS)
+
+* Provide `react-intl` as a dev-dep. Refs STRIPES-672.
+
 ## 4.2.0 (IN PROGRESS)
 
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mocha-junit-reporter": "^1.17.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-intl": "^4.5.3",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "sinon": "^7.3.2",
@@ -163,7 +164,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "react-intl": "^4.5.1",
+    "react-intl": "^4.5.3",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1"
   },


### PR DESCRIPTION
`react-intl` needs to be provided as a dev-dep since it is only listed
as a peer-dep. It isn't clear to me why this is suddenly the case when
previously releases were not, but here we are.

Refs [STRIPES-672](https://issues.folio.org/browse/STRIPES-672)