### PR TITLE
STCOR-551 configure karma for v6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * Indicate that logging out of FOLIO will not affect an SSO session. Refs STCOR-532.
 * Introduce `withNamespace` HOC. Refs STCOR-542.
 * Pull user's locale settings from configurations on login, if available. Refs STCOR-527.
-* Able to close `<AppContextDropdown>` outside. Refs STCOR-543. 
+* Able to close `<AppContextDropdown>` outside. Refs STCOR-543.
+* Update `@folio/stripes-cli` to `^2.3.0` and update `karma.conf.js` for `karma` `v6` compatibility. Refs STCOR-551.
 
 ## [7.1.1](https://github.com/folio-org/stripes-core/tree/v7.1.1) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.1.0...v7.1.1)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,15 +1,5 @@
 module.exports = (config) => {
-  const testIndex = './test/bigtest/index.js';
-
   const configuration = {
-    files: [
-      { pattern: testIndex, watched: false },
-    ],
-
-    preprocessors: {
-      [testIndex]: ['webpack']
-    },
-
     browserStack: {
       project: 'stripes-core'
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.2.0",
-    "@folio/stripes-cli": "^2.0.0",
+    "@folio/stripes-cli": "^2.3.0",
     "@folio/stripes-components": "^9.2.0",
     "@folio/stripes-connect": "^6.2.0",
     "@folio/stripes-logger": "^1.0.0",


### PR DESCRIPTION
There are some overlapping things going on here.

* `stripes-webpack` supports the new JSX transform that means we
  shouldn't have to `import React ...` any longer, but BigTest tests
fail without it when using `karma` `v4` (from `stripes-cli` `v1.2`).
* when using `karma` `v6` (from `stripes-cli` `v1.3`), the karma config
  directives `files` and `preprocessors` cause test files not be found
at all.

Bumping the `stripes-cli` dep (so we get `karma` `v6`) and cleaning up
`karma.config.js` (so it is `v6` compatible, and more aligned with
configs in other repos) allows tests to run as they always did. Phew.

Refs [STCOR-551](https://issues.folio.org/browse/STCOR-551)