### PR TITLE
Add okapiKy helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update `react-intl` to `v5`. Refs STCOR-449.
 * Add `suppressIntlErrors` option to stripes.config.js.
 * Refactor `CreateResetPassword` to use final-form instead of redux-form. Refs STCOR-441
+* Add `okapiKy` helpers (see [docs/okapiKy.md](docs/okapiKy.md)).
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/doc/okapiKy.md
+++ b/doc/okapiKy.md
@@ -1,0 +1,34 @@
+# Ky for Okapi
+
+Ky (https://github.com/sindresorhus/ky) is a convenient wrapper over
+browsers' fetch() implementation, allowing you to avoid much of the tedious
+promise-resolution and error-checking that raw fetch() needs by combining it
+all into one promise.
+
+## useOkapiKy
+
+useOkapiKy is a hook that sets up a Ky object that prefixes everything with
+the Okapi URL and adds headersfor tenant and token.
+
+Example usage:
+
+```
+SomeComponent = props => {
+ const ky = useOkapiKy();
+ ky('circulation/check-in-by-barcode', {
+   method: 'POST',
+   JSON: { some: 'object to encode to json...' },
+ }).then(res => {
+   if (res.ok) {
+     //...success!
+   } else {
+     //...error :(
+   }
+ });
+};
+```
+
+## withOkapiKy
+
+withOkapiKy is a higher-order component that sets up a ky object the same way
+and passes it in to the wrapped component as the prop `okapiKy`.

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ export { default as stripesConnect } from './src/stripesConnect';
 export { default as Pluggable } from './src/Pluggable';
 export { setServicePoints, setCurServicePoint } from './src/loginServices';
 export { default as coreEvents } from './src/events';
+export { default as useOkapiKy } from './src/useOkapiKy';
+export { default as withOkapiKy } from './src/withOkapiKy';
 
 /* components */
 export { default as AppContextMenu } from './src/components/MainNav/CurrentApp/AppContextMenu';

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "hoist-non-react-statics": "^3.3.0",
     "html-webpack-plugin": "^4.0.0-beta.10",
     "jwt-decode": "^2.2.0",
+    "ky": "^0.23.0",
     "localforage": "^1.5.6",
     "lodash": "^4.17.11",
     "lodash-webpack-plugin": "^0.11.5",

--- a/src/useOkapiKy.js
+++ b/src/useOkapiKy.js
@@ -1,0 +1,17 @@
+import ky from 'ky';
+import { useStripes } from './StripesContext';
+
+export default () => {
+  const { tenant, token, url } = useStripes().okapi;
+  return ky.create({
+    prefixUrl: url,
+    hooks: {
+      beforeRequest: [
+        request => {
+          request.headers.set('X-Okapi-Tenant', tenant);
+          request.headers.set('X-Okapi-Token', token);
+        }
+      ]
+    }
+  });
+};

--- a/src/withOkapiKy.js
+++ b/src/withOkapiKy.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ky from 'ky';
+import { withStripes } from './StripesContext';
+
+const withOkapiKy = (WrappedComponent) => {
+  class HOC extends React.Component {
+    static propTypes = {
+      stripes: PropTypes.shape({
+        okapi: PropTypes.shape({
+          tenant: PropTypes.string.isRequired,
+          token: PropTypes.string.isRequired,
+          url: PropTypes.string.isRequired,
+        }).isRequired,
+      }).isRequired,
+    };
+
+    constructor(props) {
+      super();
+      const { tenant, token, url } = props.stripes.okapi;
+      this.okapiKy = ky.create({
+        prefixUrl: url,
+        hooks: {
+          beforeRequest: [
+            request => {
+              request.headers.set('X-Okapi-Tenant', tenant);
+              request.headers.set('X-Okapi-Token', token);
+            }
+          ]
+        }
+      });
+    }
+
+    render() {
+      return <WrappedComponent {...this.props} okapiKy={this.okapiKy} />;
+    }
+  }
+
+  return withStripes(HOC);
+};
+
+export default withOkapiKy;


### PR DESCRIPTION
Documented in doc/okapiKy.md, these provide an especially convenient
API for when you want to send HTTP requests to Okapi rather then let
stripes-connect manage a resouce. The previous alternative was an
explicit use of window.fetch where you'll need to feed it headers from
useStripes() and handle errors in at least two places (response with an
HTTP error code and an exception). Ky is a light wrapper that cleanly
lets us inherit the headers and streamlines error handling.