### PR TITLE
STCOR-522 do not nest forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Configure `swr`. Refs STCOR-516.
 * Callouts are opened after page reload. Refs STCOR-518.
 * Use `==` where possible for more efficient queries. Refs STCOR-520.
+* Do not nest authentication forms. Refs STCOR-522.
 
 ## [6.0.0](https://github.com/folio-org/stripes-core/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v5.0.2...v6.0.0)

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -202,6 +202,7 @@ class Login extends Component {
                       </Col>
                     </Row>
                   </form>
+                  { ssoActive && <form id="ssoForm" /> }
                 </Row>
               </div>
             </div>

--- a/src/components/SSOLogin/SSOLogin.js
+++ b/src/components/SSOLogin/SSOLogin.js
@@ -25,7 +25,6 @@ function SSOLogin(props) {
       >
         <FormattedMessage id="stripes-core.loginViaSSO" />
       </Button>
-      <form id="ssoForm" />
     </div>
   );
 }


### PR DESCRIPTION
The SSO/SAML form was nested inside the username-and-password form, but
forms may not be nested. This generated a console warning.

Refs [STCOR-522](https://issues.folio.org/browse/STCOR-522)