### PR TITLE
Updated documentation to instruct developers to pass full module name…

### DIFF
--- a/src/components/AppIcon/readme.md
+++ b/src/components/AppIcon/readme.md
@@ -10,11 +10,11 @@ AppIcon supports different ways of loading icons.
   import { AppIcon } from '@folio/stripes/core';
 
   // Note: Make sure that the AppIcon has "stripes" in context as it relies on stripes.metadata.
-  <AppIcon app="users" size="small" />
+  <AppIcon app="@folio/users" size="small" />
   ```
   Optional: You can supply an iconKey if you need a specific icon within an app. If the specific icon isn't bundled with the app it will simply render a placeholder.
 ```js
-  <AppIcon app="inventory" iconKey="holdings" />
+  <AppIcon app="@folio/inventory" iconKey="holdings" />
 ```
 
 ***2. Supply an object to the icon prop***
@@ -46,7 +46,7 @@ AppIcon supports different ways of loading icons.
 Name | Type | Description | default
 -- | -- | -- | --
 alt | string | Adds an 'alt'-attribute on the img-tag. | undefined
-app | string | The lowercased name of an app, e.g. "users" or "inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context. Read more [here](https://github.com/folio-org/stripes-core/blob/master/doc/app-metadata.md#icons). | undefined
+app | string | The lowercased full package name of an app, e.g. "@folio/users" or "@folio/inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context. Read more [here](https://github.com/folio-org/stripes-core/blob/master/doc/app-metadata.md#icons). | undefined
 children | node | Add content next to the icon - e.g. a label | undefined
 className | string | For adding custom class to component | undefined
 icon | object | Icon in form of an object. E.g. { src, alt } | undefined


### PR DESCRIPTION
… into `<AppIcon>`