### PR TITLE
STCOR-555 list available numbering systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Localize ProfileDropdown text. Fixes STCOR-554.
 * Increase contrast for ProfileDropdown permissions display. Fixes STCOR-553.
+* Provide a list of available numbering formats. Fixes STCOR-555.
 
 ## [7.2.0](https://github.com/folio-org/stripes-core/tree/v7.2.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.1.0...v7.2.0)

--- a/index.js
+++ b/index.js
@@ -33,4 +33,5 @@ export {
 
 /* misc */
 export { supportedLocales } from './src/loginServices';
+export { supportedNumberingSystems } from './src/loginServices';
 export { userLocaleConfig } from './src/loginServices';

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -76,6 +76,13 @@ export const supportedLocales = [
   'ur',     // urdu
 ];
 
+// export supported numbering systems, i.e. the systems tenants may chose
+// for numeral display
+export const supportedNumberingSystems = [
+  'latn',  // Arabic (0 1 2 3 4 5 6 7 8 9)
+  'arab',  // Arabic-Hindi (٠ ١ ٢ ٣ ٤ ٥ ٦ ٧ ٨ ٩)
+];
+
 // export config values for storing user locale
 export const userLocaleConfig = {
   'configName': 'localeSettings',


### PR DESCRIPTION
Export a list of available numbering system so apps that allow for
providing a locale suffix (i.e. `-u-nu-NUMBERING_SYSTEM`) don't have to
duplicate the list locally.

Refs [STCOR-555](https://issues.folio.org/browse/STCOR-555), [FOLIO-3208](https://issues.folio.org/browse/FOLIO-3208)