### PR TITLE
Revert "Tweak regex to match the entire module route string, refs ERM-950"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * Abandon legacy context! Refs STCOR-390.
 * Increment `react-router` to `^5.2`.
-* Tweak regex to match the entire module route. Refs ERM-950
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/src/locationService.js
+++ b/src/locationService.js
@@ -29,7 +29,7 @@ export function isQueryResourceModule(module, location) {
   if (!module) return false;
 
   const path = location.pathname;
-  const re = new RegExp(`^${module.route}$|^/settings${module.route}$`, 'i');
+  const re = new RegExp(`^${module.route}|^/settings${module.route}`, 'i');
 
   return module.queryResource && path.match(re);
 }


### PR DESCRIPTION
Reverts folio-org/stripes-core#884

Reverting this PR as the fix doesnt handle the scenario when the `foo` apps `module.route` is `/foo` whereas the `home` route is `foo/bar`.

In that scenario the `location.pathname` would be `foo/bar` which we are matching with an end-of-string marker, so `/foo` in this case which fails to match and hence the query resource is not annointed to the `foo` app as expected.

I would rather wait to discuss a solution for this on the stripes-arch call before adding in some additional conditional regexes. 