### PR TITLE
Allow for passing custom initial state to BigTest setupApplication

### DIFF
--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -29,10 +29,9 @@ export default function setupApplication({
   scenarios,
   currentUser = {},
   userLoggedIn = false,
+  initialState = {},
 } = {}) {
   beforeEach(async function () {
-    const initialState = {};
-
     // when auth is disabled, add a fake user to the store
     if (disableAuth) {
       initialState.okapi = {


### PR DESCRIPTION
Due to the change in: https://github.com/folio-org/stripes-core/pull/893/files

The discovery part of the store is only populated after a successful login. This caused some tests to fail because the `discovery` was missing.

This PR allows for passing a customized `initialState` via `setupApplication` so we can populate the `discovery`. 

For example in `ui-users` the `setupApplication` can pass `initialState` similar to:

````js

export default function setupApplication({
  scenarios,
  permissions = {},
  hasAllPerms = true,
  modules,
  translations,
  currentUser,
} = {}) {
  const initialState = {
    discovery: {
      modules: {
        'mod-circulation-16.0.0-SNAPSHOT.253': 'Circulation Module',
        'mod-users-16.0.1-SNAPSHOT.121': 'users',
        'mod-feesfines-15.8.0-SNAPSHOT.73': 'feesfines',
      },
    },
  };

  setupStripesCore({
    mirageOptions,
    scenarios,
    permissions,
    modules,
    translations,
    stripesConfig: {
      hasAllPerms,
    },
    currentUser,
    initialState,
  });
}

````
 