### PR TITLE
sort interfaces modules depend on

### DIFF
--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -56,7 +56,7 @@ const About = (props) => {
           <FormattedMessage id="stripes-core.about.moduleDependsOn" values={{ module: `${m.module} ${m.version || ''}` }} />
         </Headline>
         <List
-          items={Object.keys(okapiInterfaces)}
+          items={Object.keys(okapiInterfaces).sort()}
           itemFormatter={itemFormatter}
           listStyle="bullets"
         />
@@ -80,9 +80,12 @@ const About = (props) => {
       default:
         headlineMsg = <FormattedMessage id="stripes-core.about.moduleTypeCount" values={{ count: list.length, type: caption }} />;
     }
+
+    list.sort();
+
     return (
       <div key={caption}>
-        <Headline>{headlineMsg}</Headline>
+        <Headline>headline: {headlineMsg}</Headline>
         <div data-test-stripes-core-about-module={caption}>
           <List
             listStyle="bullets"

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -85,7 +85,7 @@ const About = (props) => {
 
     return (
       <div key={caption}>
-        <Headline>headline: {headlineMsg}</Headline>
+        <Headline>{headlineMsg}</Headline>
         <div data-test-stripes-core-about-module={caption}>
           <List
             listStyle="bullets"


### PR DESCRIPTION
Sort the list of interfaces a module depends on, because it's much
easier to find something in a sorted list than an unsorted one.