### PR TITLE
STCOR-443 single source of truth for locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Abandon legacy context! Refs STCOR-390.
 * Increment `react-router` to `^5.2`.
 * Update location only if `resourceQuery` actually changes. Fixes STCOR-440.
+* Export the list of supported locales so there is one true source for this. Refs STCOR-443.
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/index.js
+++ b/index.js
@@ -19,3 +19,6 @@ export { default as HandlerManager } from './src/components/HandlerManager';
 export { default as IntlConsumer } from './src/components/IntlConsumer';
 export { default as AppIcon } from './src/components/AppIcon';
 export { Route, Switch, Redirect } from './src/components/NestedRouter';
+
+/* misc */
+export { supportedLocales } from './src/loginServices';

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -24,6 +24,30 @@ import {
 } from './okapiActions';
 import processBadResponse from './processBadResponse';
 
+// export supported locales, i.e. the languages we provide translations for
+export const supportedLocales = [
+  'ar',
+  'zh-CN',
+  'zh-TW',
+  'da-DK',
+  'en-GB',
+  'en-SE',
+  'en-US',
+  'fr-FR',
+  'de-DE',
+  'he',
+  'hu-HU',
+  'ja',
+  'it-IT',
+  'pt-BR',
+  'pt-PT',
+  'ru',
+  'es',
+  'es-419',
+  'es-ES',
+  'ur',
+];
+
 function getHeaders(tenant, token) {
   return {
     'X-Okapi-Tenant': tenant,


### PR DESCRIPTION
The list of available locales should be exported and available from one
and only one location.

Refs [STCOR-443](https://issues.folio.org/browse/STCOR-443)