### PR TITLE
STCOR-535: Regexp denial of service (ReDoS) in validatePhoneNumber

### DIFF
--- a/src/validators/validatePhoneNumber/validatePhoneNumber.js
+++ b/src/validators/validatePhoneNumber/validatePhoneNumber.js
@@ -1,5 +1,5 @@
 export default phoneNumber => {
-  const phoneRegExp = /^(\d+[.-]*)+\d+$/;
+  const phoneRegExp = /^\d+([.-]+\d+)*$/;
 
   return phoneRegExp.test(phoneNumber);
 };


### PR DESCRIPTION
## Overview

Regular expression denial of service (ReDoS) in [validatePhoneNumber.js](https://github.com/folio-org/stripes-core/blob/v7.1.0/src/validators/validatePhoneNumber/validatePhoneNumber.js):

`^(\d+[.-]*)+\d+$`


## Steps to Reproduce

* Open "Forget username" form, for example https://folio-snapshot.dev.folio.org/forgot-username
* Paste `1234567890123456788901234567890@mail`
* Press enter or click "Continue"

## Expected Results

Error message saying "Please enter a valid email address."

## Actual Results

Nothing. Console shows "Uncaught (in promise) InternalError: too much recursion" after 6 seconds.

## Additional Information

The issue exists in stripes-core in all versions >= 2.17.0. Commit that has introduced the issue: https://github.com/folio-org/stripes-core/commit/d51ea404280d57e974aa296d57e08d92a5a40a4e

Replacing
`^(\d+[.-]*)+\d+$`
by
`^\d+([.-]+\d+)*$`
matches the same but has no Regular expression denial of service (ReDoS) issue.

The problem is `[.-]*`
This not only matches when there is a full stop or a hyphen, it also matches the empty string. The group
`(\d+[.-]*)`
can match any sub-sequence of a sequence of digits. The expression
`(\d+[.-]*)+`
can match a sequence of digits by chunking it in any possible way, for example
```
(12345678901234567890)
(1234567890123456789)(0)
(123456789012345678)(90)
(12345678901234567)(890)
(1)(23)(4)(5678)(90)(1)(234567)(890)
```
The number of partition sets increases very fast: https://en.wikipedia.org/wiki/Bell_number

A long list of digits followed by a character that is neither digit nor full stop nor hyphen forces the regexp engine to try all possible digit matches (chunking, partitioning) resulting in a recursion or timeout problem.

The fix doesn't require any backtracking. A new group is only started when a digit is followed by one of the two punctuation characters. Using `[.-]+` instead of `[.-]*` doesn't allow the empty string to match.