### PR TITLE
STCOR-502 Expose module config

### DIFF
--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -36,7 +36,7 @@ function getModuleRoutes(stripes) {
             throw Error(error);
           }
 
-          const moduleStripes = stripes.clone({ connect });
+          const moduleStripes = stripes.clone({ connect, moduleConfig: module });
 
           return (
             <Route


### PR DESCRIPTION
This illustrates one approach to exposing the module config: adding it to the Stripes context. This way modules don't need to iterate through all modules to find their config (unlike via the plugin or exposing the whole module context) and we don't have to maintain a separate per-module context to surface just that.