### PR TITLE
Revert "STCOR-503 Move react-titled to peer dependency"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 * Append dlls to final output during build. STCOR-492.
 * Avoid retrying of http requests using `useOkapiKy` hook by default. STCOR-500.
 * Expose module context via `useModules`/`withModules`/`withModule`. STCOR-502
-* Move `react-titled` to peer. Refs STCOR-503.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "react-titled": "^1.0.0",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
     "stylelint": "^8.2.0",
@@ -137,6 +136,7 @@
     "react-final-form": "^6.3.0",
     "react-hot-loader": "^4.3.10",
     "react-redux": "^7.2.0",
+    "react-titled": "^1.0.0",
     "react-transform-catch-errors": "^1.0.2",
     "react-transition-group": "^2.2.1",
     "redux": "^4.0.0",
@@ -169,8 +169,7 @@
     "react-dom": "*",
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0",
-    "react-router-dom": "^5.2.0",
-    "react-titled": "^1.0.0"
+    "react-router-dom": "^5.2.0"
   },
   "resolutions": {
     "moment": "~2.24.0"


### PR DESCRIPTION
Reverts folio-org/stripes-core#990

In fact this was exported here but we missed it. Sorry!