### PR TITLE
STCOR-547 use constant value icons in AppContextDropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Provide a list of available numbering formats. Fixes STCOR-555.
 * Add 404 error screen for invalid url. Fixes STCOR-533.
 * Wait for SSO enabled status response before setting okapi ready. Fixes STCOR-557.
+* `AppContextDropdown` uses a constant value to retrieve its icon. Fixes STCOR-547.
 
 ## [7.2.0](https://github.com/folio-org/stripes-core/tree/v7.2.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.1.0...v7.2.0)

--- a/src/components/MainNav/CurrentApp/AppContextDropdown.js
+++ b/src/components/MainNav/CurrentApp/AppContextDropdown.js
@@ -24,7 +24,7 @@ class AppContextDropdown extends React.Component {
         data-test-context-menu-toggle-button
         ref={triggerRef}
         onClick={onToggle}
-        iconKey={selectedApp?.displayName.toLowerCase()}
+        iconKey={selectedApp?.module?.toLowerCase()}
         onKeyDown={keyHandler}
         open={open}
         label={


### PR DESCRIPTION
`AppContextDropdown` mistakenly used `displayName`, a value that is
passed through translation and therefore changes when the locale
changes, instead of `module`, which is constant.

Refs [STCOR-547](https://issues.folio.org/browse/STCOR-547)