### PR TITLE
STCOR-539 clean up props to Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Move `<CalloutContext>` back to `<RootWithIntl>` to make sure `<Callout>` works between relogins. Fixes STCOR-534.
 * Access to Help Site from Universal Header. Refs STCOR-531.
-
+* Do not pass useless props to `<Dropdown>`. Refs STCOR-539.
 
 ## [7.1.0](https://github.com/folio-org/stripes-core/tree/v7.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.0.0...v7.1.0)

--- a/src/components/MainNav/AppList/AppList.js
+++ b/src/components/MainNav/AppList/AppList.js
@@ -168,7 +168,6 @@ class AppList extends Component {
       <div className={css.navListDropdownWrap}>
         <Dropdown
           placement="bottom-end"
-          dropdownClass={css.navListDropdown}
           id={dropdownId}
           renderTrigger={renderDropdownToggleButton}
           usePortal={false}


### PR DESCRIPTION
`<Dropdown>` no longer uses the `dropdownClass` prop (so it should
really be labeled as deprecated there in order to avoid this particular
console warning, though replacing one console warning with another does
seem kind of lame).

@JohnC-80, I don't see any use of this prop in `<Dropdown>` except in the [proptypes list](https://github.com/folio-org/stripes-components/blame/fcccc3af706a75b0777f1ebd05785f19907ecfd4/lib/Dropdown/Dropdown.js#L20). I think it was removed in https://github.com/folio-org/stripes-components/pull/283 (maybe?) and because of how props are destructured elsewhere, we now get a console warning. 

Refs [STCOR-539](https://issues.folio.org/browse/STCOR-539)