### PR TITLE
Updating postcss-custom-properties to v10 fixing DoS security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "stylelint": "stylelint \"src/**/*.css\""
   },
   "engines": {
-    "node": ">=8.9.4"
+    "node": ">=10.0.0"
   },
   "stripes": {
     "okapiInterfaces": {
@@ -123,7 +123,7 @@
     "postcss-calc": "^6.0.0",
     "postcss-color-function": "^4.0.0",
     "postcss-custom-media": "^6.0.0",
-    "postcss-custom-properties": "^9.1.1",
+    "postcss-custom-properties": "^10.0.0",
     "postcss-import": "^12.0.0",
     "postcss-loader": "^3.0.0",
     "postcss-media-minmax": "^3.0.0",


### PR DESCRIPTION
- Also updating node version runtime to v10 since that is a requirement of `postcss-custom-properties` v10: https://github.com/postcss/postcss-custom-properties/releases/tag/10.0.0