### PR TITLE
STCOR-502 Expose module context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Passing in full module name to resolve icon for modules that don't use @folio/ scope prefix. Refs STCOR-490.
 * Append dlls to final output during build. STCOR-492.
 * Avoid retrying of http requests using `useOkapiKy` hook by default. STCOR-500.
+* Expose module context via `useModules`/`withModules`/`withModule`. STCOR-502
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ export { default as CalloutContext } from './src/CalloutContext';
 /* internal utilities */
 export { stripesShape } from './src/Stripes';
 export { withStripes, useStripes } from './src/StripesContext';
+export { useModules } from './src/ModulesContext';
+export { withModule, withModules } from './src/components/Modules';
 export { default as stripesConnect } from './src/stripesConnect';
 export { default as Pluggable } from './src/Pluggable';
 export { setServicePoints, setCurServicePoint } from './src/loginServices';

--- a/src/ModulesContext.js
+++ b/src/ModulesContext.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { modules } from 'stripes-config';
 
-export default React.createContext(modules);
+export const ModulesContext = React.createContext(modules);
+export default ModulesContext;
+export const useModules = () => useContext(ModulesContext);
 export { modules as originalModules };

--- a/src/components/ModuleTranslator/ModuleTranslator.js
+++ b/src/components/ModuleTranslator/ModuleTranslator.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 
-import ModulesContext, { originalModules } from '../../ModulesContext';
+import { ModulesContext, originalModules } from '../../ModulesContext';
 
 class ModuleTranslator extends React.Component {
   static propTypes = {

--- a/src/components/Modules/withModule.js
+++ b/src/components/Modules/withModule.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import ModulesContext from '../../ModulesContext';
+import { ModulesContext } from '../../ModulesContext';
 
 const getDisplayName = (WrappedComponent) => {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/src/components/Modules/withModules.js
+++ b/src/components/Modules/withModules.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import ModulesContext from '../../ModulesContext';
+import { ModulesContext } from '../../ModulesContext';
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -3,7 +3,7 @@ import { Route } from 'react-router-dom';
 
 import { connectFor } from '@folio/stripes-connect';
 
-import ModulesContext from './ModulesContext';
+import { ModulesContext } from './ModulesContext';
 import { StripesContext } from './StripesContext';
 import AddContext from './AddContext';
 import TitleManager from './components/TitleManager';


### PR DESCRIPTION
Exposes the module context, enabling apps to consume build-time configuration.