### PR TITLE
STCOR-526 provide and HTML entity id for the settings Paneset

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -114,7 +114,7 @@ class Settings extends React.Component {
     const activeLink = `/settings/${location.pathname.split('/')[2]}`;
 
     return (
-      <Paneset>
+      <Paneset id="settings-module-display">
         <Pane
           defaultWidth="20%"
           paneTitle={<FormattedMessage id="stripes-core.settings" />}


### PR DESCRIPTION
Without a unique HTML element ID, it is not possible for end-to-end
tests to assess when the settings pane has loaded.

Refs [STCOR-526](https://issues.folio.org/browse/STCOR-526), [FOLIO-2946](https://issues.folio.org/browse/FOLIO-2946)