### PR TITLE
STCOR-419: Fix aXe error related to <OverlayContainer>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 5.0.0 (IN PROGRESS)
 
 * Provide `react-intl` as a dev-dep. Refs STRIPES-672.
+* Moved `<OverlayContainer>` into the main content area to fix an aXe warning. Refs STCOR-419.
+
 
 ## 4.2.0 (IN PROGRESS)
 

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -84,7 +84,6 @@ class RootWithIntl extends React.Component {
                   <Router history={history}>
                     { token || disableAuth ?
                       <MainContainer>
-                        <OverlayContainer />
                         <AppCtxMenuProvider>
                           <MainNav stripes={stripes} />
                           <HandlerManager
@@ -93,6 +92,7 @@ class RootWithIntl extends React.Component {
                           />
                           { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
                             <ModuleContainer id="content">
+                              <OverlayContainer />
                               <Switch>
                                 <TitledRoute
                                   name="home"

--- a/src/components/OverlayContainer/OverlayContainer.css
+++ b/src/components/OverlayContainer/OverlayContainer.css
@@ -3,5 +3,6 @@
   pointer-events: none;
   z-index: 9999;
   width: 100vw;
-  height: 100vh;
+  top: 0;
+  bottom: 0;
 }

--- a/src/components/OverlayContainer/OverlayContainer.css
+++ b/src/components/OverlayContainer/OverlayContainer.css
@@ -1,5 +1,5 @@
 .overlayContainer {
-  position: absolute;
+  position: fixed;
   pointer-events: none;
   z-index: 9999;
   width: 100vw;


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-419

Moved `<OverlayContainer>` into the main content area to fix the aXe error: `Some page content is not contained by landmarks'`

Since the `<OverlayContainer>` was rendered outside a landmark element, aXe would report an error when e.g. a dropdown was opened inside the `<OverlayContainer>`. Moving it into the the `<main>` fixes this issue since it's now inside a landmark element.

Updated position to `fixed` to ensure that the `<OverlayContainer>` covers the entire viewport.