### PR TITLE
STCOR-577 use correct css-loader syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 8.1 IN PROGRESS
+
+* Use correct `css-loader` syntax. STCOR-577.
+
 ## [8.0.0](https://github.com/folio-org/stripes-core/tree/v8.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.2.0...v8.0.0)
 

--- a/src/components/MainNav/NavButton/NavButton.css
+++ b/src/components/MainNav/NavButton/NavButton.css
@@ -9,7 +9,7 @@
 }
 
 .navButton {
-  composes: interactionStylesControl from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
+  composes: interactionStylesControl from "~@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
   padding: 0 var(--gutter-static-one-third);
   min-height: var(--main-nav-button-min-height);
   font-size: var(--main-nav-button-font-size);
@@ -35,7 +35,7 @@
 }
 
 .isInteractive {
-  composes: interactionStyles from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
+  composes: interactionStyles from "~@folio/stripes-components/lib/sharedStyles/interactionStyles.css";  /* stylelint-disable-line */
 }
 
 /* To make sure we overwrite default link colors */


### PR DESCRIPTION
Use the correct syntax when linking to styles in other packages.

Refs [STCOR-577](https://issues.folio.org/browse/STCOR-577), [STRIPES-770](https://issues.folio.org/browse/STRIPES-770)