### PR TITLE
better harness doesn't throw react-intl errors

### DIFF
--- a/test/bigtest/helpers/Harness.js
+++ b/test/bigtest/helpers/Harness.js
@@ -5,7 +5,9 @@ import { reducer as formReducer } from 'redux-form';
 import { Provider } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 
-import translations from '@folio/stripes-components/translations/stripes-components/en';
+import componentsTranslations from '@folio/stripes-components/translations/stripes-components/en';
+import coreTranslations from '../../../translations/stripes-core/en';
+
 
 const reducers = {
   form: formReducer,
@@ -15,20 +17,36 @@ const reducer = combineReducers(reducers);
 
 const store = createStore(reducer);
 
-// mimics the StripesTranslationPlugin in @folio/stripes-core
-function prefixKeys(obj) {
+/**
+ * mimics the StripesTranslationPlugin in @folio/stripes-core:
+ * given a list of key-value pairs like {"foo": "bar"} and a prefix,
+ * return {"prefix.foo": "bar", ...}.
+ *
+ * @param {*} obj map of key-value pairs
+ * @param {*} prefix module-path to prepend to each key
+ */
+function prefixKeys(obj, prefix) {
   const res = {};
   for (const key of Object.keys(obj)) {
-    res[`stripes-components.${key}`] = obj[key];
+    res[`${prefix}.${key}`] = obj[key];
   }
   return res;
 }
 
+/**
+ * mount a component with contexts provided by redux-store
+ * and react-intl.
+ */
 class Harness extends React.Component {
   render() {
+    const prefixedComponentsTranslations = prefixKeys(componentsTranslations, 'stripes-components');
+    const prefixedCoreTranslations = prefixKeys(coreTranslations, 'stripes-core');
+
+    const allTranslations = { ...prefixedComponentsTranslations, ...prefixedCoreTranslations };
+
     return (
       <Provider store={store}>
-        <IntlProvider locale="en" key="en" timeZone="UTC" messages={prefixKeys(translations)}>
+        <IntlProvider locale="en" key="en" timeZone="UTC" messages={allTranslations}>
           {this.props.children}
         </IntlProvider>
       </Provider>
@@ -37,6 +55,7 @@ class Harness extends React.Component {
 }
 
 Harness.propTypes = {
+  // the components to render into the context
   children: PropTypes.node,
 };
 

--- a/test/bigtest/tests/sso-login-test.js
+++ b/test/bigtest/tests/sso-login-test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { IntlProvider } from 'react-intl';
 import { expect } from 'chai';
 import { beforeEach, it, describe } from '@bigtest/mocha';
-
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
 
 import { mount } from '../helpers/render-helpers';
+import Harness from '../helpers/Harness';
 import SSOLogin from '../../../src/components/SSOLogin';
+import translations from '../../../translations/stripes-core/en';
 
 describe('Login via SSO', () => {
   const ssoLoginButton = new ButtonInteractor('[data-test-sso-login-button]');
@@ -14,9 +14,9 @@ describe('Login via SSO', () => {
 
   beforeEach(async () => {
     await mount(
-      <IntlProvider locale="en">
+      <Harness>
         <SSOLogin handleSSOLogin={() => { clicked = true; }} />
-      </IntlProvider>
+      </Harness>
     );
   });
 
@@ -26,7 +26,7 @@ describe('Login via SSO', () => {
   });
 
   it('text should be rendered as label of button', () => {
-    expect(ssoLoginButton.text).to.equal('stripes-core.loginViaSSO');
+    expect(ssoLoginButton.text).to.equal(translations.loginViaSSO);
   });
 
   describe('clicking the SSO Login button', () => {


### PR DESCRIPTION
Include stripes-core translations in `<Harness>` so it doesn't throw the
big nasty react-intl errors when a translation key is missing. This
helps clean up the test output.