### PR TITLE
STCOR-537: Introduce useNamespace hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Access to Help Site from Universal Header. Refs STCOR-531.
 * Do not pass useless props to `<Dropdown>`. Refs STCOR-539.
 * Introduce `<ModuleHierarchyProvider>`. Refs STCOR-529.
+* Introduce `useNamespace` hook which returns module namespace. Refs STCOR-537.
 
 ## [7.1.0](https://github.com/folio-org/stripes-core/tree/v7.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.0.0...v7.1.0)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ export { default as coreEvents } from './src/events';
 export { default as useOkapiKy } from './src/useOkapiKy';
 export { default as withOkapiKy } from './src/withOkapiKy';
 export { default as useCustomFields } from './src/useCustomFields';
+export { default as useNamespace } from './src/hooks/useNamespace';
 
 /* components */
 export { default as AppContextMenu } from './src/components/MainNav/CurrentApp/AppContextMenu';
@@ -28,3 +29,4 @@ export { ModuleHierarchyContext, useModuleHierarchy } from './src/components';
 
 /* misc */
 export { supportedLocales } from './src/loginServices';
+

--- a/src/constants/delimiters.js
+++ b/src/constants/delimiters.js
@@ -1,0 +1,5 @@
+const delimiters = {
+  NAMESPACE_DELIMITER: ':',
+};
+
+export default delimiters;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,3 +3,4 @@ export { default as forgotFormErrorCodes } from './forgotFormErrorCodes';
 export { default as changePasswordErrorCodes } from './changePasswordErrorCodes';
 export { default as defaultErrors } from './defaultErrors';
 export { default as packageName } from './packageName';
+export { default as delimiters } from './delimiters';

--- a/src/hooks/useNamespace.js
+++ b/src/hooks/useNamespace.js
@@ -1,0 +1,31 @@
+import { useModuleHierarchy } from '../components';
+
+// A hook which returns module namespace as a string
+// https://issues.folio.org/browse/STCOR-537
+
+// Example usage:
+
+// from app module (e.g. ui-users)
+// const namespace = useNamespace(); // "@folio/users"
+
+// from plugin embedded in app module (e.g. ui-plugin-find-order executing in ui-agreements)
+// const namespace = useNamespace(); // "@folio/agreements:@folio/plugin-find-order"
+
+// from plugin embedded in app module with `ignoreParents` option (e.g. plugin ui-plugin-find-order executing in ui-agreements)
+// const namespace = useNamespace({ ignoreParents: true }); // "@folio/plugin-find-order"
+
+// from plugin embedded in app module with `key` option present (e.g. ui-plugin-find-order executing in ui-agreements)
+// const namespace = useNamespace({ key: "filters-pane" }); // "@folio/agreements:@folio/plugin-find-order:filters-pane"
+const useNamespace = (options = {}) => {
+  const moduleHierarchy = useModuleHierarchy();
+  const { ignoreParents, key } = options;
+  let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(':');
+
+  if (key) {
+    namespace += `:${key}`;
+  }
+
+  return namespace;
+};
+
+export default useNamespace;

--- a/src/hooks/useNamespace.js
+++ b/src/hooks/useNamespace.js
@@ -20,10 +20,11 @@ import { delimiters } from '../constants';
 const useNamespace = (options = {}) => {
   const moduleHierarchy = useModuleHierarchy();
   const { ignoreParents, key } = options;
-  let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(delimiters.NAMESPACE_DELIMITER);
+  const { NAMESPACE_DELIMITER } = delimiters;
+  let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(NAMESPACE_DELIMITER);
 
   if (key) {
-    namespace += `${delimiters.NAMESPACE_DELIMITER}${key}`;
+    namespace += `${NAMESPACE_DELIMITER}${key}`;
   }
 
   return namespace;

--- a/src/hooks/useNamespace.js
+++ b/src/hooks/useNamespace.js
@@ -18,9 +18,10 @@ import { delimiters } from '../constants';
 // from plugin embedded in app module with `key` option present (e.g. ui-plugin-find-order executing in ui-agreements)
 // const namespace = useNamespace({ key: "filters-pane" }); // "@folio/agreements:@folio/plugin-find-order:filters-pane"
 const useNamespace = (options = {}) => {
-  const moduleHierarchy = useModuleHierarchy();
   const { ignoreParents, key } = options;
   const { NAMESPACE_DELIMITER } = delimiters;
+  const moduleHierarchy = useModuleHierarchy();
+
   let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(NAMESPACE_DELIMITER);
 
   if (key) {

--- a/src/hooks/useNamespace.js
+++ b/src/hooks/useNamespace.js
@@ -4,31 +4,45 @@ import { delimiters } from '../constants';
 // A hook which returns module namespace as a string
 // https://issues.folio.org/browse/STCOR-537
 
+// const [namespace, getNamespace] = useNamespace();
+
 // Example usage:
 
 // from app module (e.g. ui-users)
-// const namespace = useNamespace(); // "@folio/users"
+// const [namespace] = useNamespace(); // "@folio/users"
+
+// from app module (e.g. ui-users) via getNamespace
+// const [_, getNamespace] = useNamespace();
+// const namespace = getNamespace({ key: 'test-key' }) // "@folio/users:test-key"
 
 // from plugin embedded in app module (e.g. ui-plugin-find-order executing in ui-agreements)
-// const namespace = useNamespace(); // "@folio/agreements:@folio/plugin-find-order"
+// const [namespace] = useNamespace(); // "@folio/agreements:@folio/plugin-find-order"
 
 // from plugin embedded in app module with `ignoreParents` option (e.g. plugin ui-plugin-find-order executing in ui-agreements)
-// const namespace = useNamespace({ ignoreParents: true }); // "@folio/plugin-find-order"
+// const [namespace] = useNamespace({ ignoreParents: true }); // "@folio/plugin-find-order"
 
 // from plugin embedded in app module with `key` option present (e.g. ui-plugin-find-order executing in ui-agreements)
-// const namespace = useNamespace({ key: "filters-pane" }); // "@folio/agreements:@folio/plugin-find-order:filters-pane"
+// const [namespace] = useNamespace({ key: "filters-pane" }); // "@folio/agreements:@folio/plugin-find-order:filters-pane"
+
+
 const useNamespace = (options = {}) => {
-  const { ignoreParents, key } = options;
-  const { NAMESPACE_DELIMITER } = delimiters;
   const moduleHierarchy = useModuleHierarchy();
+  const getNamespace = (opts) => {
+    const { ignoreParents, key } = opts;
+    const { NAMESPACE_DELIMITER } = delimiters;
 
-  let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(NAMESPACE_DELIMITER);
+    let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(NAMESPACE_DELIMITER);
 
-  if (key) {
-    namespace += `${NAMESPACE_DELIMITER}${key}`;
-  }
+    if (key) {
+      namespace += `${NAMESPACE_DELIMITER}${key}`;
+    }
 
-  return namespace;
+    return namespace;
+  };
+
+  const namespace = getNamespace(options);
+
+  return [namespace, getNamespace];
 };
 
 export default useNamespace;

--- a/src/hooks/useNamespace.js
+++ b/src/hooks/useNamespace.js
@@ -1,4 +1,5 @@
 import { useModuleHierarchy } from '../components';
+import { delimiters } from '../constants';
 
 // A hook which returns module namespace as a string
 // https://issues.folio.org/browse/STCOR-537
@@ -19,10 +20,10 @@ import { useModuleHierarchy } from '../components';
 const useNamespace = (options = {}) => {
   const moduleHierarchy = useModuleHierarchy();
   const { ignoreParents, key } = options;
-  let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(':');
+  let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(delimiters.NAMESPACE_DELIMITER);
 
   if (key) {
-    namespace += `:${key}`;
+    namespace += `${delimiters.NAMESPACE_DELIMITER}${key}`;
   }
 
   return namespace;

--- a/test/bigtest/interactors/Namespace.js
+++ b/test/bigtest/interactors/Namespace.js
@@ -1,0 +1,9 @@
+import {
+  interactor,
+  text,
+} from '@bigtest/interactor';
+
+export default @interactor
+class NamespaceInteractor {
+  name = text('#module-namespace');
+}

--- a/test/bigtest/tests/use-namespace-test.js
+++ b/test/bigtest/tests/use-namespace-test.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-core-application';
+import AppInteractor from '../interactors/app';
+
+import useNamespace from '../../../src/hooks/useNamespace';
+import Pluggable from '../../../src/Pluggable';
+import NamespaceInteractor from '../interactors/Namespace';
+
+const PrintNamespace = ({ options }) => {
+  const namespace = useNamespace(options);
+
+  return <div id="module-namespace">{namespace}</div>;
+};
+
+PrintNamespace.propTypes = {
+  options: PropTypes.object,
+};
+
+const ModuleA = () => <Pluggable type="plugin-a" />;
+const PluginA = () => <PrintNamespace />;
+
+const ModuleB = () => <Pluggable type="plugin-b" />;
+const PluginB = () => <PrintNamespace options={{ ignoreParents: true }} />;
+
+const ModuleC = () => <PrintNamespace options={{ key: 'test-key' }} />;
+
+describe('useNamespace', () => {
+  const app = new AppInteractor();
+  const namespace = new NamespaceInteractor();
+
+  setupApplication({
+    modules: [
+      {
+        type: 'app',
+        name: '@folio/ui-module-a',
+        displayName: 'module-a.title',
+        route: '/module-a',
+        module: ModuleA,
+      },
+      {
+        type: 'plugin',
+        name: '@folio/plugin-a',
+        displayName: 'plugin-a.title',
+        pluginType: 'plugin-a',
+        module: PluginA,
+      },
+      {
+        type: 'app',
+        name: '@folio/ui-module-b',
+        displayName: 'module-b.title',
+        route: '/module-b',
+        module: ModuleB,
+      },
+      {
+        type: 'plugin',
+        name: '@folio/plugin-b',
+        displayName: 'plugin-b.title',
+        pluginType: 'plugin-b',
+        module: PluginB,
+      },
+      {
+        type: 'app',
+        name: '@folio/ui-module-c',
+        displayName: 'module-c.title',
+        route: '/module-c',
+        module: ModuleC,
+      },
+    ],
+    translations: {
+      'module-a.title': 'ModuleA',
+      'module-b.title': 'ModuleB',
+      'module-c.title': 'ModuleC',
+      'plugin-a.title': 'PluginA',
+      'plugin-b.title': 'PluginB',
+    },
+  });
+
+  describe('Open app A with a plugin', () => {
+    beforeEach(async () => {
+      await app.nav('ModuleA').click();
+    });
+
+    it('shows full namespace', () => {
+      expect(namespace.name).to.equal('@folio/ui-module-a:@folio/plugin-a');
+    });
+  });
+
+  describe('open app B with a plugin ignoring parents', () => {
+    beforeEach(async () => {
+      await app.nav('ModuleB').click();
+    });
+
+    it('shows plugin namespace', () => {
+      expect(namespace.name).to.equal('@folio/plugin-b');
+    });
+  });
+
+  describe('open app C with a namespace key', () => {
+    beforeEach(async () => {
+      await app.nav('ModuleC').click();
+    });
+
+    it('shows module namespace with a key', () => {
+      expect(namespace.name).to.equal('@folio/ui-module-c:test-key');
+    });
+  });
+});

--- a/test/bigtest/tests/use-namespace-test.js
+++ b/test/bigtest/tests/use-namespace-test.js
@@ -12,13 +12,19 @@ import Pluggable from '../../../src/Pluggable';
 import NamespaceInteractor from '../interactors/Namespace';
 
 const PrintNamespace = ({ options }) => {
-  const namespace = useNamespace(options);
+  const [namespace] = useNamespace(options);
 
   return <div id="module-namespace">{namespace}</div>;
 };
 
 PrintNamespace.propTypes = {
   options: PropTypes.object,
+};
+
+const PrintViaGetNamespace = () => {
+  const [, getNamepace] = useNamespace();
+
+  return <div id="module-namespace">{getNamepace({ key: 'test-key-2' })}</div>;
 };
 
 const ModuleA = () => <Pluggable type="plugin-a" />;
@@ -28,6 +34,8 @@ const ModuleB = () => <Pluggable type="plugin-b" />;
 const PluginB = () => <PrintNamespace options={{ ignoreParents: true }} />;
 
 const ModuleC = () => <PrintNamespace options={{ key: 'test-key' }} />;
+
+const ModuleD = () => <PrintViaGetNamespace />;
 
 describe('useNamespace', () => {
   const app = new AppInteractor();
@@ -70,11 +78,19 @@ describe('useNamespace', () => {
         route: '/module-c',
         module: ModuleC,
       },
+      {
+        type: 'app',
+        name: '@folio/ui-module-d',
+        displayName: 'module-d.title',
+        route: '/module-d',
+        module: ModuleD,
+      }
     ],
     translations: {
       'module-a.title': 'ModuleA',
       'module-b.title': 'ModuleB',
       'module-c.title': 'ModuleC',
+      'module-d.title': 'ModuleD',
       'plugin-a.title': 'PluginA',
       'plugin-b.title': 'PluginB',
     },
@@ -107,6 +123,16 @@ describe('useNamespace', () => {
 
     it('shows module namespace with a key', () => {
       expect(namespace.name).to.equal('@folio/ui-module-c:test-key');
+    });
+  });
+
+  describe('open app D', () => {
+    beforeEach(async () => {
+      await app.nav('ModuleD').click();
+    });
+
+    it('shows module namespace with a key', () => {
+      expect(namespace.name).to.equal('@folio/ui-module-d:test-key-2');
     });
   });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-537

This PR introduces a `useNamespace` hook described by @skomorokh and outlined by @doytch under [STCOR-537](https://issues.folio.org/browse/STCOR-537).

The signature currently looks like this:

````js
const [namespace, getNamespace] = useNamespace(options);
````

The `namespace` represents a namespace as a string. The `getNamespace` is a function which can be used to retrieve a namespace with a different set of options:

````js
const ns = getNamepace({ key: 'test-key' });
````

Possible options:

- key - a string which will be appended to the given namespace
- ignoreParents - a boolean which can be used to ignore the parents part from a module hierarchy. For example when `useNamespace` is executed from a plugin embedded in app module (e.g. ui-plugin-find-order executing in ui-agreements) and `ignoreParents` is used it will only return `@folio/plugin-find-order` as a namespace.

The PR does not include `useGlobalNamespace` as it felt like we should handle it in a separate JIRA/issue.