### PR TITLE
STSMACOM-338: Add localization for password validation message

### DIFF
--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -125,6 +125,7 @@
   "errors.password.keyboardSequence.invalid": "The password must not contain a keyboard sequence.",
   "errors.password.repeatingSymbols.invalid": "The password must not contain the same character in a row.",
   "errors.password.whiteSpace.invalid": "The password must not contain whitespaces.",
+  "errors.password.consecutiveWhitespaces.invalid": "The password must not contain consecutive white space characters.",
 
   "createResetPassword.header": "Choose a password",
   "createResetPassword.newPassword": "New Password",


### PR DESCRIPTION
# Description
Add localization for password validation message
# Task
https://issues.folio.org/browse/STSMACOM-338