### PR TITLE
Add support for generic package scope names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add support for building and consuming Webpack DLLs. Refs STCOR-471.
 * Provide default HTML formatters to `<IntlProvider>` so we can avoid `<SafeHTMLMessage>`. Fixes STCOR-477.
 * Settings > Software version > Display a loading indicator when querying for missing/incompatible modules, STCOR-479.
+* Add support for generic package scope names (instead of assuming @folio/something). Refs STCOR-490.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/components/AppIcon/AppIcon.js
+++ b/src/components/AppIcon/AppIcon.js
@@ -39,8 +39,18 @@ const AppIcon = ({
      * If no icon is found we display a placeholder.
      *
      */
-    let appIcon = stripes?.icons?.[app]?.[iconKey];
-    if (!appIcon) appIcon = stripes?.icons?.[`@folio/${app}`]?.[iconKey];
+    const icons = stripes?.icons;
+    // First, see if the app name matches the package name exactly (no scope prefix).
+    let appIcon = icons?.[app]?.[iconKey];
+    if (!appIcon) {
+      for (const key in icons) {
+        // Otherwise, match the package name based on the name after the scope prefix.
+        // For example, app name 'inventory' would match '@folio/inventory' after removing scope.
+        if (key.indexOf('/') && key.slice(key.lastIndexOf('/') + 1) === app) {
+          appIcon = icons?.[key]?.[iconKey];
+        }
+      }
+    }
     if (appIcon && appIcon.src) {
       appIconProps = {
         src: appIcon.src,


### PR DESCRIPTION
- Fulfills [STCOR-490](https://issues.folio.org/browse/STCOR-490).
- Remove hard-coded requirement that modules must have prefix of `@folio/` scope and allow for other scope names.