### PR TITLE
Fix React unique-key error

### DIFF
--- a/src/components/HandlerManager/HandlerManager.js
+++ b/src/components/HandlerManager/HandlerManager.js
@@ -26,8 +26,8 @@ class HandlerManager extends React.Component {
   render() {
     const { stripes, data, props } = this.props;
     return (this.components.map(Component => (
-      <ModuleHierarchyProvider module={Component.module.module}>
-        <Component key={Component.name} stripes={stripes} actAs="handler" data={data} {...props} />
+      <ModuleHierarchyProvider key={Component.name} module={Component.module.module}>
+        <Component stripes={stripes} actAs="handler" data={data} {...props} />
       </ModuleHierarchyProvider>
     )));
   }


### PR DESCRIPTION
Originally, the loop at the end was just

	this.components.map(Component => (
	  <Component key={Component.name} {...props} />
	)

But when the invocation of `<Component>` got wrapped in `<ModuleHierarchyProvider>` in commit bf282ea1, the `key` was left in the wrapped `<Component>`, so it no longer appeared directly inside the list generated by `map`.

This commit fixes this by moving the `key` up a level.