### PR TITLE
STCOR-496 conduct discovery after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 5.0.4 IN PROGRESS
+
+* Conduct module discovery after login as current tenant. Fixes STCOR-496.
+
 ## [5.0.3](https://github.com/folio-org/stripes-core/tree/v5.0.3) (2020-09-28)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v5.0.3)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 buildNPM {
   publishModDescriptor = true
   runLint = true
-  runSonarqube = true
+  runSonarqube = false
   runScripts = [
    ['test:core':'--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'],
    ['test:webpack':'--reporter mocha-junit-reporter --reporter-options mochaFile=./artifacts/runTest/webpack-results.xml'] 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.2.0",
-    "@folio/stripes-cli": "^1.15.0",
+    "@folio/stripes-cli": "~1.18.0",
     "babel-eslint": "^8.0.1",
     "chai": "^4.1.2",
     "eslint": "^6.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,6 @@ import connectErrorEpic from './connectErrorEpic';
 import configureEpics from './configureEpics';
 import configureLogger from './configureLogger';
 import configureStore from './configureStore';
-import { discoverServices } from './discoverServices';
 import gatherActions from './gatherActions';
 import { destroyStore } from './mainActions';
 
@@ -32,7 +31,6 @@ export default class StripesCore extends Component {
 
     this.epics = configureEpics(connectErrorEpic);
     this.store = configureStore(initialState, this.logger, this.epics);
-    if (!okapi.withoutOkapi) discoverServices(this.store);
     this.actionNames = gatherActions();
   }
 

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -1,6 +1,13 @@
 import 'isomorphic-fetch';
 import { some } from 'lodash';
 
+function getHeaders(tenant, token) {
+  return {
+    'X-Okapi-Tenant': tenant,
+    'X-Okapi-Token': token,
+    'Content-Type': 'application/json'
+  };
+}
 /*
  * This function probes Okapi to discover what versions of what
  * interfaces are supported by the services that it is proxying
@@ -13,9 +20,7 @@ export function discoverServices(store) {
   const okapi = store.getState().okapi;
   return Promise.all([
     fetch(`${okapi.url}/_/version`, {
-      'headers': {
-        'X-Okapi-Tenant': 'supertenant'
-      }
+      headers: getHeaders(okapi.tenant, okapi.token)
     })
       .then((response) => { // eslint-disable-line consistent-return
         if (response.status >= 400) {
@@ -29,9 +34,7 @@ export function discoverServices(store) {
         store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
       }),
     fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules?full=true`, {
-      'headers': {
-        'X-Okapi-Tenant': 'supertenant'
-      }
+      headers: getHeaders(okapi.tenant, okapi.token)
     })
       .then((response) => { // eslint-disable-line consistent-return
         if (response.status >= 400) {

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -4,6 +4,7 @@ import localforage from 'localforage';
 import { translations } from 'stripes-config';
 import rtlDetect from 'rtl-detect';
 import moment from 'moment';
+import { discoverServices } from './discoverServices';
 
 import {
   clearCurrentUser,
@@ -150,6 +151,7 @@ function loadResources(okapiUrl, store, tenant) {
   getLocale(okapiUrl, store, tenant);
   getPlugins(okapiUrl, store, tenant);
   getBindings(okapiUrl, store, tenant);
+  if (!store.getState().okapi.withoutOkapi) discoverServices(store);
 }
 
 function createOkapiSession(okapiUrl, store, tenant, token, data) {


### PR DESCRIPTION
Backport changes from STCOR-454 (PR #893, #901) to `v5` in order to
allow operators in a multi-tenant environment to update their okapi to
v4. This means conducting module-discovery _after_ login and
authenticated as the current tenant instead of `supertenant`.

In short, this change allows `@folio/stripes` `v4`
(`@folio/stripes-core` `v5`) to be compatible with `okapi` `v4`;
previously, it was compatible only with `v3`.

Refs [STCOR-496](https://issues.folio.org/browse/STCOR-496), [STCOR-454](https://issues.folio.org/browse/STCOR-454)