### PR TITLE
STCOR-492: Append dlls to final output during build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Provide default HTML formatters to `<IntlProvider>` so we can avoid `<SafeHTMLMessage>`. Fixes STCOR-477.
 * Settings > Software version > Display a loading indicator when querying for missing/incompatible modules, STCOR-479.
 * Passing in full module name to resolve icon for modules that don't use @folio/ scope prefix. Refs STCOR-490.
+* Append dlls to final output during build. STCOR-492.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@formatjs/intl-pluralrules": "^2.2.1",
     "@formatjs/intl-relativetimeformat": "^5.2.3",
     "@hot-loader/react-dom": "^16.8.6",
+    "add-asset-html-webpack-plugin": "^3.1.3",
     "autoprefixer": "^9.1.1",
     "awesome-typescript-loader": "^5.2.0",
     "babel-loader": "^8.0.0",

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -28,7 +28,6 @@ module.exports = function build(stripesConfig, options) {
     if (options.sourcemap) {
       config.devtool = 'source-map';
     }
-
     if (options.createDll && options.dllName) { // Adjust build to create Webpack DLL
       config.entry = {};
       config.entry[options.dllName] = options.createDll.split(',');


### PR DESCRIPTION
When building with `--useDll` option the output folder needs to also include the dll file and append it to `index.html`. This PR is trying to address that.

https://issues.folio.org/browse/STCOR-492