### PR TITLE
STCOR-448: Handle `react-router-dom` deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Export the list of supported locales so there is one true source for this. Refs STCOR-443.
 * Get OKAPI version and tenant module info after login. Refs STRIPES-671.
 * Mock okapi session in local storage for testing. Refs STCOR-444.
+* Handle `react-router-dom` deprecation warnings. Refs STCOR-448.
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/src/components/MainNav/NavButton/NavButton.js
+++ b/src/components/MainNav/NavButton/NavButton.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Link from 'react-router-dom/Link';
+import { Link } from 'react-router-dom';
+
 import Badge from '@folio/stripes-components/lib/Badge';
 
 import AppIcon from '../../AppIcon';

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Switch from 'react-router-dom/Switch';
-import Route from 'react-router-dom/Route';
-import { connectFor } from '@folio/stripes-connect';
+import { FormattedMessage } from 'react-intl';
 import { withRouter } from 'react-router';
+import {
+  Switch,
+  Route,
+} from 'react-router-dom';
+
+import { connectFor } from '@folio/stripes-connect';
 import NavList from '@folio/stripes-components/lib/NavList';
 import NavListItem from '@folio/stripes-components/lib/NavListItem';
 import NavListSection from '@folio/stripes-components/lib/NavListSection';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
-import { FormattedMessage } from 'react-intl';
 
 import About from '../About';
 import { StripesContext } from '../../StripesContext';

--- a/src/components/TitledRoute/TitledRoute.js
+++ b/src/components/TitledRoute/TitledRoute.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import Route from 'react-router-dom/Route';
+import { Route } from 'react-router-dom';
 
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
 

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Route from 'react-router-dom/Route';
+import { Route } from 'react-router-dom';
 
 import { connectFor } from '@folio/stripes-connect';
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';


### PR DESCRIPTION
## Purpose

Handle react-router-dom deprecation warnings

```
Chrome 84.0.4147 (Mac OS X 10.15.6) ERROR: 'Warning: Please use `require("react-router-dom").Route` instead of `require("react-router-dom/Route")`. Support for the latter will be removed in the next major release.'
Chrome 84.0.4147 (Mac OS X 10.15.6) ERROR: 'Warning: Please use `require("react-router-dom").Link` instead of `require("react-router-dom/Link")`. Support for the latter will be removed in the next major release.'
Chrome 84.0.4147 (Mac OS X 10.15.6) ERROR: 'Warning: Please use `require("react-router-dom").Switch` instead of `require("react-router-dom/Switch")`. Support for the latter will be removed in the next major release.'
```
