### PR TITLE
STCOR-584 dependency cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use correct `css-loader` syntax. STCOR-577.
 * Your password changed confirmation page > Continue to Login URL goes to an error page. Fixes STCOR-582.
+* Dependency cleanup. Refs STCOR-584.
 
 ## [8.0.0](https://github.com/folio-org/stripes-core/tree/v8.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.2.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "classnames": "^2.2.5",
     "final-form": "^4.18.2",
     "graphql": "^0.11.7",
-    "handlebars": "^4.5.1",
     "history": "^4.6.3",
     "hoist-non-react-statics": "^3.3.0",
     "jwt-decode": "^2.2.0",
@@ -100,7 +99,8 @@
     "rimraf": "^2.5.4",
     "rtl-detect": "^1.0.2",
     "rxjs": "^6.6.3",
-    "swr": "^0.4.1"
+    "swr": "^0.4.1",
+    "use-deep-compare": "^1.1.0"
   },
   "peerDependencies": {
     "@folio/stripes-components": "^10.0.0",


### PR DESCRIPTION
When we split `stripes-core` from `stripes-webpack`, we moved some
things we shouldn't have and kept some things we didn't need.
* handlebars is a peer-dep of handlebars-loader but is not used here
* use-deep-compare is used in the error-boundary

Refs [STCOR-584](https://issues.folio.org/browse/STCOR-584)