### PR TITLE
fix tests - focus button before assertions

### DIFF
--- a/src/components/MainNav/AppList/tests/AppList-test.js
+++ b/src/components/MainNav/AppList/tests/AppList-test.js
@@ -47,6 +47,7 @@ describe('AppList', () => {
           </BrowserRouter>
         </div>
       );
+      await appList.dropdownToggle.focus();
       await appList.dropdownToggle.click();
     });
 
@@ -68,6 +69,8 @@ describe('AppList', () => {
             </BrowserRouter>
           </div>
         );
+        await appList.dropdownToggle.$root.focus();
+        await appList.when(() => appList.dropdownToggle.isFocused);
         await appList.dropdownToggle.click();
       });
 
@@ -108,6 +111,8 @@ describe('AppList', () => {
           </BrowserRouter>
         </div>
       );
+      await appList.dropdownToggle.$root.focus();
+      await appList.when(() => appList.dropdownToggle.isFocused);
       await appList.dropdownToggle.click();
     });
 


### PR DESCRIPTION
In a recent change to stripes-components' `<Dropdown>`, the focus moves into the menu only when the dropdown's trigger is in focus when the menu opens... this action isn't quite fast enough for the assertions and `click` alone doesn't appear to be setting a focus to the dropdown trigger.