### PR TITLE
STCOR-467 update serialize-javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.1.0 IN PROGRESS
 
 * Validate token using a request that does not require permissions. Refs STCOR-452.
+* Update `serialize-javascript` to avoid CVE-2020-7660. Refs STCOR-467.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "rxjs": "^5.4.3",
     "rxjs-compat": "^6.5.4",
     "semver": "^7.1.3",
-    "serialize-javascript": "^2.1.2",
+    "serialize-javascript": "^5.0.0",
     "style-loader": "^1.0.0",
     "svgo": "^1.2.2",
     "svgo-loader": "^2.2.1",


### PR DESCRIPTION
Versions of `serialize-javascript` before 3.1.0 suffer from security
vulnerability CVE-2020-7660.

Refs [STCOR-467](https://issues.folio.org/browse/STCOR-467)