### PR TITLE
STCOR-477 provide formatters to IntlProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Validate token using a request that does not require permissions. Refs STCOR-452.
 * Update `serialize-javascript` to avoid CVE-2020-7660. Refs STCOR-467.
 * Pass a string, not a `<FormattedMessage>`, to `<NavButton>`. Refs STCOR-472.
+* Provide default HTML formatters to `<IntlProvider>` so we can avoid `<SafeHTMLMessage>`. Fixes STCOR-477.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -43,6 +43,19 @@ class Root extends Component {
     const { modules, history } = this.props;
     const appModule = getCurrentModule(modules, history.location);
     this.queryResourceStateKey = (appModule) ? getQueryResourceKey(appModule) : null;
+
+    this.defaultRichTextElements = {
+      b: (chunks) => <b>{chunks}</b>,
+      i: (chunks) => <i>{chunks}</i>,
+      em: (chunks) => <em>{chunks}</em>,
+      strong: (chunks) => <strong>{chunks}</strong>,
+      span: (chunks) => <span>{chunks}</span>,
+      div: (chunks) => <div>{chunks}</div>,
+      p: (chunks) => <p>{chunks}</p>,
+      ul: (chunks) => <ul>{chunks}</ul>,
+      ol: (chunks) => <ol>{chunks}</ol>,
+      li: (chunks) => <li>{chunks}</li>,
+    };
   }
 
   getChildContext() {
@@ -138,6 +151,7 @@ class Root extends Component {
               messages={translations}
               textComponent={Fragment}
               onError={config?.suppressIntlErrors ? () => {} : undefined}
+              defaultRichTextElements={this.defaultRichTextElements}
             >
               <RootWithIntl
                 stripes={stripes}


### PR DESCRIPTION
Provide default HTML-element formatters for `b`, `i`, `em`, `strong`,
`span`, `div`, `p`, `ul`, `ol`, and `li` so they can be freely used in
translation values without requiring special handling in the
`<FormattedMessage>` component or `formatMessage()` function call. This
effectively replaces `<SafeHTMLMessage>` from `react-intl-safe-html`,
which can now be deprecated.

Refs [STCOR-477](https://issues.folio.org/browse/STCOR-477)