### PR TITLE
Release 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-core
 
-## 6.1.0 IN PROGRESS
+## [6.1.0](https://github.com/folio-org/stripes-core/tree/v6.1.0) (2020-11-19)
+[Full Changelog](https://github.com/folio-org/stripes-core/compare/v6.0.0...v6.1.0)
 
 * Validate token using a request that does not require permissions. Refs STCOR-452.
 * Update `serialize-javascript` to avoid CVE-2020-7660. Refs STCOR-467.

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -23,6 +23,9 @@ import IntlConsumer from '../../IntlConsumer';
 
 class ProfileDropdown extends Component {
   static propTypes = {
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func.isRequired,
+    }),
     modules: PropTypes.shape({
       app: PropTypes.array,
       settings: PropTypes.array,

--- a/src/components/TitledRoute/TitledRoute.js
+++ b/src/components/TitledRoute/TitledRoute.js
@@ -13,6 +13,9 @@ class TitledRoute extends React.Component {
   static propTypes = {
     component: PropTypes.element,
     computedMatch: PropTypes.oneOfType([PropTypes.element, PropTypes.object]),
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func.isRequired,
+    }),
     name: PropTypes.string
   };
 


### PR DESCRIPTION
- Validate token using a request that does not require permissions. Refs STCOR-452.
- Update `serialize-javascript` to avoid CVE-2020-7660. Refs STCOR-467.
- Pass a string, not a `<FormattedMessage>`, to `<NavButton>`. Refs STCOR-472.
- Move `CalloutContext` to `<Root>` to avoid issues with Intl. Refs STCOR-481.
- Test HTTP response cleanup. Refs STCOR-483.
- Avoid using `<FormattedMessage>` with render-props. Refs STCOR-472, STCOR-482.
- Add support for building and consuming Webpack DLLs. Refs STCOR-471.
- Also, some small lint fixes