### PR TITLE
STCOR-483 avoid render-props with FormattedMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Validate token using a request that does not require permissions. Refs STCOR-452.
 * Update `serialize-javascript` to avoid CVE-2020-7660. Refs STCOR-467.
-* Pass a string, not a `<FormattedMessage>`, to `<NavButton>`. Refs STCOR-472.
+* Avoid using `<FormattedMessage>` with render-props. Refs STCOR-472, STCOR-482.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 
 import { Dropdown } from '@folio/stripes-components/lib/Dropdown';
 import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
@@ -31,6 +31,9 @@ class AppList extends Component {
     ),
     dropdownId: PropTypes.string,
     dropdownToggleId: PropTypes.string.isRequired,
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func.isRequired,
+    }),
     selectedApp: PropTypes.object,
   }
 
@@ -117,7 +120,7 @@ class AppList extends Component {
    * The button that toggles the dropdown
    */
   renderDropdownToggleButton = ({ open, getTriggerProps }) => {
-    const { dropdownToggleId } = this.props;
+    const { dropdownToggleId, intl: { formatMessage } } = this.props;
     const icon = (
       <svg className={css.dropdownToggleIcon} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
         <path d="M8.4 2.4H5.1c-1.5 0-2.7 1.2-2.7 2.7v3.3c0 1.5 1.2 2.7 2.7 2.7h3.3c1.5 0 2.7-1.2 2.7-2.7V5.1c0-1.5-1.2-2.7-2.7-2.7zm.7 6c0 .4-.3.7-.7.7H5.1c-.4 0-.7-.3-.7-.7V5.1c0-.4.3-.7.7-.7h3.3c.4 0 .7.3.7.7v3.3zM18.9 2.4h-3.3c-1.5 0-2.7 1.2-2.7 2.7v3.3c0 1.5 1.2 2.7 2.7 2.7h3.3c1.5 0 2.7-1.2 2.7-2.7V5.1c0-1.5-1.2-2.7-2.7-2.7zm.7 6c0 .4-.3.7-.7.7h-3.3c-.4 0-.7-.3-.7-.7V5.1c0-.4.3-.7.7-.7h3.3c.4 0 .7.3.7.7v3.3zM8.4 12.9H5.1c-1.5 0-2.7 1.2-2.7 2.7v3.3c0 1.5 1.2 2.7 2.7 2.7h3.3c1.5 0 2.7-1.2 2.7-2.7v-3.3c0-1.5-1.2-2.7-2.7-2.7zm.7 6c0 .4-.3.7-.7.7H5.1c-.4 0-.7-.3-.7-.7v-3.3c0-.4.3-.7.7-.7h3.3c.4 0 .7.3.7.7v3.3zM18.9 12.9h-3.3c-1.5 0-2.7 1.2-2.7 2.7v3.3c0 1.5 1.2 2.7 2.7 2.7h3.3c1.5 0 2.7-1.2 2.7-2.7v-3.3c0-1.5-1.2-2.7-2.7-2.7zm.7 6c0 .4-.3.7-.7.7h-3.3c-.4 0-.7-.3-.7-.7v-3.3c0-.4.3-.7.7-.7h3.3c.4 0 .7.3.7.7v3.3z" />
@@ -130,23 +133,19 @@ class AppList extends Component {
     );
 
     return (
-      <FormattedMessage id="stripes-core.mainnav.showAllApplicationsButtonAriaLabel">
-        { ariaLabel => (
-          <NavButton
-            data-test-app-list-apps-toggle
-            label={label}
-            aria-label={ariaLabel}
-            className={css.navMobileToggle}
-            labelClassName={css.dropdownToggleLabel}
-            onClick={this.toggleDropdown}
-            selected={this.state.open}
-            icon={icon}
-            {...getTriggerProps()}
-            id={dropdownToggleId}
-            noSelectedBar
-          />
-        )}
-      </FormattedMessage>
+      <NavButton
+        data-test-app-list-apps-toggle
+        label={label}
+        aria-label={formatMessage({ id: 'stripes-core.mainnav.showAllApplicationsButtonAriaLabel' })}
+        className={css.navMobileToggle}
+        labelClassName={css.dropdownToggleLabel}
+        onClick={this.toggleDropdown}
+        selected={this.state.open}
+        icon={icon}
+        {...getTriggerProps()}
+        id={dropdownToggleId}
+        noSelectedBar
+      />
     );
   }
 
@@ -216,4 +215,4 @@ class AppList extends Component {
   }
 }
 
-export default AppList;
+export default injectIntl(AppList);

--- a/src/components/MainNav/components/SkipLink/SkipLink.js
+++ b/src/components/MainNav/components/SkipLink/SkipLink.js
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import NavButton from '../../NavButton';
 import css from './SkipLink.css';
 
@@ -16,17 +16,17 @@ const SkipIcon = () => (
   </svg>
 );
 
-const SkipLink = () => (
-  <FormattedMessage id="stripes-core.mainnav.skipMainNavigation">
-    {label => (
-      <NavButton
-        icon={<SkipIcon />}
-        href="#ModuleContainer"
-        aria-label={label}
-        className={css.skipLink}
-      />
-    )}
-  </FormattedMessage>
-);
+const SkipLink = () => {
+  const intl = useIntl();
+
+  return (
+    <NavButton
+      icon={<SkipIcon />}
+      href="#ModuleContainer"
+      aria-label={intl.formatMessage({ id: 'stripes-core.mainnav.skipMainNavigation' })}
+      className={css.skipLink}
+    />
+  );
+};
 
 export default SkipLink;

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+} from 'react-intl';
 import { withRouter } from 'react-router';
 import {
   Switch,
@@ -33,7 +36,10 @@ class Settings extends React.Component {
     modules: PropTypes.shape({
       app: PropTypes.array,
       settings: PropTypes.array,
-    })
+    }),
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func.isRequired,
+    }),
   };
 
   constructor(props) {
@@ -63,7 +69,7 @@ class Settings extends React.Component {
   }
 
   render() {
-    const { stripes, location } = this.props;
+    const { stripes, location, intl: { formatMessage } } = this.props;
     const navLinks = this.connectedModules.map(({ module }) => {
       const iconData = module.module.replace(packageName.PACKAGE_SCOPE_REGEX, '');
       return (
@@ -108,34 +114,26 @@ class Settings extends React.Component {
           defaultWidth="20%"
           paneTitle={<FormattedMessage id="stripes-core.settings" />}
         >
-          <FormattedMessage id="stripes-core.settings">
-            { label => (
-              <NavList ariaLabel={label}>
-                <NavListSection
-                  activeLink={activeLink}
-                  label={label}
-                  className={css.navListSection}
-                >
-                  {navLinks}
-                </NavListSection>
-              </NavList>
-            )}
-          </FormattedMessage>
-          <FormattedMessage id="stripes-core.settingSystemInfo">
-            {label => (
-              <NavList aria-label={label}>
-                <NavListSection
-                  label={label}
-                  activeLink={activeLink}
-                  className={css.navListSection}
-                >
-                  <NavListItem to="/settings/about">
-                    <FormattedMessage id="stripes-core.front.about" />
-                  </NavListItem>
-                </NavListSection>
-              </NavList>
-            )}
-          </FormattedMessage>
+          <NavList aria-label={formatMessage({ id: 'stripes-core.settings' })}>
+            <NavListSection
+              activeLink={activeLink}
+              label={formatMessage({ id: 'stripes-core.settings' })}
+              className={css.navListSection}
+            >
+              {navLinks}
+            </NavListSection>
+          </NavList>
+          <NavList aria-label={formatMessage({ id: 'stripes-core.settingSystemInfo' })}>
+            <NavListSection
+              label={formatMessage({ id: 'stripes-core.settingSystemInfo' })}
+              activeLink={activeLink}
+              className={css.navListSection}
+            >
+              <NavListItem to="/settings/about">
+                <FormattedMessage id="stripes-core.front.about" />
+              </NavListItem>
+            </NavListSection>
+          </NavList>
         </Pane>
         <Switch>
           {routes}
@@ -147,4 +145,4 @@ class Settings extends React.Component {
   }
 }
 
-export default withRouter(withModules(Settings));
+export default withRouter(withModules(injectIntl(Settings)));


### PR DESCRIPTION
Using render-props with a `<FormattedMessage>` in `react-intl` `v5`
renders as an array rather than as a string as it did in `v4`. This
causes problems for attributes such as `aria-label`, which expect
strings.

Refs [STCOR-482](https://issues.folio.org/browse/STCOR-482), [STRIPES-694](https://issues.folio.org/browse/STRIPES-694)