### PR TITLE
STCOR-471: Adjust context in DllReferencePlugin

### DIFF
--- a/webpack/build.js
+++ b/webpack/build.js
@@ -43,7 +43,7 @@ module.exports = function build(stripesConfig, options) {
       for (const dependency of dependencies) {
         const dependencyPath = path.resolve(dependency);
         config.plugins.push(new webpack.DllReferencePlugin({
-          context: dependencyPath.substring(0, dependencyPath.lastIndexOf('/')),
+          context: path.resolve(),
           manifest: require(dependencyPath)
         }));
       }


### PR DESCRIPTION
@ryandberger the previous context didn't work for me correctly. I think the idea for the context is to match the paths in the dll's manifest with the paths in the folder where we run build consuming the dll.

Now when I build with `--useDll` I finally see:

````js
   [0] delegated ./node_modules/react/index.js from dll-reference reactDll 42 bytes {0} [built]
   [1] delegated ./node_modules/prop-types/index.js from dll-reference reactDll 42 bytes {0} [built]
````