### PR TITLE
STCOR-472 pass correct props to NavButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Validate token using a request that does not require permissions. Refs STCOR-452.
 * Update `serialize-javascript` to avoid CVE-2020-7660. Refs STCOR-467.
+* Pass a string, not a `<FormattedMessage>`, to `<NavButton>`. Refs STCOR-472.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -4,7 +4,7 @@ import get from 'lodash/get';
 import { compose } from 'redux';
 import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import { Dropdown } from '@folio/stripes-components/lib/Dropdown';
 import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
 import NavList from '@folio/stripes-components/lib/NavList';
@@ -223,28 +223,25 @@ class ProfileDropdown extends Component {
   }
 
   renderProfileTrigger = ({ getTriggerProps, open }) => {
+    const { intl } = this.props;
     const servicePointName = get(this.getUserData(), 'curServicePoint.name', null);
 
     return (
-      <FormattedMessage id="stripes-core.mainnav.myProfileAriaLabel">
-        {label => (
-          <NavButton
-            ariaLabel={label}
-            selected={open}
-            className={css.button}
-            icon={this.getProfileImage()}
-            label={servicePointName ? (
-              <>
-                <span className={css.button__label}>
-                  {servicePointName}
-                </span>
-                <Icon icon={open ? 'caret-up' : 'caret-down'} />
-              </>
-            ) : null}
-            {...getTriggerProps()}
-          />)
-        }
-      </FormattedMessage>
+      <NavButton
+        ariaLabel={intl.formatMessage({ id: 'stripes-core.mainnav.myProfileAriaLabel' })}
+        selected={open}
+        className={css.button}
+        icon={this.getProfileImage()}
+        label={servicePointName ? (
+          <>
+            <span className={css.button__label}>
+              {servicePointName}
+            </span>
+            <Icon icon={open ? 'caret-up' : 'caret-down'} />
+          </>
+        ) : null}
+        {...getTriggerProps()}
+      />
     );
   }
 
@@ -278,4 +275,5 @@ class ProfileDropdown extends Component {
 export default compose(
   withRouter,
   withModules,
+  injectIntl,
 )(ProfileDropdown);

--- a/src/components/TitledRoute/TitledRoute.js
+++ b/src/components/TitledRoute/TitledRoute.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { Route } from 'react-router-dom';
 
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
@@ -21,6 +21,7 @@ class TitledRoute extends React.Component {
       name,
       component,
       computedMatch,
+      intl,
       ...rest
     } = this.props;
 
@@ -39,11 +40,7 @@ class TitledRoute extends React.Component {
         {...rest}
         render={() => (
           <ErrorBoundary>
-            <FormattedMessage id={`stripes-core.title.${name}`} defaultMessage={name}>
-              {formattedName => (
-                <TitleManager page={formattedName} />
-              )}
-            </FormattedMessage>
+            <TitleManager page={intl.formatMessage({ id: `stripes-core.title.${name}`, defaultMessage: name })} />
             {componentWithExtraProps}
           </ErrorBoundary>
         )}
@@ -52,4 +49,4 @@ class TitledRoute extends React.Component {
   }
 }
 
-export default withStripes(TitledRoute);
+export default withStripes(injectIntl(TitledRoute));


### PR DESCRIPTION
* `<ProfileDropdown>` passed a `<FormattedMessage>` to `<NavButton>` which
expected a string, generating a console warning:
```
Warning: Failed prop type: Invalid prop `ariaLabel` of type `array` supplied to `ForwardRef`, expected `string`
```
* `<TitledRoute>` used `<FormattedMessage>` with renderprops to derive
the value to pass to `<TitleManager>`, but as of `react-intl` `v5`
that results in an array instead of a string, which sucks, and which
generates this console warning:
```
Warning: Failed prop type: Invalid prop `page` of type `array` supplied to `TitleManager`, expected `string`.
```

Refs [STCOR-472](https://issues.folio.org/browse/STCOR-472)