### PR TITLE
STCOR-449 update react-intl to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Get OKAPI version and tenant module info after login. Refs STRIPES-671.
 * Mock okapi session in local storage for testing. Refs STCOR-444.
 * Handle `react-router-dom` deprecation warnings. Refs STCOR-448.
+* Update `react-intl` to `v5`. Refs STCOR-449.
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mocha-junit-reporter": "^1.17.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "sinon": "^7.3.2",
@@ -166,7 +166,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -174,7 +174,7 @@ const About = (props) => {
             id="stripes-core.about.notEnabledModules"
             tagName="p"
             values={{
-              span: (...chunks) => <span className={css.isEmptyMessage}>{chunks}</span>
+              span: chunks => <span className={css.isEmptyMessage}>{chunks}</span>
             }}
           />
           <br />
@@ -206,14 +206,14 @@ const About = (props) => {
             <FormattedMessage
               id="stripes-core.about.key.absentInterfaces"
               values={{
-                span: (...chunks) => <span className={css.absent}>{chunks}</span>
+                span: chunks => <span className={css.absent}>{chunks}</span>
               }}
             />
             <br />
             <FormattedMessage
               id="stripes-core.about.key.incompatibleIntf"
               values={{
-                span: (...chunks) => <span className={css.incompatible}>{chunks}</span>
+                span: chunks => <span className={css.incompatible}>{chunks}</span>
               }}
             />
             <br />


### PR DESCRIPTION
Update `react-intl` from `v4` to `v5`.

Refs [STCORE-449](https://issues.folio.org/browse/STCOR-449)