### PR TITLE
STCOR-491 Migrate AppContextDropdown away from legacy API

### DIFF
--- a/src/components/MainNav/CurrentApp/AppContextDropdown.js
+++ b/src/components/MainNav/CurrentApp/AppContextDropdown.js
@@ -19,13 +19,12 @@ class AppContextDropdown extends React.Component {
       selectedApp,
     } = this.props;
 
-    const toggle = (
+    const renderToggle = () => (
       <Button
         data-test-context-menu-toggle-button
         buttonStyle="noStyle"
         marginBottom0
         style={{ height: '40px' }}
-        data-role="toggle"
       >
         <Icon icon={open ? 'caret-up' : 'caret-down'} iconPosition="end">
           <AppIcon app={selectedApp.displayName.toLowerCase()}>
@@ -43,12 +42,11 @@ class AppContextDropdown extends React.Component {
     return (
       <Dropdown
         onToggle={onToggle}
+        renderTrigger={renderToggle}
         open={open}
       >
-        { toggle }
         <DropdownMenu
           id="App_context_dropdown_menu"
-          data-role="menu"
           onToggle={onToggle}
         >
           {/* `currently, dropdowns need something initially rendered

--- a/src/components/MainNav/CurrentApp/AppContextDropdown.js
+++ b/src/components/MainNav/CurrentApp/AppContextDropdown.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Dropdown, Headline, DropdownMenu, Icon, Button } from '@folio/stripes-components';
 import AppIcon from '../../AppIcon';
+import css from './../NavButton/NavButton.css';
 import { withAppCtxMenu } from './AppCtxMenuContext';
 
 class AppContextDropdown extends React.Component {
@@ -19,16 +20,25 @@ class AppContextDropdown extends React.Component {
       selectedApp,
     } = this.props;
 
-    const renderToggle = () => (
+    const renderToggle = ({ triggerRef, onToggle, ariaProps, keyHandler }) => (
       <Button
         data-test-context-menu-toggle-button
+        ref={triggerRef}
+        onClick={onToggle}
         buttonStyle="noStyle"
+        buttonClass={css.navButton}
         marginBottom0
         style={{ height: '40px' }}
+        onKeyDown={keyHandler}
+        {...ariaProps}
       >
         <Icon icon={open ? 'caret-up' : 'caret-down'} iconPosition="end">
           <AppIcon app={selectedApp.displayName.toLowerCase()}>
-            <Headline tag="h1" size="small" margin="none">
+            <Headline
+              tag="h1"
+              margin="none"
+              weight="black"
+            >
               {selectedApp.displayName}
               <span className="sr-only">
                 <FormattedMessage id="stripes-core.mainnav.appContextMenu" />
@@ -44,6 +54,7 @@ class AppContextDropdown extends React.Component {
         onToggle={onToggle}
         renderTrigger={renderToggle}
         open={open}
+        usePortal={false}
       >
         <DropdownMenu
           id="App_context_dropdown_menu"


### PR DESCRIPTION
Followed migration direction here to remove the old dropdown API:

https://github.com/folio-org/stripes-components/tree/master/lib/Dropdown#migration-from-past-versions

Refs [STCOR-491](https://issues.folio.org/browse/STCOR-491)