### PR TITLE
CHAL-300: CalloutContext provides context rather than context.current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0 (IN PROGRESS)
 
 * Provide `react-intl` as a dev-dep. Refs STRIPES-672.
+* BREAKING: Changed `CalloutContext` to provide `context` rather than `context.current`. Refs CHAL-300
 
 ## 4.2.0 (IN PROGRESS)
 

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -73,6 +73,7 @@ class RootWithIntl extends React.Component {
 
     return (
       <StripesContext.Provider value={stripes}>
+        <Callout ref={this.callout} />
         <CalloutContext.Provider value={this.callout}>
           <ModuleTranslator>
             <TitleManager>
@@ -172,7 +173,6 @@ class RootWithIntl extends React.Component {
             </TitleManager>
           </ModuleTranslator>
         </CalloutContext.Provider>
-        <Callout ref={this.callout} />
       </StripesContext.Provider>
     );
   }

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -73,7 +73,7 @@ class RootWithIntl extends React.Component {
 
     return (
       <StripesContext.Provider value={stripes}>
-        <CalloutContext.Provider value={this.callout.current}>
+        <CalloutContext.Provider value={this.callout}>
           <ModuleTranslator>
             <TitleManager>
               <HotKeys

--- a/test/bigtest/tests/callout-context-test.js
+++ b/test/bigtest/tests/callout-context-test.js
@@ -12,7 +12,7 @@ import AppInteractor from '../interactors/app';
 
 const HookApp = () => {
   const callout = useContext(CalloutContext);
-  callout.sendCallout({ message: 'Hook', type: 'success' });
+  callout.current.sendCallout({ message: 'Hook', type: 'success' });
   return <h1>Hook App</h1>;
 };
 
@@ -20,7 +20,7 @@ class ContextApp extends Component {
   static contextType = CalloutContext;
 
   componentDidMount() {
-    this.context.sendCallout({ message: 'Context', type: 'error' });
+    this.context.current.sendCallout({ message: 'Context', type: 'error' });
   }
 
   render() {
@@ -30,7 +30,7 @@ class ContextApp extends Component {
 
 const CalloutFreeApp = () => <h1>No Callouts!</h1>;
 
-describe('CalloutContext', () => {
+describe.only('CalloutContext', () => {
   const app = new AppInteractor();
   const callout = new CalloutInteractor();
 
@@ -98,6 +98,26 @@ describe('CalloutContext', () => {
       it('continues to show the previous error callout', () => {
         expect(callout.errorCalloutIsPresent).to.be.true;
       });
+    });
+  });
+
+  describe('loading the Context app directly via URL', () => {
+    beforeEach(function () {
+      this.visit('/context');
+    });
+
+    it('shows a error callout', () => {
+      expect(callout.errorCalloutIsPresent).to.be.true;
+    });
+  });
+
+  describe('loading the Hook app directly via URL', () => {
+    beforeEach(function () {
+      this.visit('/hook');
+    });
+
+    it('shows a success callout', () => {
+      expect(callout.successCalloutIsPresent).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Inspired by https://github.com/folio-org/stripes-core/pull/857

These tests are still breaking locally.