### PR TITLE
STCOR-424 stop filtering react-intl permissions warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Show app icons in the settings navigation. It's pretty.
 * Make accessible errors at `Login` page. Refs STCOR-430.
+* Stop filtering "missing permission" warnings from `react-intl`. Refs STCOR-424.
 
 ## [5.0.0](https://github.com/folio-org/stripes-core/tree/v5.0.0) (2020-05-19)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v4.1.0...v5.0.0)

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -137,15 +137,6 @@ class Root extends Component {
               currency={currency}
               messages={translations}
               textComponent={Fragment}
-              // The filtering that follows in onError was added as part of resolving UIU-488.
-              // We should remove it by May 15 2020 per STCOR-424.
-              onError={error => {
-                if (/React.Intl.*Missing.message.*\.permission\..*using.default.message/.test(error)) {
-                  return;
-                }
-
-                console.error(error); // eslint-disable-line
-              }}
             >
               <RootWithIntl
                 stripes={stripes}


### PR DESCRIPTION
`react-intl` is pretty verbose about missing translation values, even
when using its own built-in system for providing default values, which
seems odd. We suppressed those warnings for permissions-related values
for a while to give folks time to update their apps and start providing
entries in their translation files, rather than just displaying the
English-only values pulled from `package.json` files as part of the
permission description. No longer.

I was supposed to do this in time for the 5.0 release on/before May 15. Alas. 
There will likely be a `v5.0.x` patch release and we should include it there. 

Refs [STCOR-424](https://issues.folio.org/browse/STCOR-424)