### PR TITLE
STCOR-455 webpack plugin for error logging config

### DIFF
--- a/webpack/stripes-config-plugin.js
+++ b/webpack/stripes-config-plugin.js
@@ -21,7 +21,7 @@ module.exports = class StripesConfigPlugin {
     if (!_.isObject(options.modules)) {
       throw new StripesBuildError('stripes-config-plugin was not provided a "modules" object for enabling stripes modules');
     }
-    this.options = _.omit(options, 'branding');
+    this.options = _.omit(options, 'branding', 'errorLogging');
   }
 
   apply(compiler) {
@@ -55,6 +55,7 @@ module.exports = class StripesConfigPlugin {
     // Data provided by other stripes plugins via hooks
     const pluginData = {
       branding: {},
+      errorLogging: {},
       translations: {},
     };
     compiler.hooks.stripesConfigPluginBeforeWrite.call(pluginData);
@@ -63,10 +64,11 @@ module.exports = class StripesConfigPlugin {
     const stripesVirtualModule = `
       const { okapi, config, modules } = ${serialize(this.mergedConfig, { space: 2 })};
       const branding = ${stripesSerialize.serializeWithRequire(pluginData.branding)};
+      const errorLogging = ${stripesSerialize.serializeWithRequire(pluginData.errorLogging)};
       const translations = ${serialize(pluginData.translations, { space: 2 })};
       const metadata = ${stripesSerialize.serializeWithRequire(this.metadata)};
       const icons = ${stripesSerialize.serializeWithRequire(this.icons)};
-      export { okapi, config, modules, branding, translations, metadata, icons };
+      export { okapi, config, modules, branding, errorLogging, translations, metadata, icons };
     `;
 
     logger.log('writing virtual module...', stripesVirtualModule);

--- a/webpack/stripes-error-logging-plugin.js
+++ b/webpack/stripes-error-logging-plugin.js
@@ -1,0 +1,27 @@
+// This webpack plugin generates a virtual module containing the
+// error-handler configuration.
+
+const logger = require('./logger')('stripesErrorLoggingPlugin');
+
+module.exports = class StripesErrorLoggingPlugin {
+  constructor(options) {
+    logger.log('initializing...');
+
+    const defaultErrorLogging = {
+      rollbar: null,
+      bugsnag: null,
+      sentry: null,
+    };
+
+    const tenantErrorLogging = (options && options.tenantErrorLogging) ? options.tenantErrorLogging : {};
+    this.errorLogging = Object.assign({}, defaultErrorLogging, tenantErrorLogging);
+  }
+
+  apply(compiler) {
+    // Hook into stripesConfigPlugin to supply errorHandler config
+    compiler.hooks.stripesConfigPluginBeforeWrite.tap('StripesErrorLoggingPlugin', (config) => {
+      config.errorLogging = this.errorLogging;
+      logger.log('stripesConfigPluginBeforeWrite', config.errorHandler);
+    });
+  }
+};

--- a/webpack/stripes-webpack-plugin.js
+++ b/webpack/stripes-webpack-plugin.js
@@ -2,6 +2,7 @@
 
 const StripesConfigPlugin = require('./stripes-config-plugin');
 const StripesBrandingPlugin = require('./stripes-branding-plugin');
+const StripesErrorLoggingPlugin = require('./stripes-error-logging-plugin');
 const StripesTranslationsPlugin = require('./stripes-translations-plugin');
 const StripesDuplicatesPlugin = require('./stripes-duplicate-plugin');
 const logger = require('./logger')('stripesWebpackPlugin');
@@ -20,6 +21,9 @@ module.exports = class StripesWebpackPlugin {
       new StripesBrandingPlugin({
         tenantBranding: this.stripesConfig.branding,
         buildAllFavicons: isProduction,
+      }),
+      new StripesErrorLoggingPlugin({
+        tenantErrorLogging: this.stripesConfig.errorLogging,
       }),
       new StripesTranslationsPlugin(this.stripesConfig),
       new StripesDuplicatesPlugin(this.stripesConfig),


### PR DESCRIPTION
Read config values for error logging from the `stripes.config.js`
property `errorLogging`. Include the default keys `bugsnag`, `sentry`,
and `rollbar` with null values. The `errorLogging` object will be
present in `stripes-config` just as `branding` is, i.e. it can be
imported as
```
import { errorLogging } from `stripes-config`.
```

Refs STCOR-455