### PR TITLE
avoid interactor destructuring

### DIFF
--- a/test/bigtest/tests/forgotPassword-test.js
+++ b/test/bigtest/tests/forgotPassword-test.js
@@ -20,7 +20,6 @@ describe('forgot password form test', () => {
   const {
     inputField,
     submitButton,
-    submitButton: { button },
     mainHeading,
     callToActionParagraph,
     errorsWrapper,
@@ -47,7 +46,7 @@ describe('forgot password form test', () => {
 
   describe('forgot form submit button tests', () => {
     it('should display a "Continue" button to submit a request', () => {
-      expect(button.isPresent).to.be.true;
+      expect(submitButton.isPresent).to.be.true;
     });
 
     it('should have a disabled "Continue" button by default', () => {

--- a/test/bigtest/tests/forgotUsername-test.js
+++ b/test/bigtest/tests/forgotUsername-test.js
@@ -20,7 +20,6 @@ describe('Forgot username form test', () => {
   const {
     inputField,
     submitButton,
-    submitButton: { button },
     mainHeading,
     callToActionParagraph,
     errorsWrapper,
@@ -48,7 +47,7 @@ describe('Forgot username form test', () => {
 
   describe('forgot form submit button tests', () => {
     it('should display a "Continue" button to submit a request', () => {
-      expect(button.isPresent).to.be.true;
+      expect(submitButton.isPresent).to.be.true;
     });
 
     it('should have a disabled "Continue" button by default', () => {


### PR DESCRIPTION
Tests on `#master` suddenly started failing. Yay!!! This PR addresses
the issue by removing the destructuring of the `SubmitButton`
interactor and tests that operated on the internals there in favor of
just interacting with `SubmitButton` itself. My best guess is that
something higher in the hierarchy of stripes-components interactors is
now causing a disabled button to return `false` for `isPresent` queries,
though this doesn't really hold water because there haven't been any
recent updates there in STCOM. But I have no other better explanation.

I am not thrilled with this PR for two reasons:
1. I don't know why the `SubmitButton` was destructured to begin with,
   so I am hesitant to undo it given it was probably done for a reason.
1. I don't know what changed in stripes-components (or elsewhere) that
   would have caused the `button` behavior to change.

OTOH, I am totally thrilled that this PR restores passing tests without
reducing test coverage. I guess this falls squarely into, "Wait, how did
this ever work?!?"