### PR TITLE
STCOR-505 revert #992 to restore change-password menu item

### DIFF
--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -85,14 +85,6 @@ class ProfileDropdown extends Component {
   }
 
   createLink(link, index, module) {
-    // STCOR-504: for reasons unclear, the isLocalLoginCheck line (below)
-    // started throwing an NPE, implying that module.getModule() is
-    // returning null. I don't understand how/why, but it is completely 
-    // breaking our nightly builds. returning null here will prevent the
-    // change-password link from appearing in the profile menu, but at 
-    // least we'll _have_ a profile menu.
-    return null;
-
     const { stripes } = this.props;
     const { check, route } = link;
     const isLocalLoginCheck = module.getModule()[check] || validations[check];

--- a/src/components/MainNav/ProfileDropdown/tests/profile-dropdown-test.js
+++ b/src/components/MainNav/ProfileDropdown/tests/profile-dropdown-test.js
@@ -12,7 +12,7 @@ class DummyApp extends Component {
   }
 }
 
-describe.skip('Profile dropdown', () => {
+describe('Profile dropdown', () => {
   const dropdown = new DropdownInteractor('#profileDropdown');
   const loginInteractor = new Interactor('[data-test-new-username-field]');
 


### PR DESCRIPTION
Reverts #992

With react 17 in place, the change-password menu somehow triggered an
NPE that, because it fell early in the render tree, completely blocked
access to the FOLIO UI. Now that the react 17 update itself has been
reverted, this temporary hack is, too.

Refs [STCOR-505](https://issues.folio.org/browse/STCOR-505), [STRIPES-722](https://issues.folio.org/browse/STRIPES-722)