### PR TITLE
STCOR-390 abandon legacy context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 5.1.0 (IN PROGRESS)
+
+* Abandon legacy context! Refs STCOR-390.
+
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)
 

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -2,12 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect as reduxConnect } from 'react-redux';
 
+import { ConnectContext } from '@folio/stripes-connect';
 import {
   requestLogin,
   requestSSOLogin,
 } from '../../loginServices';
 import { setAuthError } from '../../okapiActions';
-
 import Login from './Login';
 
 class LoginCtrl extends Component {
@@ -21,13 +21,10 @@ class LoginCtrl extends Component {
     clearAuthErrors: PropTypes.func.isRequired,
   };
 
-  static contextTypes = {
-    store: PropTypes.object,
-  };
+  static contextType = ConnectContext;
 
-  constructor(props, context) {
+  constructor(props) {
     super(props);
-    this.store = context.store;
     this.handleSubmit = this.handleSubmit.bind(this);
     this.sys = require('stripes-config'); // eslint-disable-line global-require
     this.okapiUrl = this.sys.okapi.url;
@@ -43,7 +40,7 @@ class LoginCtrl extends Component {
   }
 
   handleSubmit(data) {
-    return requestLogin(this.okapiUrl, this.store, this.tenant, data);
+    return requestLogin(this.okapiUrl, this.context.store, this.tenant, data);
   }
 
   handleSSOLogin() {

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -34,10 +34,6 @@ class AppList extends Component {
     selectedApp: PropTypes.object,
   }
 
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-  }
-
   constructor(props) {
     super(props);
 

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { isEqual, find } from 'lodash';
 import { compose } from 'redux';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router';
 import localforage from 'localforage';
 
@@ -53,15 +53,6 @@ class MainNav extends Component {
     })
   };
 
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-  }
-
-  static childContextTypes = {
-    // It seems wrong that we have to tell this generic component what specific properties to put in the context
-    stripes: PropTypes.object,
-  };
-
   constructor(props) {
     super(props);
     this.state = {
@@ -70,12 +61,6 @@ class MainNav extends Component {
     this.store = props.stripes.store;
     this.logout = this.logout.bind(this);
     this.getAppList = this.getAppList.bind(this);
-  }
-
-  getChildContext() {
-    return {
-      stripes: this.props.stripes,
-    };
   }
 
   componentDidMount() {

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -45,10 +45,6 @@ class ProfileDropdown extends Component {
     }).isRequired,
   };
 
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-  };
-
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
* Abandon use of React's legacy context API in favor of the currently
supported API.
* Remove unused references to the router context.

Refs [STCOR-390](https://issues.folio.org/browse/STCOR-390)