### PR TITLE
STCOR-534: Move CalloutContext back to RootWithIntl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.2.0 (IN PROGRESS)
 
+* Move `<CalloutContext>` back to `<RootWithIntl>` to make sure `<Callout>` works between relogins. Fixes STCOR-534.
+
+
 ## [7.1.0](https://github.com/folio-org/stripes-core/tree/v7.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.0.0...v7.1.0)
 

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -10,6 +10,7 @@ import { CookiesProvider } from 'react-cookie';
 
 import { HotKeys } from '@folio/stripes-components/lib/HotKeys';
 import { connectFor } from '@folio/stripes-connect';
+import { Callout } from '@folio/stripes-components';
 
 import getModuleRoutes from './moduleRoutes';
 import events from './events';
@@ -35,6 +36,7 @@ import {
   AppCtxMenuProvider,
 } from './components';
 import { StripesContext } from './StripesContext';
+import CalloutContext from './CalloutContext';
 
 class RootWithIntl extends React.Component {
   static propTypes = {
@@ -52,6 +54,14 @@ class RootWithIntl extends React.Component {
     token: '',
     history: {},
   };
+
+  state = { callout: null };
+
+  setCalloutRef = (ref) => {
+    this.setState({
+      callout: ref,
+    });
+  }
 
   render() {
     const {
@@ -72,52 +82,57 @@ class RootWithIntl extends React.Component {
               noWrapper
             >
               <Provider store={stripes.store}>
-                <OverlayContainer />
                 <Router history={history}>
                   { token || disableAuth ?
-                    <MainContainer>
-                      <AppCtxMenuProvider>
-                        <MainNav stripes={stripes} />
-                        <HandlerManager
-                          event={events.LOGIN}
-                          stripes={stripes}
-                        />
-                        { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
-                          <ModuleContainer id="content">
-                            <Switch>
-                              <TitledRoute
-                                name="home"
-                                path="/"
-                                key="root"
-                                exact
-                                component={<Front stripes={stripes} />}
-                              />
-                              <TitledRoute
-                                name="ssoRedirect"
-                                path="/sso-landing"
-                                key="sso-landing"
-                                component={<SSORedirect stripes={stripes} />}
-                              />
-                              <TitledRoute
-                                name="settings"
-                                path="/settings"
-                                component={<Settings stripes={stripes} />}
-                              />
-                              {getModuleRoutes(stripes)}
-                              <TitledRoute
-                                name="notFound"
-                                component={(
-                                  <div>
-                                    <h2>Uh-oh!</h2>
-                                    <p>This route does not exist.</p>
-                                  </div>
-                                )}
-                              />
-                            </Switch>
-                          </ModuleContainer>
-                        )}
-                      </AppCtxMenuProvider>
-                    </MainContainer> :
+                    <>
+                      <CalloutContext.Provider value={this.state.callout}>
+                        <MainContainer>
+                          <AppCtxMenuProvider>
+                            <MainNav stripes={stripes} />
+                            <HandlerManager
+                              event={events.LOGIN}
+                              stripes={stripes}
+                            />
+                            { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
+                              <ModuleContainer id="content">
+                                <OverlayContainer />
+                                <Switch>
+                                  <TitledRoute
+                                    name="home"
+                                    path="/"
+                                    key="root"
+                                    exact
+                                    component={<Front stripes={stripes} />}
+                                  />
+                                  <TitledRoute
+                                    name="ssoRedirect"
+                                    path="/sso-landing"
+                                    key="sso-landing"
+                                    component={<SSORedirect stripes={stripes} />}
+                                  />
+                                  <TitledRoute
+                                    name="settings"
+                                    path="/settings"
+                                    component={<Settings stripes={stripes} />}
+                                  />
+                                  {getModuleRoutes(stripes)}
+                                  <TitledRoute
+                                    name="notFound"
+                                    component={(
+                                      <div>
+                                        <h2>Uh-oh!</h2>
+                                        <p>This route does not exist.</p>
+                                      </div>
+                                    )}
+                                  />
+                                </Switch>
+                              </ModuleContainer>
+                            )}
+                          </AppCtxMenuProvider>
+                        </MainContainer>
+                      </CalloutContext.Provider>
+                      <Callout ref={this.setCalloutRef} />
+                    </> :
                     <Switch>
                       <TitledRoute
                         name="CreateResetPassword"

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -75,17 +75,17 @@ class RootWithIntl extends React.Component {
 
     return (
       <StripesContext.Provider value={stripes}>
-        <ModuleTranslator>
-          <TitleManager>
-            <HotKeys
-              keyMap={stripes.bindings}
-              noWrapper
-            >
-              <Provider store={stripes.store}>
-                <Router history={history}>
-                  { token || disableAuth ?
-                    <>
-                      <CalloutContext.Provider value={this.state.callout}>
+        <CalloutContext.Provider value={this.state.callout}>
+          <ModuleTranslator>
+            <TitleManager>
+              <HotKeys
+                keyMap={stripes.bindings}
+                noWrapper
+              >
+                <Provider store={stripes.store}>
+                  <Router history={history}>
+                    { token || disableAuth ?
+                      <>
                         <MainContainer>
                           <AppCtxMenuProvider>
                             <MainNav stripes={stripes} />
@@ -130,53 +130,53 @@ class RootWithIntl extends React.Component {
                             )}
                           </AppCtxMenuProvider>
                         </MainContainer>
-                      </CalloutContext.Provider>
-                      <Callout ref={this.setCalloutRef} />
-                    </> :
-                    <Switch>
-                      <TitledRoute
-                        name="CreateResetPassword"
-                        path="/reset-password/:token"
-                        component={<CreateResetPassword stripes={stripes} />}
-                      />
-                      <TitledRoute
-                        name="ssoLanding"
-                        exact
-                        path="/sso-landing"
-                        component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>}
-                        key="sso-landing"
-                      />
-                      <TitledRoute
-                        name="forgotPassword"
-                        path="/forgot-password"
-                        component={<ForgotPasswordCtrl stripes={stripes} />}
-                      />
-                      <TitledRoute
-                        name="forgotUsername"
-                        path="/forgot-username"
-                        component={<ForgotUserNameCtrl stripes={stripes} />}
-                      />
-                      <TitledRoute
-                        name="checkEmail"
-                        path="/check-email"
-                        component={<CheckEmailStatusPage />}
-                      />
-                      <TitledRoute
-                        name="login"
-                        component={
-                          <Login
-                            autoLogin={stripes.config.autoLogin}
-                            stripes={stripes}
-                          />
-                        }
-                      />
-                    </Switch>
-                  }
-                </Router>
-              </Provider>
-            </HotKeys>
-          </TitleManager>
-        </ModuleTranslator>
+                        <Callout ref={this.setCalloutRef} />
+                      </> :
+                      <Switch>
+                        <TitledRoute
+                          name="CreateResetPassword"
+                          path="/reset-password/:token"
+                          component={<CreateResetPassword stripes={stripes} />}
+                        />
+                        <TitledRoute
+                          name="ssoLanding"
+                          exact
+                          path="/sso-landing"
+                          component={<CookiesProvider><SSOLanding stripes={stripes} /></CookiesProvider>}
+                          key="sso-landing"
+                        />
+                        <TitledRoute
+                          name="forgotPassword"
+                          path="/forgot-password"
+                          component={<ForgotPasswordCtrl stripes={stripes} />}
+                        />
+                        <TitledRoute
+                          name="forgotUsername"
+                          path="/forgot-username"
+                          component={<ForgotUserNameCtrl stripes={stripes} />}
+                        />
+                        <TitledRoute
+                          name="checkEmail"
+                          path="/check-email"
+                          component={<CheckEmailStatusPage />}
+                        />
+                        <TitledRoute
+                          name="login"
+                          component={
+                            <Login
+                              autoLogin={stripes.config.autoLogin}
+                              stripes={stripes}
+                            />
+                          }
+                        />
+                      </Switch>
+                    }
+                  </Router>
+                </Provider>
+              </HotKeys>
+            </TitleManager>
+          </ModuleTranslator>
+        </CalloutContext.Provider>
       </StripesContext.Provider>
     );
   }

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -72,6 +72,7 @@ class RootWithIntl extends React.Component {
               noWrapper
             >
               <Provider store={stripes.store}>
+                <OverlayContainer />
                 <Router history={history}>
                   { token || disableAuth ?
                     <MainContainer>
@@ -83,7 +84,6 @@ class RootWithIntl extends React.Component {
                         />
                         { (stripes.okapi !== 'object' || stripes.discovery.isFinished) && (
                           <ModuleContainer id="content">
-                            <OverlayContainer />
                             <Switch>
                               <TitledRoute
                                 name="home"

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -10,7 +10,6 @@ import { SWRConfig } from 'swr';
 import { ApolloProvider } from '@apollo/client';
 
 import ErrorBoundary from '@folio/stripes-components/lib/ErrorBoundary';
-import { Callout } from '@folio/stripes-components';
 import { metadata, icons } from 'stripes-config';
 
 /* ConnectContext - formerly known as RootContext, now comes from stripes-connect, so stripes-connect
@@ -29,7 +28,6 @@ import { getQueryResourceKey, getCurrentModule } from '../../locationService';
 import Stripes from '../../Stripes';
 import RootWithIntl from '../../RootWithIntl';
 import SystemSkeleton from '../SystemSkeleton';
-import CalloutContext from '../../CalloutContext';
 
 import './Root.css';
 
@@ -68,10 +66,6 @@ class Root extends Component {
     this.apolloClient = createApolloClient(okapi);
     this.reactQueryClient = createReactQueryClient();
     this.swrOptions = createSwrOptions();
-
-    this.state = {
-      callout: null,
-    };
   }
 
   getChildContext() {
@@ -112,12 +106,6 @@ class Root extends Component {
       return true;
     }
     return false;
-  }
-
-  setCalloutRef = (ref) => {
-    this.setState({
-      callout: ref,
-    });
   }
 
   render() {
@@ -177,15 +165,12 @@ class Root extends Component {
                   onError={config?.suppressIntlErrors ? () => {} : undefined}
                   defaultRichTextElements={this.defaultRichTextElements}
                 >
-                  <CalloutContext.Provider value={this.state.callout}>
-                    <RootWithIntl
-                      stripes={stripes}
-                      token={token}
-                      disableAuth={disableAuth}
-                      history={history}
-                    />
-                  </CalloutContext.Provider>
-                  <Callout ref={this.setCalloutRef} />
+                  <RootWithIntl
+                    stripes={stripes}
+                    token={token}
+                    disableAuth={disableAuth}
+                    history={history}
+                  />
                 </IntlProvider>
               </SWRConfig>
             </QueryClientProvider>


### PR DESCRIPTION
This PR moves `<CalloutContext>` back to `<RootWithIntl>`. This was our original setup back in:

https://github.com/folio-org/stripes-core/commit/a2ab520d33308fd415807ab1d3ac871f8e190114

https://issues.folio.org/browse/STCOR-534

The previous setup was causing issues with the `Callout` ref being lost between re-logins since  it's only created once when the app loads initially:

https://github.com/folio-org/stripes-core/blob/master/src/components/Root/Root.js#L188

This change makes sure that:

1. Callout works when locale is changed (STCOR-481)
2. Menus and dialogs display correctly
3. Callout works during re-login and page refresh
