### PR TITLE
STCOR-514 dispatch checkSSO on session hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Dispatch `setOkapiReady` when all resources are loaded. Fixes STCOR-506.
 * Configure `swr`. Refs STCOR-516.
 * Callouts are opened after page reload. Refs STCOR-518. 
+* When rehydrating a session from local storage, always dispatch `checkSSO`. Fixes STCOR-514.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Publish `ERROR` events from `<RouteErrorBoundary>` so handler modules can react to them. Refs STCOR-455.
 * Dispatch `setOkapiReady` when all resources are loaded. Fixes STCOR-506.
 * Configure `swr`. Refs STCOR-516.
+* Callouts are opened after page reload. Refs STCOR-518. 
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -52,7 +52,6 @@ class Root extends Component {
 
     const appModule = getCurrentModule(modules, history.location);
     this.queryResourceStateKey = (appModule) ? getQueryResourceKey(appModule) : null;
-    this.callout = React.createRef();
     this.defaultRichTextElements = {
       b: (chunks) => <b>{chunks}</b>,
       i: (chunks) => <i>{chunks}</i>,
@@ -69,6 +68,10 @@ class Root extends Component {
     this.apolloClient = createApolloClient(okapi);
     this.reactQueryClient = createReactQueryClient();
     this.swrOptions = createSwrOptions();
+
+    this.state = {
+      callout: null,
+    };
   }
 
   getChildContext() {
@@ -109,6 +112,12 @@ class Root extends Component {
       return true;
     }
     return false;
+  }
+
+  setCalloutRef = (ref) => {
+    this.setState({
+      callout: ref,
+    });
   }
 
   render() {
@@ -168,7 +177,7 @@ class Root extends Component {
                   onError={config?.suppressIntlErrors ? () => {} : undefined}
                   defaultRichTextElements={this.defaultRichTextElements}
                 >
-                  <CalloutContext.Provider value={this.callout.current}>
+                  <CalloutContext.Provider value={this.state.callout}>
                     <RootWithIntl
                       stripes={stripes}
                       token={token}
@@ -176,7 +185,7 @@ class Root extends Component {
                       history={history}
                     />
                   </CalloutContext.Provider>
-                  <Callout ref={this.callout} />
+                  <Callout ref={this.setCalloutRef} />
                 </IntlProvider>
               </SWRConfig>
             </QueryClientProvider>

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -314,6 +314,7 @@ function validateUser(okapiUrl, store, tenant, session) {
       store.dispatch(clearCurrentUser());
       store.dispatch(clearOkapiToken());
       localforage.removeItem('okapiSess');
+      return null;
     } else {
       const { token, user, perms } = session;
       store.dispatch(setSessionData({ token, user, perms }));
@@ -429,9 +430,7 @@ function processOkapiSession(okapiUrl, store, tenant, resp, ssoToken) {
 export function checkOkapiSession(okapiUrl, store, tenant) {
   localforage.getItem('okapiSess')
     .then((sess) => {
-      if (sess !== null) {
-        return validateUser(okapiUrl, store, tenant, sess);
-      }
+      return sess !== null ? validateUser(okapiUrl, store, tenant, sess) : null;
     })
     .then(() => {
       getSSOEnabled(okapiUrl, store, tenant);


### PR DESCRIPTION
When restoring a session that was preserved in local-storage, as when
opening a new window when all previous windows had been closed but the
user had never logged out, check SSO/SAML. Previously, these were
handled as a disjuction (if we have a session, rehydrate it; else check
for sso). Now they are simply both handled in series.

There is no reason they need to be alternatives. You could login via
SSO, then close your window, then open a new one, then logout. At this
point, you want to see the "Login with SSO" button again, but previously
you wouldn't have because the SSO/SAML check only happened when starting
new sessions, not when rehydrating existing sessions.

Refs [STCOR-514](https://issues.folio.org/browse/STCOR-514)