### PR TITLE
STCOR-483 use correct HTTP responses codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Validate token using a request that does not require permissions. Refs STCOR-452.
 * Update `serialize-javascript` to avoid CVE-2020-7660. Refs STCOR-467.
 * Pass a string, not a `<FormattedMessage>`, to `<NavButton>`. Refs STCOR-472.
+* Test HTTP response cleanup. Refs STCOR-483.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -19,7 +19,9 @@ export default function configure() {
   });
 
   this.get('/bl-users/_self', {});
-  this.post('/bl-users/password-reset/validate', {}, 204);
+  this.post('/bl-users/password-reset/validate', () => {
+    return new Response(204, {}, '');
+  }, 204);
   this.post('/bl-users/password-reset/reset', {}, 401);
 
 

--- a/test/bigtest/network/scenarios/changePasswordSuccess.js
+++ b/test/bigtest/network/scenarios/changePasswordSuccess.js
@@ -1,3 +1,5 @@
 export default (server) => {
-  server.post('/bl-users/password-reset/reset', {}, 204);
+  server.post('/bl-users/password-reset/reset', () => {
+    return new Response(204, {}, '');
+  }, 204);
 };

--- a/test/bigtest/network/scenarios/forgotPasswordSuccess.js
+++ b/test/bigtest/network/scenarios/forgotPasswordSuccess.js
@@ -1,3 +1,5 @@
 export default (server) => {
-  server.post('bl-users/forgotten/password', {}, 204);
+  server.post('bl-users/forgotten/password', () => {
+    return new Response(204, {}, '');
+  }, 204);
 };

--- a/test/bigtest/network/scenarios/forgotUsernameSuccess.js
+++ b/test/bigtest/network/scenarios/forgotUsernameSuccess.js
@@ -1,3 +1,5 @@
 export default (server) => {
-  server.post('bl-users/forgotten/username', {}, 204);
+  server.post('bl-users/forgotten/username', () => {
+    return new Response(204, {}, '');
+  }, 204);
 };


### PR DESCRIPTION
The [mirage documentation
notwithstanding](https://miragejs.com/docs/main-concepts/route-handlers/#status-codes-and-headers),
to actually return a custom response code you must return a
custom `Response` object with the desired code _and_ include that same
code as the third parameter to the action (`put`, `post`, etc) method.
Only doing the first (as in the documentation) or the later (as in
previous code) doesn't work correctly.

With only the former, mirage is happy but the code under test receives a
201 instead of the custom code, causing tests of code that expect
specific response codes to fail.

With only the latter, mirage spews the warning but the code under test
receives the expected response.

Refs [STCOR-483](https://issues.folio.org/browse/STCOR-483)