### PR TITLE
Revert "STCOR-501 bump stripes-connect for react 17 compat"

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@babel/register": "^7.0.0",
     "@bigtest/mirage": "^0.0.1",
     "@folio/stripes-components": "~9.0.0",
-    "@folio/stripes-connect": "~7.0.0",
+    "@folio/stripes-connect": "~6.1.0",
     "@folio/stripes-logger": "~1.0.0",
     "@formatjs/intl-displaynames": "^2.2.3",
     "@formatjs/intl-pluralrules": "^2.2.1",


### PR DESCRIPTION
Reverts folio-org/stripes-core#991

Crackerjack research by @aditya-matukumalli and @mkuklis suggests [onFocus changes in React 17](https://github.com/facebook/react/issues/19743), which have caused [event handling trouble for others](https://eng.wealthfront.com/2021/01/14/upgrading-to-react-17-how-to-fix-the-issues-and-breaking-changes/), may be causing [our woes](https://issues.folio.org/browse/STCOR-504) too. 

Because we reverted the react-17 update all the way down the stack, [the `stripes-connect` version bump was also reverted](https://github.com/folio-org/stripes-connect/pull/168) and thus the desired version remains `6.1`.

Refs [STRIPES-722](https://issues.folio.org/browse/STRIPES-722)