### PR TITLE
Use a prefetched copy of module discovery

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { okapi as okapiConfig, config } from 'stripes-config';
+import { okapi as okapiConfig, okapiModules, config } from 'stripes-config';
 import merge from 'lodash/merge';
 
 import connectErrorEpic from './connectErrorEpic';
@@ -32,6 +32,11 @@ export default class StripesCore extends Component {
     this.epics = configureEpics(connectErrorEpic);
     this.store = configureStore(initialState, this.logger, this.epics);
     this.actionNames = gatherActions();
+
+    if (Array.isArray(okapiModules)) {
+      this.store.dispatch({ type: 'DISCOVERY_SUCCESS', data: okapiModules });
+      okapiModules.map(entry => this.store.dispatch({ type: 'DISCOVERY_INTERFACES', data: entry }));
+    }
   }
 
   componentWillUnmount() {

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -18,39 +18,21 @@ function getHeaders(tenant, token) {
 
 export function discoverServices(store) {
   const okapi = store.getState().okapi;
-  return Promise.all([
-    fetch(`${okapi.url}/_/version`, {
+  return fetch(`${okapi.url}/_/version`, {
       headers: getHeaders(okapi.tenant, okapi.token)
-    })
-      .then((response) => { // eslint-disable-line consistent-return
-        if (response.status >= 400) {
-          store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
-        } else {
-          return response.text().then((text) => {
-            store.dispatch({ type: 'DISCOVERY_OKAPI', version: text });
-          });
-        }
-      }).catch((reason) => {
-        store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
-      }),
-    fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules?full=true`, {
-      headers: getHeaders(okapi.tenant, okapi.token)
-    })
-      .then((response) => { // eslint-disable-line consistent-return
-        if (response.status >= 400) {
-          store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
-        } else {
-          return response.json().then((json) => {
-            store.dispatch({ type: 'DISCOVERY_SUCCESS', data: json });
-            return Promise.all(json.map(entry => store.dispatch({ type: 'DISCOVERY_INTERFACES', data: entry })));
-          });
-        }
-      }).catch((reason) => {
-        store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
-      }),
-  ]).then(() => {
-    store.dispatch({ type: 'DISCOVERY_FINISHED' });
-  });
+    }).then((response) => { // eslint-disable-line consistent-return
+      if (response.status >= 400) {
+        store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
+      } else {
+        return response.text().then((text) => {
+          store.dispatch({ type: 'DISCOVERY_OKAPI', version: text });
+        });
+      }
+    }).then(() => {
+      store.dispatch({ type: 'DISCOVERY_FINISHED' });
+    }).catch((reason) => {
+      store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
+    });
 }
 
 export function discoveryReducer(state = {}, action) {

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -44,7 +44,9 @@ export function discoverServices(store) {
   // If Stripes is being served by a dev server, it actually reaches out to Okapi and pulls down the set of modules
   // at build time. This is so that when devs are working on Folio, they don't consistently need to reach out and fetch
   // the new set of modules for every page reload/session. The fetch takes 2-4 seconds to complete so this is an appreciable
-  // time savings in aggregate. See https://github.com/folio-org/stripes-cli/pull/240 for more info.
+  // time savings in aggregate. As a result of this, we check if the Okapi modules have been prefetched and included in the
+  // stripes-config module created at build time. If they haven't, we go out and fetch the modules.
+  // See https://github.com/folio-org/stripes-cli/pull/240 for more info.
   if (Array.isArray(okapiModules) === false || okapiModules.length === 0) {
     promises.push(
       fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules?full=true`, {

--- a/test/webpack/stripes-config-plugin.spec.js
+++ b/test/webpack/stripes-config-plugin.spec.js
@@ -130,7 +130,7 @@ describe('The stripes-config-plugin', function () {
       expect(writeModuleArgs[0]).to.be.a('string').that.equals('node_modules/stripes-config.js');
 
       // TODO: More thorough analysis of the generated virtual module
-      expect(writeModuleArgs[1]).to.be.a('string').with.match(/export { okapi, config, modules, branding, translations, metadata, icons }/);
+      expect(writeModuleArgs[1]).to.be.a('string').with.match(/export { okapi, config, modules, branding, translations, metadata, icons, okapiModules }/);
     });
   });
 

--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -61,12 +61,12 @@ module.exports = class StripesConfigPlugin {
 
     // Create a virtual module for Webpack to include in the build
     const stripesVirtualModule = `
-      const { okapi, config, modules } = ${serialize(this.mergedConfig, { space: 2 })};
+      const { okapi, config, modules, okapiModules } = ${serialize(this.mergedConfig, { space: 2 })};
       const branding = ${stripesSerialize.serializeWithRequire(pluginData.branding)};
       const translations = ${serialize(pluginData.translations, { space: 2 })};
       const metadata = ${stripesSerialize.serializeWithRequire(this.metadata)};
       const icons = ${stripesSerialize.serializeWithRequire(this.icons)};
-      export { okapi, config, modules, branding, translations, metadata, icons };
+      export { okapi, config, modules, branding, translations, metadata, icons, okapiModules };
     `;
 
     logger.log('writing virtual module...', stripesVirtualModule);


### PR DESCRIPTION
Companion to a [related PR in stripes-cli](https://github.com/folio-org/stripes-cli/pull/240)

Fetching the list of modules from Okapi on every session start has long been a bugaboo of @skomorokh. He argues that:

- Fetching that often isn't necessary since _the modules we expect to be present_ should only change upon rebuilds.
- Fetching per session gives us a false sense of security. It intrinsically makes the assumption that the set of modules/interfaces live at session start _is correct and desired._ That is, if an interface is not present, we should silently fail checks for that interface. This can be a terrible UX in the case that we just stop showing a UI element because the module providing some interface is down in error. That's confusing! Better to actually show an error in cases like that.
- In development, we spend a bunch of time waiting for this fetch to occur because we're always running sans cache. Multiplied across all the developers involved in the project, that's a lot of wasted person-hours.

This set of PRs presents the minimum required work to stop fetching the data at run time and instead fetch it at build time. It is presented as a PR for the purpose of publicizing this work, soliciting opinions, and hopefully catching any bugs with our reasoning or code. 

**To-Dos**
- [ ] Support mocking the list of modules/interfaces in [tests such as these](https://github.com/folio-org/ui-erm-usage/blob/1632423816b76ea58cbc83ea6353720e186c0f0d/test/bigtest/network/config.js#L11), perhaps via [`setupApplication`](https://github.com/folio-org/stripes-core/blob/master/test/bigtest/helpers/setup-application.js#L22)