### PR TITLE
STCOR-481: Move CalloutContext Provider back under IntlProvider

### DIFF
--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -133,25 +133,25 @@ class Root extends Component {
       <ErrorBoundary>
         <ConnectContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store }}>
           <ApolloProvider client={createApolloClient(okapi)}>
-            <CalloutContext.Provider value={this.callout.current}>
-              <IntlProvider
-                locale={locale}
-                key={locale}
-                timeZone={timezone}
-                currency={currency}
-                messages={translations}
-                textComponent={Fragment}
-                onError={config?.suppressIntlErrors ? () => {} : undefined}
-              >
+            <IntlProvider
+              locale={locale}
+              key={locale}
+              timeZone={timezone}
+              currency={currency}
+              messages={translations}
+              textComponent={Fragment}
+              onError={config?.suppressIntlErrors ? () => {} : undefined}
+            >
+              <CalloutContext.Provider value={this.callout.current}>
                 <RootWithIntl
                   stripes={stripes}
                   token={token}
                   disableAuth={disableAuth}
                   history={history}
                 />
-              </IntlProvider>
-            </CalloutContext.Provider>
-            <Callout ref={this.callout} />
+              </CalloutContext.Provider>
+              <Callout ref={this.callout} />
+            </IntlProvider>
           </ApolloProvider>
         </ConnectContext.Provider>
       </ErrorBoundary>


### PR DESCRIPTION
After some refactoring related to STCOR-481 we started to see some issues reported by @ViktorSoroka07 and @aliaksei-chumakou related to missing `intl` when using `FormattedMessage` with the `callout`.

https://github.com/folio-org/stripes-core/pull/946#issuecomment-731106017

@zburke found a good solution for it under:

https://github.com/folio-org/stripes-smart-components/pull/962

This PR is moving the `CalloutContext.Provider` back under `IntlProvider` to address similar issues in other places.

The callout ref is kept in the `Root` so the issue reported in STCOR-481 should still work. 