### PR TITLE
STCOR-553 increase ProfileDropdown color contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 7.3.0 IN PROGRESS
+
+* Increase contrast for ProfileDropdown permissions display. Fixes STCOR-553.
+
 ## [7.2.0](https://github.com/folio-org/stripes-core/tree/v7.2.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.1.0...v7.2.0)
 

--- a/src/components/MainNav/MainNav.css
+++ b/src/components/MainNav/MainNav.css
@@ -22,6 +22,10 @@
   min-height: var(--main-nav-min-height-desktop);
   z-index: 99999;
   position: relative;
+
+  & li {
+    color: var(--color-text);
+  }
 }
 
 .nowrap {


### PR DESCRIPTION
White-on-white does not meet the 4.5:1 color contrast threshold
standard.

Fixes [STCOR-553](https://issues.folio.org/browse/STCOR-553)