### PR TITLE
STCOR-531 Add help button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.2.0 (IN PROGRESS)
 
 * Move `<CalloutContext>` back to `<RootWithIntl>` to make sure `<Callout>` works between relogins. Fixes STCOR-534.
+* Access to Help Site from Universal Header. Refs STCOR-531.
 
 
 ## [7.1.0](https://github.com/folio-org/stripes-core/tree/v7.1.0) (2021-04-08)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -207,13 +207,13 @@ class MainNav extends Component {
                 <NavDivider md="hide" />
                 <NavButton
                   aria-label="Help button"
-                  data-test-app-list-item-help-button
+                  data-test-item-help-button
+                  href="https://docs.folio.org/docs/"
                   icon={<Icon
                     icon="question-mark"
                     size="large"
                   />}
                   id="helpButton"
-                  href="https://docs.folio.org/docs/"
                   target="_blank"
                 />
                 <NavDivider md="hide" />

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -6,6 +6,8 @@ import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router';
 import localforage from 'localforage';
 
+import Icon from '@folio/stripes-components/lib/Icon';
+
 import { withModules } from '../Modules';
 import { LastVisitedContext } from '../LastVisited';
 import { clearOkapiToken, clearCurrentUser } from '../../okapiActions';
@@ -20,6 +22,7 @@ import {
 } from '../../locationService';
 
 import css from './MainNav.css';
+import NavButton from './NavButton';
 import NavDivider from './NavDivider';
 import { CurrentAppGroup } from './CurrentApp';
 import ProfileDropdown from './ProfileDropdown';
@@ -200,6 +203,18 @@ class MainNav extends Component {
                   apps={apps}
                   selectedApp={selectedApp}
                   dropdownToggleId="app-list-dropdown-toggle"
+                />
+                <NavDivider md="hide" />
+                <NavButton
+                  aria-label="Help button"
+                  data-test-app-list-item-help-button
+                  icon={<Icon
+                    icon="question-mark"
+                    size="large"
+                  />}
+                  id="helpButton"
+                  href="https://docs.folio.org/docs/"
+                  target="_blank"
                 />
                 <NavDivider md="hide" />
                 <ProfileDropdown

--- a/test/bigtest/interactors/app.js
+++ b/test/bigtest/interactors/app.js
@@ -1,7 +1,12 @@
-import { interactor, collection } from '@bigtest/interactor';
+import {
+  interactor,
+  scoped,
+  collection,
+} from '@bigtest/interactor';
 
 const navSelector = '[class^="navRoot---"]';
 
 export default @interactor class AppInteractor {
   nav = collection(title => `${navSelector} a[aria-label="${title}"]`);
+  helpButton = scoped('[data-test-item-help-button]');
 }

--- a/test/bigtest/tests/nav-test.js
+++ b/test/bigtest/tests/nav-test.js
@@ -37,6 +37,10 @@ describe('Nav', () => {
     expect(app.nav('Dummy').isPresent).to.be.true;
   });
 
+  it('shows help button', function () {
+    expect(app.helpButton.isPresent).to.be.true;
+  });
+
   describe('clicking settings', () => {
     beforeEach(async () => {
       await app.nav('Settings').click();


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-531

As a staff person
I want to access the FOLIO help site via a ? help icon from the upper right hand side of the universal header
So that I have ready access to help documentation

**Current situation or problem:** There is no way to access the help site from the UI of FOLIO
**Requirement:** To open the FOLIO UI and have access to a button on the top menu bar that launches https://docs.folio.org/docs/ in a new browser tab/window.

**Mockups**
![image](https://user-images.githubusercontent.com/48911833/115678018-5b0a1d00-a351-11eb-81a2-eb379b23a275.png)
![image](https://user-images.githubusercontent.com/48911833/115678033-60676780-a351-11eb-8446-62311074e2b1.png)

