### PR TITLE
STCOR-549: Handle React is not defined in npm-folio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * Indicate that logging out of FOLIO will not affect an SSO session. Refs STCOR-532.
 * Introduce `withNamespace` HOC. Refs STCOR-542.
 * Pull user's locale settings from configurations on login, if available. Refs STCOR-527.
-* Able to close `<AppContextDropdown>` outside. Refs STCOR-543. 
+* Able to close `<AppContextDropdown>` outside. Refs STCOR-543.
+* Handle React is not defined in npm-folio. Refs STCOR-549.
 
 ## [7.1.1](https://github.com/folio-org/stripes-core/tree/v7.1.1) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.1.0...v7.1.1)

--- a/src/components/ModuleHierarchy/ModuleHierarchyProvider.js
+++ b/src/components/ModuleHierarchy/ModuleHierarchyProvider.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import ModuleHierarchyContext from './ModuleHierarchyContext';


### PR DESCRIPTION
## Purpose

Handle React is not defined in npm-folio in the scope of the [STCOR-549](https://issues.folio.org/browse/STCOR-549).