### PR TITLE
STCOR-506: Dispatch setOkapiReady only after all resources are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Remove support for `hardsource-webpack-plugin`. Refs STCOR-421, STCOR-510.
 * Refactor `<SSOLanding>` to avoid context error; upgrade `react-cookie` for the hooks. Refs STCOR-514.
 * Publish `ERROR` events from `<RouteErrorBoundary>` so handler modules can react to them. Refs STCOR-455.
+* Dispatch `setOkapiReady` when all resources are loaded. Fixes STCOR-506.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -8,6 +8,45 @@ function getHeaders(tenant, token) {
   };
 }
 
+function fetchOkapiVersion(store) {
+  const okapi = store.getState().okapi;
+
+  return fetch(`${okapi.url}/_/version`, {
+    headers: getHeaders(okapi.tenant, okapi.token)
+  }).then((response) => { // eslint-disable-line consistent-return
+    if (response.status >= 400) {
+      store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
+      return response;
+    } else {
+      return response.text().then((text) => {
+        store.dispatch({ type: 'DISCOVERY_OKAPI', version: text });
+      });
+    }
+  }).catch((reason) => {
+    store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
+  });
+}
+
+function fetchModules(store) {
+  const okapi = store.getState().okapi;
+
+  return fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules?full=true`, {
+    headers: getHeaders(okapi.tenant, okapi.token)
+  }).then((response) => { // eslint-disable-line consistent-return
+    if (response.status >= 400) {
+      store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
+      return response;
+    } else {
+      return response.json().then((json) => {
+        store.dispatch({ type: 'DISCOVERY_SUCCESS', data: json });
+        return Promise.all(json.map(entry => store.dispatch({ type: 'DISCOVERY_INTERFACES', data: entry })));
+      });
+    }
+  }).catch((reason) => {
+    store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
+  });
+}
+
 /*
  * This function probes Okapi to discover what versions of what
  * interfaces are supported by the services that it is proxying
@@ -15,40 +54,13 @@ function getHeaders(tenant, token) {
  * (e.g. not attempting to fetch loan information for a
  * non-circulating library that doesn't provide the circ interface)
  */
-
 export function discoverServices(store) {
-  const okapi = store.getState().okapi;
-  return Promise.all([
-    fetch(`${okapi.url}/_/version`, {
-      headers: getHeaders(okapi.tenant, okapi.token)
-    })
-      .then((response) => { // eslint-disable-line consistent-return
-        if (response.status >= 400) {
-          store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
-        } else {
-          return response.text().then((text) => {
-            store.dispatch({ type: 'DISCOVERY_OKAPI', version: text });
-          });
-        }
-      }).catch((reason) => {
-        store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
-      }),
-    fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules?full=true`, {
-      headers: getHeaders(okapi.tenant, okapi.token)
-    })
-      .then((response) => { // eslint-disable-line consistent-return
-        if (response.status >= 400) {
-          store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
-        } else {
-          return response.json().then((json) => {
-            store.dispatch({ type: 'DISCOVERY_SUCCESS', data: json });
-            return Promise.all(json.map(entry => store.dispatch({ type: 'DISCOVERY_INTERFACES', data: entry })));
-          });
-        }
-      }).catch((reason) => {
-        store.dispatch({ type: 'DISCOVERY_FAILURE', message: reason });
-      }),
-  ]).then(() => {
+  const promises = [
+    fetchOkapiVersion(store),
+    fetchModules(store),
+  ];
+
+  return Promise.all(promises).then(() => {
     store.dispatch({ type: 'DISCOVERY_FINISHED' });
   });
 }


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-506

The issue described in STCOR-506 was related to the fact that the `setOkapiReady` was dispatched inside `getBindings`:

https://github.com/folio-org/stripes-core/compare/STCOR-506?expand=1#diff-c9d695b1d57404dfed01196c8cf479c0e4cd48583f6c78e7db23402582846864L182

This would incorrectly mark okapi as ready causing `Root` to rerender before all other resources were loaded:

https://github.com/folio-org/stripes-core/blob/master/src/components/Root/Root.js#L83

This PR is changing the time when the  `setOkapiReady` is dispatched. It will happen only after all requests to resources are fetched and processed.

