### PR TITLE
Moving tenant module info retrieval to post-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Abandon legacy context! Refs STCOR-390.
 * Increment `react-router` to `^5.2`.
 * Update location only if `resourceQuery` actually changes. Fixes STCOR-440.
+* Get OKAPI version and tenant module info after login. Refs STRIPES-671.
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,6 @@ import connectErrorEpic from './connectErrorEpic';
 import configureEpics from './configureEpics';
 import configureLogger from './configureLogger';
 import configureStore from './configureStore';
-import { discoverServices } from './discoverServices';
 import gatherActions from './gatherActions';
 import { destroyStore } from './mainActions';
 
@@ -32,7 +31,6 @@ export default class StripesCore extends Component {
 
     this.epics = configureEpics(connectErrorEpic);
     this.store = configureStore(initialState, this.logger, this.epics);
-    if (!okapi.withoutOkapi) discoverServices(this.store);
     this.actionNames = gatherActions();
   }
 

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import localforage from 'localforage';
 import { translations } from 'stripes-config';
-import { discoverServices } from './discoverServices';
 import rtlDetect from 'rtl-detect';
 import moment from 'moment';
+import { discoverServices } from './discoverServices';
 
 import {
   clearCurrentUser,

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import localforage from 'localforage';
 import { translations } from 'stripes-config';
+import { discoverServices } from './discoverServices';
 import rtlDetect from 'rtl-detect';
 import moment from 'moment';
 
@@ -149,6 +150,7 @@ function loadResources(okapiUrl, store, tenant) {
   getLocale(okapiUrl, store, tenant);
   getPlugins(okapiUrl, store, tenant);
   getBindings(okapiUrl, store, tenant);
+  if (!store.getState().okapi.withoutOkapi) discoverServices(store);
 }
 
 function createOkapiSession(okapiUrl, store, tenant, token, data) {

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import Route from 'react-router-dom/Route';
+
 import { connectFor } from '@folio/stripes-connect';
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
+
 import ModulesContext from './ModulesContext';
 import { StripesContext } from './StripesContext';
 import AddContext from './AddContext';
@@ -68,3 +70,23 @@ function getModuleRoutes(stripes) {
 }
 
 export default getModuleRoutes;
+
+// this might be handy at some point:
+//
+// import React, { useContext, useMemo } from 'react';
+// import { Route, useLocation } from 'react-router-dom';
+// import { isQueryResourceModule } from './locationService';
+//
+// export const useModules = () => useContext(ModulesContext);
+//
+// export const useCurrentApp = () => {
+//   const modules = useModules();
+//   const location = useLocation();
+//
+//   const memoizedApp = useMemo(() => {
+//     const { app, settings } = modules;
+//     return app.concat(settings).find(m => isQueryResourceModule(m, location));
+//   }, [location, modules]);
+//
+//   return memoizedApp;
+// };


### PR DESCRIPTION
- Satisfies [STRIPES-671](https://issues.folio.org/browse/STRIPES-671)
- Confirmed only OKAPI call that happens before login now is /saml/check to determine SSO status, which has graceful handling for > 400 HTTP response.
- Determining locale occurs after login, so moving to config-based is out of scope for this story.