### PR TITLE
STRIPES-685 - move to users-bl 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 5.0.2 (IN PROGRESS)
+
+* Support `users-bl` `v6.0` (some unused endpoints were removed). Refs STCOR-436, STRIPES-685.
+
 ## [5.0.1](https://github.com/folio-org/stripes-core/tree/v5.0.1) (2020-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.0...v5.0.1)
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "stripes": {
     "okapiInterfaces": {
-      "users-bl": "6.0",
+      "users-bl": "5.0 6.0",
       "authtoken": "1.0 2.0",
       "configuration": "2.0"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "stripes": {
     "okapiInterfaces": {
-      "users-bl": "5.0",
+      "users-bl": "6.0",
       "authtoken": "1.0 2.0",
       "configuration": "2.0"
     },


### PR DESCRIPTION
See https://issues.folio.org/browse/STRIPES-685

For additional context, see https://issues.folio.org/browse/MODUSERBL-97, https://issues.folio.org/browse/MODLOGIN-128 and other related issues

I think we can dual-support 5.0 and 6.0 here since `?includes=credentials` isn't used here - unless I'm missing something.