### PR TITLE
STCOR-481: Move CalloutContext to Root to avoid issues with React Intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Validate token using a request that does not require permissions. Refs STCOR-452.
 * Update `serialize-javascript` to avoid CVE-2020-7660. Refs STCOR-467.
 * Pass a string, not a `<FormattedMessage>`, to `<NavButton>`. Refs STCOR-472.
+* Move `CalloutContext` to `<Root>` to avoid issues with Intl. Refs STCOR-481.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -9,7 +9,6 @@ import { Provider } from 'react-redux';
 import { CookiesProvider } from 'react-cookie';
 
 import { HotKeys } from '@folio/stripes-components/lib/HotKeys';
-import { Callout } from '@folio/stripes-components';
 import { connectFor } from '@folio/stripes-connect';
 
 import getModuleRoutes from './moduleRoutes';
@@ -36,7 +35,6 @@ import {
   AppCtxMenuProvider,
 } from './components';
 import { StripesContext } from './StripesContext';
-import CalloutContext from './CalloutContext';
 
 class RootWithIntl extends React.Component {
   static propTypes = {
@@ -55,12 +53,6 @@ class RootWithIntl extends React.Component {
     history: {},
   };
 
-  constructor(props) {
-    super(props);
-
-    this.callout = React.createRef();
-  }
-
   render() {
     const {
       token,
@@ -73,106 +65,103 @@ class RootWithIntl extends React.Component {
 
     return (
       <StripesContext.Provider value={stripes}>
-        <CalloutContext.Provider value={this.callout.current}>
-          <ModuleTranslator>
-            <TitleManager>
-              <HotKeys
-                keyMap={stripes.bindings}
-                noWrapper
-              >
-                <Provider store={stripes.store}>
-                  <Router history={history}>
-                    { token || disableAuth ?
-                      <MainContainer>
-                        <AppCtxMenuProvider>
-                          <MainNav stripes={stripes} />
-                          <HandlerManager
-                            event={events.LOGIN}
+        <ModuleTranslator>
+          <TitleManager>
+            <HotKeys
+              keyMap={stripes.bindings}
+              noWrapper
+            >
+              <Provider store={stripes.store}>
+                <Router history={history}>
+                  { token || disableAuth ?
+                    <MainContainer>
+                      <AppCtxMenuProvider>
+                        <MainNav stripes={stripes} />
+                        <HandlerManager
+                          event={events.LOGIN}
+                          stripes={stripes}
+                        />
+                        { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
+                          <ModuleContainer id="content">
+                            <OverlayContainer />
+                            <Switch>
+                              <TitledRoute
+                                name="home"
+                                path="/"
+                                key="root"
+                                exact
+                                component={<Front stripes={stripes} />}
+                              />
+                              <TitledRoute
+                                name="ssoRedirect"
+                                path="/sso-landing"
+                                key="sso-landing"
+                                component={<SSORedirect stripes={stripes} />}
+                              />
+                              <TitledRoute
+                                name="settings"
+                                path="/settings"
+                                component={<Settings stripes={stripes} />}
+                              />
+                              {getModuleRoutes(stripes)}
+                              <TitledRoute
+                                name="notFound"
+                                component={(
+                                  <div>
+                                    <h2>Uh-oh!</h2>
+                                    <p>This route does not exist.</p>
+                                  </div>
+                                )}
+                              />
+                            </Switch>
+                          </ModuleContainer>
+                        )}
+                      </AppCtxMenuProvider>
+                    </MainContainer> :
+                    <Switch>
+                      <TitledRoute
+                        name="CreateResetPassword"
+                        path="/reset-password/:token"
+                        component={<CreateResetPassword stripes={stripes} />}
+                      />
+                      <TitledRoute
+                        name="ssoLanding"
+                        exact
+                        path="/sso-landing"
+                        component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>}
+                        key="sso-landing"
+                      />
+                      <TitledRoute
+                        name="forgotPassword"
+                        path="/forgot-password"
+                        component={<ForgotPasswordCtrl stripes={stripes} />}
+                      />
+                      <TitledRoute
+                        name="forgotUsername"
+                        path="/forgot-username"
+                        component={<ForgotUserNameCtrl stripes={stripes} />}
+                      />
+                      <TitledRoute
+                        name="checkEmail"
+                        path="/check-email"
+                        component={<CheckEmailStatusPage />}
+                      />
+                      <TitledRoute
+                        name="login"
+                        component={
+                          <Login
+                            autoLogin={stripes.config.autoLogin}
                             stripes={stripes}
                           />
-                          { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
-                            <ModuleContainer id="content">
-                              <OverlayContainer />
-                              <Switch>
-                                <TitledRoute
-                                  name="home"
-                                  path="/"
-                                  key="root"
-                                  exact
-                                  component={<Front stripes={stripes} />}
-                                />
-                                <TitledRoute
-                                  name="ssoRedirect"
-                                  path="/sso-landing"
-                                  key="sso-landing"
-                                  component={<SSORedirect stripes={stripes} />}
-                                />
-                                <TitledRoute
-                                  name="settings"
-                                  path="/settings"
-                                  component={<Settings stripes={stripes} />}
-                                />
-                                {getModuleRoutes(stripes)}
-                                <TitledRoute
-                                  name="notFound"
-                                  component={(
-                                    <div>
-                                      <h2>Uh-oh!</h2>
-                                      <p>This route does not exist.</p>
-                                    </div>
-                                  )}
-                                />
-                              </Switch>
-                            </ModuleContainer>
-                          )}
-                        </AppCtxMenuProvider>
-                      </MainContainer> :
-                      <Switch>
-                        <TitledRoute
-                          name="CreateResetPassword"
-                          path="/reset-password/:token"
-                          component={<CreateResetPassword stripes={stripes} />}
-                        />
-                        <TitledRoute
-                          name="ssoLanding"
-                          exact
-                          path="/sso-landing"
-                          component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>}
-                          key="sso-landing"
-                        />
-                        <TitledRoute
-                          name="forgotPassword"
-                          path="/forgot-password"
-                          component={<ForgotPasswordCtrl stripes={stripes} />}
-                        />
-                        <TitledRoute
-                          name="forgotUsername"
-                          path="/forgot-username"
-                          component={<ForgotUserNameCtrl stripes={stripes} />}
-                        />
-                        <TitledRoute
-                          name="checkEmail"
-                          path="/check-email"
-                          component={<CheckEmailStatusPage />}
-                        />
-                        <TitledRoute
-                          name="login"
-                          component={
-                            <Login
-                              autoLogin={stripes.config.autoLogin}
-                              stripes={stripes}
-                            />
-                          }
-                        />
-                      </Switch>
-                    }
-                  </Router>
-                </Provider>
-              </HotKeys>
-            </TitleManager>
-          </ModuleTranslator>
-        </CalloutContext.Provider>
-        <Callout ref={this.callout} />
+                        }
+                      />
+                    </Switch>
+                  }
+                </Router>
+              </Provider>
+            </HotKeys>
+          </TitleManager>
+        </ModuleTranslator>
       </StripesContext.Provider>
     );
   }

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -7,6 +7,7 @@ import { IntlProvider } from 'react-intl';
 import queryString from 'query-string';
 import { ApolloProvider } from '@apollo/client';
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
+import { Callout } from '@folio/stripes-components';
 import { metadata, icons } from 'stripes-config';
 
 /* ConnectContext - formerly known as RootContext, now comes from stripes-connect, so stripes-connect
@@ -23,6 +24,7 @@ import { getQueryResourceKey, getCurrentModule } from '../../locationService';
 import Stripes from '../../Stripes';
 import RootWithIntl from '../../RootWithIntl';
 import SystemSkeleton from '../SystemSkeleton';
+import CalloutContext from '../../CalloutContext';
 
 import './Root.css';
 
@@ -43,6 +45,7 @@ class Root extends Component {
     const { modules, history } = this.props;
     const appModule = getCurrentModule(modules, history.location);
     this.queryResourceStateKey = (appModule) ? getQueryResourceKey(appModule) : null;
+    this.callout = React.createRef();
   }
 
   getChildContext() {
@@ -130,22 +133,25 @@ class Root extends Component {
       <ErrorBoundary>
         <ConnectContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store }}>
           <ApolloProvider client={createApolloClient(okapi)}>
-            <IntlProvider
-              locale={locale}
-              key={locale}
-              timeZone={timezone}
-              currency={currency}
-              messages={translations}
-              textComponent={Fragment}
-              onError={config?.suppressIntlErrors ? () => {} : undefined}
-            >
-              <RootWithIntl
-                stripes={stripes}
-                token={token}
-                disableAuth={disableAuth}
-                history={history}
-              />
-            </IntlProvider>
+            <CalloutContext.Provider value={this.callout.current}>
+              <IntlProvider
+                locale={locale}
+                key={locale}
+                timeZone={timezone}
+                currency={currency}
+                messages={translations}
+                textComponent={Fragment}
+                onError={config?.suppressIntlErrors ? () => {} : undefined}
+              >
+                <RootWithIntl
+                  stripes={stripes}
+                  token={token}
+                  disableAuth={disableAuth}
+                  history={history}
+                />
+              </IntlProvider>
+            </CalloutContext.Provider>
+            <Callout ref={this.callout} />
           </ApolloProvider>
         </ConnectContext.Provider>
       </ErrorBoundary>


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-481

It looks like every time we change the locale the `IntlProvider` is changed causing the `RootWithIntl` to be completely recreated (a new RootWithIntl instance is being created). This also recreates the callout ref and `CalloutContext.Provider`  causing issues similar to the one described in STCOR-481

This PR moves the context and callout to `Root`. This seems to help at least with the issue described in STCOR-481.