### PR TITLE
STCOR-501 bump stripes-connect for react 17 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@babel/register": "^7.0.0",
     "@bigtest/mirage": "^0.0.1",
     "@folio/stripes-components": "~9.0.0",
-    "@folio/stripes-connect": "~6.1.0",
+    "@folio/stripes-connect": "~7.0.0",
     "@folio/stripes-logger": "~1.0.0",
     "@formatjs/intl-displaynames": "^2.2.3",
     "@formatjs/intl-pluralrules": "^2.2.1",


### PR DESCRIPTION
`stripes-connect` will become compatible with `react` `v17` in `v7`, not
`v6.1`.

Refs [STCOR-501](https://issues.folio.org/browse/STCOR-501)