### PR TITLE
remove corrupt korean translation

### DIFF
--- a/translations/stripes-core/ko.json
+++ b/translations/stripes-core/ko.json
@@ -37,7 +37,7 @@
     "about.key.compatible": "호환되는 버전이 있는 인터페이스는 일반 글꼴로 표시됩니다.",
     "about.moduleTypeCount": "{count, number} {type} {count, plural, one {module} other {modules}}",
     "about.appModuleCount": "{count, number} app {count, plural, one {module} other {modules}}",
-    "about.settingsModuleCount": "{개수, 숫자} 설정 {개수, 복수, 하나의 {모듈} 기타 {모듈}}",
+    "about.settingsModuleCount": "{count, number} 설정 {count, plural, one { module } other { modules }}",
     "about.pluginModuleCount": "{count, number} plugin {count, plural, one {module} other {modules}}",
     "loggedInAs": "{firstName} {lastName} 로 로그인했습니다.",
     "logout": "로그아웃",


### PR DESCRIPTION
Most corrupt translation strings introduced in
a793957d5c78c6b23838963f3c02b598398abd01 were repaired in
02aada3871fccace74430c42681b98d555e10d88, but not all.