### PR TITLE
STCOR-447: Automatically import CSS variables from stripes-components into UI modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "postcss-calc": "^6.0.0",
     "postcss-color-function": "^4.0.0",
     "postcss-custom-media": "^6.0.0",
-    "postcss-custom-properties": "^7.0.0",
+    "postcss-custom-properties": "^9.1.1",
     "postcss-import": "^12.0.0",
     "postcss-loader": "^3.0.0",
     "postcss-media-minmax": "^3.0.0",

--- a/webpack.config.cli.dev.js
+++ b/webpack.config.cli.dev.js
@@ -1,6 +1,7 @@
 // Top level Webpack configuration for running a development environment
 // from the command line via devServer.js
 
+const path = require('path');
 const webpack = require('webpack');
 const postCssImport = require('postcss-import');
 const autoprefixer = require('autoprefixer');
@@ -10,6 +11,7 @@ const postCssNesting = require('postcss-nesting');
 const postCssCustomMedia = require('postcss-custom-media');
 const postCssMediaMinMax = require('postcss-media-minmax');
 const postCssColorFunction = require('postcss-color-function');
+const { generateStripesAlias } = require('./webpack/module-paths');
 
 const base = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
@@ -50,7 +52,8 @@ devConfig.module.rules.push({
           postCssImport(),
           autoprefixer(),
           postCssCustomProperties({
-            preserve: false
+            preserve: false,
+            importFrom: [path.join(generateStripesAlias('@folio/stripes-components'), 'lib/variables.css')]
           }),
           postCssCalc(),
           postCssNesting(),

--- a/webpack.config.cli.prod.js
+++ b/webpack.config.cli.prod.js
@@ -1,6 +1,7 @@
 // Top level Webpack configuration for building static files for
 // production deployment from the command line
 
+const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const postCssImport = require('postcss-import');
@@ -11,6 +12,7 @@ const postCssNesting = require('postcss-nesting');
 const postCssCustomMedia = require('postcss-custom-media');
 const postCssMediaMinMax = require('postcss-media-minmax');
 const postCssColorFunction = require('postcss-color-function');
+const { generateStripesAlias } = require('./webpack/module-paths');
 
 const base = require('./webpack.config.base');
 const cli = require('./webpack.config.cli');
@@ -46,7 +48,8 @@ prodConfig.module.rules.push({
           postCssImport(),
           autoprefixer(),
           postCssCustomProperties({
-            preserve: false
+            preserve: false,
+            importFrom: [path.join(generateStripesAlias('@folio/stripes-components'), 'lib/variables.css')]
           }),
           postCssCalc(),
           postCssNesting(),


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/STCOR-447

## Changes
- Upgraded `postcss-custom-properties` to the latest version
- Added `importFrom`-setting to `postcss-custom-properties` to both development and production webpack configs to enable auto imports of CSS variables in UI modules

## Notes
With this change, you will be able to use all of the available CSS variables from `@folio/stripes-components/lib/variables.css` without manually importing them into your CSS file.
