### PR TITLE
bump minor to 8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",


### PR DESCRIPTION
New features should land on a new minor version since the last release
so that feature work and bug-fix work can be correctly separated.