### PR TITLE
STCOR-532 indicate that logging out of FOLIO will not end SSO session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Do not pass useless props to `<Dropdown>`. Refs STCOR-539.
 * Introduce `<ModuleHierarchyProvider>`. Refs STCOR-529.
 * Introduce `useNamespace` hook which returns module namespace. Refs STCOR-537.
+* Indicate that logging out of FOLIO will not affect an SSO session. Refs STCOR-532.
 
 ## [7.1.0](https://github.com/folio-org/stripes-core/tree/v7.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.0.0...v7.1.0)

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -158,6 +158,7 @@ class ProfileDropdown extends Component {
     const { stripes, onLogout } = this.props;
     const user = this.getUserData();
     const currentPerms = stripes.user ? stripes.user.perms : undefined;
+    const messageId = stripes.okapi.ssoEnabled ? 'stripes-core.logoutKeepSso': 'stripes-core.logout';
 
     /**
      * Show perms, locale etc.
@@ -213,7 +214,7 @@ class ProfileDropdown extends Component {
             }
             {this.userLinks}
             <NavListItem id="clickable-logout" type="button" onClick={onLogout}>
-              <FormattedMessage id="stripes-core.logout" />
+              <FormattedMessage id={messageId} />
             </NavListItem>
           </NavListSection>
         </NavList>

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -79,6 +79,7 @@
   "currentServicePoint": "Service point: {name}",
   "currentServicePointNotSelected": "Service point: None",
   "logout": "Log out",
+  "logoutKeepSso": "Log out from FOLIO, keep SSO session",
   "login": "Log in",
   "username": "Username",
   "password": "Password",

--- a/translations/stripes-core/en_US.json
+++ b/translations/stripes-core/en_US.json
@@ -41,6 +41,7 @@
     "about.pluginModuleCount": "{count, number} plugin {count, plural, one {module} other {modules}}",
     "loggedInAs": "Logged in as {firstName} {lastName}",
     "logout": "Log out",
+    "logoutKeepSso": "Log out from FOLIO, keep SSO session",
     "settings": "Settings",
     "folioSettings": "FOLIO settings",
     "loginViaSSO": "Login via SSO",


### PR DESCRIPTION
Removing FOLIO's auth token from the browser does not have any effect on
an SSO token that may remain cached in the browser. In order to make
this clear, the user/service-point menu now reads,
```
Log out from FOLIO, keep SSO session
```
when SSO is configured.

Refs [STCOR-532](https://issues.folio.org/browse/STCOR-532)