### PR TITLE
STCOR-444: eHoldings tests fail after moving discovery services to happen after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Do not provide `Intl.DisplayNames` polyfill; Chrome already handles it, and it's huuuuuge. Refs STCOR-442.
 * Export the list of supported locales so there is one true source for this. Refs STCOR-443.
 * Get OKAPI version and tenant module info after login. Refs STRIPES-671.
+* Mock okapi session in local storage for testing. Refs STCOR-444.
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -28,6 +28,7 @@ export default function setupApplication({
   mirageOptions = {},
   scenarios,
   currentUser = {},
+  userLoggedIn = false,
 } = {}) {
   beforeEach(async function () {
     const initialState = {};
@@ -61,6 +62,14 @@ export default function setupApplication({
       setup: () => {
         this.server = startMirage(scenarios, mirageOptions);
         this.server.logging = false;
+
+        if (userLoggedIn) {
+          localforage.setItem('okapiSess', {
+            token: initialState.okapi.token,
+            user: initialState.okapi.currentUser,
+            perms: initialState.okapi.currentPerms,
+          });
+        }
 
         withModules(modules);
         withConfig({ logCategories: '', ...stripesConfig });


### PR DESCRIPTION
## Purpose
There's been an update to `loginServices` on when tenant module info is received - now it's received only after login (https://github.com/folio-org/stripes-core/pull/893). After this change a lot of eHoldings tests have started failing because eHoldings doesn't mock login or okapi session before tests.

This PR is for mocking okapi session before tests.

## Issue
[STCOR-444](https://issues.folio.org/browse/STCOR-444)