### PR TITLE
Added missing rtl-detect dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,8 +89,9 @@
     "redux-form": "^8.3.0",
     "redux-logger": "^3.0.6",
     "redux-observable": "^0.15.0",
-    "rimraf": "^2.5.4",
     "redux-thunk": "^2.1.0",
+    "rimraf": "^2.5.4",
+    "rtl-detect": "^1.0.2",
     "rxjs": "^5.5.0",
     "rxjs-compat": "^6.5.4"
   },


### PR DESCRIPTION
## Description
Added a missing `rtl-detect` dependency that was recently removed, but is still imported in `loginServices`.
This causes test failures in `ui-inventory` module https://jenkins-aws.indexdata.com/job/folio-org/job/ui-inventory/job/UIIN-1407/3/console