### PR TITLE
STCOR-495 disable SonarQube

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 buildNPM {
   publishModDescriptor = true
   runLint = true
-  runSonarqube = true
+  runSonarqube = false
   runScripts = [
    ['test:core':'--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'],
    ['test:webpack':'--reporter mocha-junit-reporter --reporter-options mochaFile=./artifacts/runTest/webpack-results.xml'] 


### PR DESCRIPTION
Disable SonarQube per [FOLIO-2920](https://issues.folio.org/browse/FOLIO-2920), because SQ is blowing up in some weird
way that we don't understand and is preventing all PRs from merging,
which sure ain't fair to them.

Refs [STCOR-495](https://issues.folio.org/browse/STCOR-495)