### PR TITLE
STCOR-508: Setup react-query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Avoid retrying of http requests using `useOkapiKy` hook by default. STCOR-500.
 * Expose module context via `useModules`/`withModules`/`withModule`. STCOR-502
 * Add `prefix` prop to TitleManager. STCOR-507
+* Setup `react-query`. Refs STCOR-508
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "redux-logger": "^3.0.6",
     "redux-observable": "^0.15.0",
     "redux-thunk": "^2.1.0",
+    "react-query": "^3.6.0",
     "regenerator-runtime": "^0.13.3",
     "rimraf": "^2.5.4",
     "rtl-detect": "^1.0.2",

--- a/src/createReactQueryClient.js
+++ b/src/createReactQueryClient.js
@@ -1,0 +1,16 @@
+import { QueryClient } from 'react-query';
+
+const cacheTimeMinutes = 5;
+
+const createReactQueryClient = () => new QueryClient({
+  // https://react-query.tanstack.com/guides/important-defaults
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+      cacheTime: 1000 * 60 * cacheTimeMinutes,
+    },
+  },
+});
+
+export default createReactQueryClient;


### PR DESCRIPTION
## Purpose

Following the decision during the stripes-architecture meeting, the purpose of this PR is to setup [react-query](https://react-query.tanstack.com/) in the scope of the [STCOR-508](https://issues.folio.org/browse/STCOR-508).

`react-query` is a library for fetching, caching, and updating data in React applications without touching any "global state". This PR also provides [default options](https://react-query.tanstack.com/guides/important-defaults) so individual applications will not need to override them every time. The library provides handy hooks such as `useQuery`, `useQueries`, `useQueryClient`, etc to work with queries and `useMutation` to work with mutations. This library can be treated as an alternative to `stripes-connect` for developers who want to write the code using hooks for querying/mutating the data and leverage the features of `react-query`.

I also checked that for the `Bigtest` tests no teardown logic is needed. The queries cache comes cleared in each test.

In case the PR is merged I will add documentation to the [stripes](https://github.com/folio-org/stripes) project about recipes and important aspects that should be followed.