### PR TITLE
STCOR-497: Node.js TLS, HTTP and OpenSSL security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "stylelint": "stylelint \"src/**/*.css\""
   },
   "engines": {
-    "node": "^15.5.1 || ^14.15.4 || ^12.20.1"
+    "node": ">=15.5.1 || ^14.15.4 || ^12.20.1"
   },
   "stripes": {
     "okapiInterfaces": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "stylelint": "stylelint \"src/**/*.css\""
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": "^15.5.1 || ^14.15.4 || ^12.20.1"
   },
   "stripes": {
     "okapiInterfaces": {


### PR DESCRIPTION
Node is used to compile the Stripes based UI.
If Node fetches dependencies (external packages) it may use TLS, HTTP and/or OpenSSL
and might be affected by this issue. Then the build crashes or the resulting
FOLIO runtime might contain malware.

https://nodejs.org/en/blog/vulnerability/january-2021-security-releases/ explains the vulnerabilities:

* use-after-free in TLSWrap (High) https://nvd.nist.gov/vuln/detail/CVE-2020-8265
* HTTP Request Smuggling in nodejs https://nvd.nist.gov/vuln/detail/CVE-2020-8287
* OpenSSL - EDIPARTYNAME NULL pointer de-reference https://nvd.nist.gov/vuln/detail/CVE-2020-1971

Zak Burke wrote in #stripes-architecture Slack channel on 2020-12-17:
"Additionally, as already noted in https://issues.folio.org/browse/FOLIO-2553,
most packages de facto require node v12 already due to dependencies which correctly state a
v12 minimum.
IOW, yes, we should update the minimum required version we state on our package"

Bumping the node version to the latest patch version of the LTS release lines will
fix the issues CVE-2020-8265, CVE-2020-8287, and CVE-2020-1971.

Refs [STCOR-497](https://issues.folio.org/browse/STCOR-497)