### PR TITLE
STCOR-500: Avoid retrying of http requests using `useOkapiKy` hook by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Settings > Software version > Display a loading indicator when querying for missing/incompatible modules, STCOR-479.
 * Passing in full module name to resolve icon for modules that don't use @folio/ scope prefix. Refs STCOR-490.
 * Append dlls to final output during build. STCOR-492.
+* Avoid retrying of http requests using `useOkapiKy` hook by default. STCOR-500.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/useOkapiKy.js
+++ b/src/useOkapiKy.js
@@ -12,6 +12,7 @@ export default () => {
           request.headers.set('X-Okapi-Token', token);
         }
       ]
-    }
+    },
+    retry: 0
   });
 };


### PR DESCRIPTION
## Purpose

Avoid retrying of HTTP requests using `useOkapiKy` hook by default in the scope of the [STCOR-500](https://issues.folio.org/browse/STCOR-500).