### PR TITLE
UIEH-976: Defined a mock for '/bl-users/_self' request

### DIFF
--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -18,7 +18,6 @@ export default function configure() {
     configs: []
   });
 
-  this.get('/users', {});
   this.get('/bl-users/_self', {});
   this.post('/bl-users/password-reset/validate', {}, 204);
   this.post('/bl-users/password-reset/reset', {}, 401);

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -19,6 +19,7 @@ export default function configure() {
   });
 
   this.get('/users', {});
+  this.get('/bl-users/_self', {});
   this.post('/bl-users/password-reset/validate', {}, 204);
   this.post('/bl-users/password-reset/reset', {}, 401);
 


### PR DESCRIPTION
## Description
eHoldings experiences test failures due to an update in stripes-core. These failures are caused by a PR that changed endpoint that validates a token (https://github.com/folio-org/stripes-core/pull/931).
This PR adds a new mock endpoint `bl-users/_self` so that the token validator receives a correct response