### PR TITLE
STCOR-554 localize ProfileDropdown content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 7.3.0 IN PROGRESS
+
+* Localize ProfileDropdown text. Fixes STCOR-554.
+
 ## [7.2.0](https://github.com/folio-org/stripes-core/tree/v7.2.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.1.0...v7.2.0)
 

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -171,8 +171,8 @@ class ProfileDropdown extends Component {
           {
             intl => {
               const items = [
-                `Locale: ${intl.locale}`,
-                `Perms: ${Object.keys(currentPerms || {}).sort().join(', ')}`,
+                `${intl.formatMessage({ id: 'stripes-core.mainnav.profileDropdown.locale' })}: ${intl.locale}`,
+                `${intl.formatMessage({ id: 'stripes-core.mainnav.profileDropdown.permissions' })}: ${Object.keys(currentPerms || {}).sort().join(', ')}`,
               ];
 
               return (

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -101,6 +101,9 @@
   "mainnav.myProfileAriaLabel": "My profile",
   "mainnav.skipMainNavigation": "Skip Main Navigation",
 
+  "mainnav.profileDropdown.locale": "Locale",
+  "mainnav.profileDropdown.permissions": "Permissions",
+
   "errors.default.error": "Sorry, the information entered does not match our records.",
   "errors.username.incorrect": "This FOLIO account cannot be located. Please contact your FOLIO systems administrator.",
   "errors.password.incorrect": "Bad credentials",


### PR DESCRIPTION
Correctly localize ProfileDropdown elements.

Fixes [STCOR-554](https://issues.folio.org/browse/STCOR-554)