### PR TITLE
STCOR-582 Your password changed confirmation page > Continue to Login URL goes to an error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.1 IN PROGRESS
 
 * Use correct `css-loader` syntax. STCOR-577.
+* Your password changed confirmation page > Continue to Login URL goes to an error page. Fixes STCOR-582.
 
 ## [8.0.0](https://github.com/folio-org/stripes-core/tree/v8.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.2.0...v8.0.0)

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -1,7 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect as reduxConnect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import {
+  withRouter,
+  matchPath,
+} from 'react-router-dom';
 
 import { ConnectContext } from '@folio/stripes-connect';
 import {
@@ -23,17 +26,18 @@ class LoginCtrl extends Component {
     history: PropTypes.shape({
       push: PropTypes.func.isRequired,
     }).isRequired,
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired,
+    }).isRequired,
   };
 
   static contextType = ConnectContext;
 
   constructor(props) {
     super(props);
-    this.handleSubmit = this.handleSubmit.bind(this);
     this.sys = require('stripes-config'); // eslint-disable-line global-require
     this.okapiUrl = this.sys.okapi.url;
     this.tenant = this.sys.okapi.tenant;
-    this.handleSSOLogin = this.handleSSOLogin.bind(this);
     if (props.autoLogin && props.autoLogin.username) {
       this.handleSubmit(props.autoLogin);
     }
@@ -43,12 +47,18 @@ class LoginCtrl extends Component {
     this.props.clearAuthErrors();
   }
 
-  handleSubmit(data) {
-    return requestLogin(this.okapiUrl, this.context.store, this.tenant, data)
-      .then(() => this.props.history.push('/'));
+  handleSuccessfulLogin = () => {
+    if (matchPath(this.props.location.pathname, '/login')) {
+      this.props.history.push('/');
+    }
   }
 
-  handleSSOLogin() {
+  handleSubmit = (data) => {
+    return requestLogin(this.okapiUrl, this.context.store, this.tenant, data)
+      .then(this.handleSuccessfulLogin);
+  }
+
+  handleSSOLogin = () => {
     requestSSOLogin(this.okapiUrl, this.tenant);
   }
 

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect as reduxConnect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
 import { ConnectContext } from '@folio/stripes-connect';
 import {
@@ -19,6 +20,9 @@ class LoginCtrl extends Component {
       password: PropTypes.string.isRequired,
     }),
     clearAuthErrors: PropTypes.func.isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   static contextType = ConnectContext;
@@ -40,7 +44,8 @@ class LoginCtrl extends Component {
   }
 
   handleSubmit(data) {
-    return requestLogin(this.okapiUrl, this.context.store, this.tenant, data);
+    return requestLogin(this.okapiUrl, this.context.store, this.tenant, data)
+      .then(() => this.props.history.push('/'));
   }
 
   handleSSOLogin() {
@@ -69,4 +74,4 @@ const mapDispatchToProps = dispatch => ({
   clearAuthErrors: () => dispatch(setAuthError([])),
 });
 
-export default reduxConnect(mapStateToProps, mapDispatchToProps)(LoginCtrl);
+export default reduxConnect(mapStateToProps, mapDispatchToProps)(withRouter(LoginCtrl));

--- a/test/bigtest/tests/useCustomFields-test.js
+++ b/test/bigtest/tests/useCustomFields-test.js
@@ -12,6 +12,13 @@ const setupWithApp = (App, title) => setupApplication({
   disableAuth: false, // Can't skip login flow bc we need to fetch module info
   modules: [{
     type: 'app',
+    name: '@folio/ui-login',
+    displayName: 'login.title',
+    route: '/login',
+    hasSettings: false,
+    module: () => {},
+  }, {
+    type: 'app',
     name: '@folio/ui-dummy',
     displayName: 'dummy.title',
     route: '/dummy',
@@ -19,8 +26,8 @@ const setupWithApp = (App, title) => setupApplication({
     module: App,
   }],
   translations: {
-    'dummy.title': title
-  }
+    'dummy.title': title,
+  },
 });
 
 const createCustomFieldRenderer = (interfaceId, interfaceVersion) => (


### PR DESCRIPTION
## Description
Fix "404" error message when user changes password and logs in. This happens because after changing password user is redirected to `/login` route and after successful login they are not redirected. But `/login` route doesn't exist when a user is logged in.

## Issues
[STCOR-582](https://issues.folio.org/browse/STCOR-582)