### PR TITLE
STCOR-452 validate token without permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 6.1.0 IN PROGRESS
+
+* Validate token using a request that does not require permissions. Refs STCOR-452.
+
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)
 
@@ -18,7 +22,7 @@
 * Apps menu - The options in the "Apps" menu do not voice as actionable (able to be activated). Refs STCOR-453.
 * Adjust package scope name filter to align with NPM rules instead of assuming `@folio/`. Refs STCOR-456.
 * Move `moment` to `peerDependencies`. Refs STCOR-464.
-* Refactor `CreateReasetPassword` to use vanilla `react-final-form` instead of `stripes-final-form` wrapper. Refs STCOR-466.
+* Refactor `CreateResetPassword` to use vanilla `react-final-form` instead of `stripes-final-form` wrapper. Refs STCOR-466.
 
 ## [5.0.2](https://github.com/folio-org/stripes-core/tree/v5.0.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.1...v5.0.2)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -219,9 +219,9 @@ function createOkapiSession(okapiUrl, store, tenant, token, data) {
   loadResources(okapiUrl, store, tenant);
 }
 
-// Validate stored token by attempting to fetch /users
+// Validate stored token by attempting to fetch /bl-users/_self
 function validateUser(okapiUrl, store, tenant, session) {
-  fetch(`${okapiUrl}/users`, { headers: getHeaders(tenant, session.token) }).then((resp) => {
+  fetch(`${okapiUrl}/bl-users/_self`, { headers: getHeaders(tenant, session.token) }).then((resp) => {
     if (resp.status >= 400) {
       store.dispatch(clearCurrentUser());
       store.dispatch(clearOkapiToken());


### PR DESCRIPTION
The `validateUser()` function actually does three things:

* check if the given token is syntactically valid
* check whether Okapi is up
* check if the token can be used to make a request

It does this in one fell swoop by making a request, but in order for
this to function for _all_ users the endpoint it hits must be one that
does not require any permissions. `/users` is not such an endpoint, but
`/bl-users/_self` is.

Replaces #923, where I attempted to resolve the permissions problem by
checking for token validity but, ahem, also ignoring the other two tasks
this function accomplishes.

Refs [STCOM-452](https://issues.folio.org/browse/STCOR-452)