### PR TITLE
STCOR-440: Update location only if resourceQuery actually changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Abandon legacy context! Refs STCOR-390.
 * Increment `react-router` to `^5.2`.
+* Update location only if `resourceQuery` actually changes. Fixes STCOR-440.
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -15,7 +15,8 @@ import {
   getLocationQuery,
   updateLocation,
   getCurrentModule,
-  isQueryResourceModule
+  isQueryResourceModule,
+  getQueryResourceState,
 } from '../../locationService';
 
 import css from './MainNav.css';
@@ -65,6 +66,8 @@ class MainNav extends Component {
 
   componentDidMount() {
     let curQuery = getLocationQuery(this.props.location);
+    const prevQueryState = {};
+
     this._unsubscribe = this.store.subscribe(() => {
       const { history, location } = this.props;
       const module = this.curModule;
@@ -75,8 +78,16 @@ class MainNav extends Component {
         && find(state.okapi.authFailure, { type: 'error', code: 'user.timeout' })) {
         this.returnToLogin();
       }
+
       if (module && isQueryResourceModule(module, location)) {
-        curQuery = updateLocation(module, curQuery, this.store, history, location);
+        const { moduleName } = module;
+        const queryState = getQueryResourceState(module, this.store);
+
+        // only update location if query state has changed
+        if (!isEqual(queryState, prevQueryState[moduleName])) {
+          curQuery = updateLocation(module, curQuery, this.store, history, location);
+          prevQueryState[moduleName] = queryState;
+        }
       }
     });
   }


### PR DESCRIPTION
This PR fixes an issue with occasional double `history.push`.

While working on https://issues.folio.org/browse/UIU-1779 I noticed that sometimes the `history.push` executes twice.

Once after we apply search:

https://github.com/folio-org/ui-users/blob/0a4b7257bcbc36450955c9a88c51713c047fefba/src/routes/UserSearchContainer.js#L172

and the second time in:

https://github.com/folio-org/stripes-core/blob/master/src/locationService.js#L75

This currently happens because when the first `history.push` is executed the location is being changed which triggers resource refresh in stripes-connect:

https://github.com/folio-org/stripes-connect/blob/master/connect.js#L149

The refresh fails in:

https://github.com/folio-org/stripes-connect/blob/master/RESTResource/RESTResource.js#L654-L660 (potentially another bug in stripes-connect)

The `abortFetch` updates the redux store causing:

https://github.com/folio-org/stripes-core/blob/master/src/components/MainNav/MainNav.js#L79

to execute again.


I think @JohnC-80 has seen these issues before too during the ui-users refactoring.