### PR TITLE
STCOM-598: MainNav a11y updates

### DIFF
--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -134,25 +134,23 @@ class AppList extends Component {
     );
 
     return (
-      <>
-        <FormattedMessage id="stripes-core.mainnav.showAllApplicationsButtonAriaLabel">
-          { ariaLabel => (
-            <NavButton
-              data-test-app-list-apps-toggle
-              label={label}
-              aria-label={ariaLabel}
-              className={css.navMobileToggle}
-              labelClassName={css.dropdownToggleLabel}
-              onClick={this.toggleDropdown}
-              selected={this.state.open}
-              icon={icon}
-              {...getTriggerProps()}
-              id={dropdownToggleId}
-              noSelectedBar
-            />
-          )}
-        </FormattedMessage>
-      </>
+      <FormattedMessage id="stripes-core.mainnav.showAllApplicationsButtonAriaLabel">
+        { ariaLabel => (
+          <NavButton
+            data-test-app-list-apps-toggle
+            label={label}
+            aria-label={ariaLabel}
+            className={css.navMobileToggle}
+            labelClassName={css.dropdownToggleLabel}
+            onClick={this.toggleDropdown}
+            selected={this.state.open}
+            icon={icon}
+            {...getTriggerProps()}
+            id={dropdownToggleId}
+            noSelectedBar
+          />
+        )}
+      </FormattedMessage>
     );
   }
 
@@ -210,13 +208,10 @@ class AppList extends Component {
       <ResizeContainer items={apps} hideAllWidth={767} currentAppId={selectedApp && selectedApp.id}>
         {({ hiddenItems, itemWidths }) => {
           return (
-            <nav className={css.appList} aria-labelledby="main_app_list_label" data-test-app-list>
-              <h3 className="sr-only" id="main_app_list_label">
-                <FormattedMessage id="stripes-core.mainnav.applicationListLabel" />
-              </h3>
+            <div className={css.appList} data-test-app-list>
               {this.renderNavButtons(hiddenItems, itemWidths)}
               {this.renderNavDropdown(hiddenItems)}
-            </nav>
+            </div>
           );
         }
       }

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -184,7 +184,7 @@ class MainNav extends Component {
   }
 
   render() {
-    const { stripes } = this.props;
+    const { stripes, intl } = this.props;
 
     return (
       <LastVisitedContext.Consumer>
@@ -198,10 +198,7 @@ class MainNav extends Component {
                 <SkipLink />
                 <CurrentAppGroup selectedApp={selectedApp} config={stripes.config} />
               </div>
-              <nav aria-labelledby="main_navigation_label" className={css.endSection}>
-                <h2 className="sr-only" id="main_navigation_label">
-                  <FormattedMessage id="stripes-core.mainnav.topLevelLabel" />
-                </h2>
+              <nav aria-label={intl.formatMessage({ id: 'stripes-core.mainnav.topLevelLabel' })} className={css.endSection}>
                 <AppList
                   apps={apps}
                   selectedApp={selectedApp}

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -90,7 +90,7 @@
   "settingChoose": "Choose settings",
 
   "mainnav.showAllApplicationsButtonLabel": "Apps",
-  "mainnav.showAllApplicationsButtonAriaLabel": "Show all applications",
+  "mainnav.showAllApplicationsButtonAriaLabel": "All applications",
   "mainnav.currentAppAriaLabel": "Current open application: {appName} (Click to go home)",
   "mainnav.topLevelLabel": "Primary",
   "mainnav.applicationListLabel": "Application List",


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/STCOM-598

## Changes
- Resolved nested nav elements in `<MainNav>`
- Removed 'Application list' header since it's redundant
- Updated nav element to use aria-label instead of aria-labelledby to avoid the referenced h2 to be listed in "Headers" on screen readers (Tested on Mac screen reader)
- Updated aria-label 'Show all applications' -> 'All applications' in en.json
- Removed redundant fragment in AppList