### PR TITLE
Minor OverlayContainer fix

### DIFF
--- a/src/components/OverlayContainer/OverlayContainer.css
+++ b/src/components/OverlayContainer/OverlayContainer.css
@@ -1,7 +1,7 @@
 .overlayContainer {
-  position: fixed;
+  position: absolute;
   pointer-events: none;
   z-index: 9999;
-  width: 100vw;
-  height: 100vw;
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
Updated CSS for OverlayContainer after noticing an issue on some touch devices where the container only stretched a part of the screen.