### PR TITLE
Tweak regex to match the entire module route string, refs ERM-950

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Abandon legacy context! Refs STCOR-390.
 * Increment `react-router` to `^5.2`.
+* Tweak regex to match the entire module route. Refs ERM-950
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/src/locationService.js
+++ b/src/locationService.js
@@ -29,7 +29,7 @@ export function isQueryResourceModule(module, location) {
   if (!module) return false;
 
   const path = location.pathname;
-  const re = new RegExp(`^${module.route}|^/settings${module.route}`, 'i');
+  const re = new RegExp(`^${module.route}$|^/settings${module.route}$`, 'i');
 
   return module.queryResource && path.match(re);
 }


### PR DESCRIPTION
Currently the [logic](https://github.com/folio-org/stripes-core/blob/master/src/locationService.js#L32) to figure out which module a [queryResource](https://github.com/folio-org/ui-erm-comparisons/blob/master/package.json#L29) belongs to, just matches on the start of the module `route` string (expressed via the stripes object in the package.json). for eg: `/erm` and `/erm-comparisons` which are top level routes to the `ui-agreements` and `ui-erm-comparisons` apps respectively would both resolve to the [agreements](https://github.com/folio-org/ui-agreements/blob/master/package.json#L107) module (If _both_ the apps were to be present in the tenants `stripes.config.js`). 

To prevent such a scenario, this PR extends the logic to match the entire `module.route` string so that the `queryResource` gets mapped to the expected `module`.