### PR TITLE
STCOR-442 don't provide Intl.DisplayNames polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Abandon legacy context! Refs STCOR-390.
 * Increment `react-router` to `^5.2`.
 * Update location only if `resourceQuery` actually changes. Fixes STCOR-440.
+* Do not provide `Intl.DisplayNames` polyfill; Chrome already handles it, and it's huuuuuge. Refs STCOR-442.
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)


### PR DESCRIPTION
We added this polyfill in #876 because react-intl v4 stopped including
certain things that are now supported directly by the browser, but the
locale data for the `Intl.DisplayNames` polyfill is just huge,
ballooning our bundle from <10 MB to >40MB. It's very noticably slower
during the initial page load, so much so that tests with a 30-second
default timeout were failing just because the bundle was still
downloading.

Refs [STCOR-442](https://issues.folio.org/browse/STCOR-442), [STCOR-435](https://issues.folio.org/browse/STCOR-435), [STRIPES-672](https://issues.folio.org/browse/STRIPES-672)