### PR TITLE
Stcor 490 full module name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add support for building and consuming Webpack DLLs. Refs STCOR-471.
 * Provide default HTML formatters to `<IntlProvider>` so we can avoid `<SafeHTMLMessage>`. Fixes STCOR-477.
 * Settings > Software version > Display a loading indicator when querying for missing/incompatible modules, STCOR-479.
+* Passing in full module name to resolve icon for modules that don't use @folio/ scope prefix. Refs STCOR-490.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -101,7 +101,7 @@ class AppList extends Component {
                   data-test-app-list-item
                   aria-label={app.displayName}
                   iconData={app.iconData}
-                  iconKey={app.name}
+                  iconKey={app.module}
                   id={`app-list-item-${app.id}`}
                   label={app.displayName}
                   role="button"

--- a/src/components/MainNav/AppList/components/AppListDropdown/AppListDropdown.js
+++ b/src/components/MainNav/AppList/components/AppListDropdown/AppListDropdown.js
@@ -37,7 +37,7 @@ const AppListDropdown = ({ toggleDropdown, apps, listRef, selectedApp }) => (
           role="button"
         >
           <AppIcon
-            app={app.name}
+            app={app.module}
             size="small"
             icon={app.iconData}
           />

--- a/src/components/MainNav/CurrentApp/CurrentApp.js
+++ b/src/components/MainNav/CurrentApp/CurrentApp.js
@@ -37,7 +37,7 @@ const CurrentApp = ({ config, currentApp, id, intl, badge }) => {
     description: config.platformDescription || 'FOLIO platform',
   };
 
-  const { displayName, iconData, name, home, route } = actualCurrentApp;
+  const { displayName, iconData, module, home, route } = actualCurrentApp;
   const href = home || route;
   const ariaLabel = href ? intl.formatMessage({ id: 'stripes-core.mainnav.currentAppAriaLabel' }, { appName: displayName }) : displayName;
 
@@ -57,7 +57,7 @@ const CurrentApp = ({ config, currentApp, id, intl, badge }) => {
       id={id}
       ariaLabel={ariaLabel}
       badge={badge}
-      iconKey={name}
+      iconKey={module}
       className={css.button}
       innerClassName={css.button__inner}
       labelClassName={css.button__label}

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -72,7 +72,6 @@ class Settings extends React.Component {
   render() {
     const { stripes, location, intl: { formatMessage } } = this.props;
     const navLinks = this.connectedModules.map(({ module }) => {
-      const iconData = module.module.replace(packageName.PACKAGE_SCOPE_REGEX, '');
       return (
         <NavListItem
           key={module.route}
@@ -80,7 +79,7 @@ class Settings extends React.Component {
         >
           <AppIcon
             alt={module.displayName}
-            app={iconData}
+            app={module.module}
             size="small"
             iconClassName={css.appIcon}
           >


### PR DESCRIPTION
- Fulfills [STCOR-490](https://issues.folio.org/browse/STCOR-490).
- Passing in full module name to resolve icon so that `@folio/` scope prefix is not assumed.
- Tested with a non-folio-scoped module and confirmed that icon appears properly in menu bar, app drop-down list, current app in top left, and settings. Also verified folio-scoped app icons continue to work as expected. 
- NOTE: Icons within non-folio-scoped module page must make this same change in their codebase for the icon to display, but this handles the cases managed by `stripes-core`.