### PR TITLE
STCOR-586: Apps > Settings > Move focus to Settings pane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 !test/webpack/node_modules/@folio/app2/node_modules/
 !test/webpack/node_modules/
 npm-debug.log
+package-lock.json
 static
 README.html
 OVERVIEW.html

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 !test/webpack/node_modules/@folio/app2/node_modules/
 !test/webpack/node_modules/
 npm-debug.log
-package-lock.json
 static
 README.html
 OVERVIEW.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Your password changed confirmation page > Continue to Login URL goes to an error page. Fixes STCOR-582.
 * Dependency cleanup. Refs STCOR-584.
 * Correct the invalid `PropTypes.stripes` prop-type. And use the alphabet.
+* Settings Focus change. Refs STRIPES-731.
 
 ## [8.0.0](https://github.com/folio-org/stripes-core/tree/v8.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v7.2.0...v8.0.0)

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -47,6 +47,7 @@ class Settings extends React.Component {
   constructor(props) {
     super(props);
 
+    this.paneTitleRef = createRef();
     const { stripes, modules } = props;
     const settingsModules = modules.settings || [];
 
@@ -75,8 +76,6 @@ class Settings extends React.Component {
       this.paneTitleRef.current.focus();
     }
   }
-
-  paneTitleRef = createRef();
 
   render() {
     const { stripes, location, intl: { formatMessage } } = this.props;

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,
@@ -70,6 +70,14 @@ class Settings extends React.Component {
       });
   }
 
+  componentDidMount() {
+    if (this.paneTitleRef.current) {
+      this.paneTitleRef.current.focus();
+    }
+  }
+
+  paneTitleRef = createRef();
+
   render() {
     const { stripes, location, intl: { formatMessage } } = this.props;
     const navLinks = this.connectedModules.map(({ module }) => {
@@ -121,6 +129,7 @@ class Settings extends React.Component {
         <Pane
           defaultWidth="20%"
           paneTitle={<FormattedMessage id="stripes-core.settings" />}
+          paneTitleRef={this.paneTitleRef}
         >
           <NavList aria-label={formatMessage({ id: 'stripes-core.settings' })}>
             <NavListSection


### PR DESCRIPTION
## Purpose
- If a user selects `Settings` from the `Apps` drop-down then move focus to the `Settings` pane.

## Approach
- Add `paneTitleRef` prop to `Pane` component to manage focus automatically.

## Refs
- https://issues.folio.org/browse/STRIPES-731

Replaces #1157