### PR TITLE
STCOR-587 Apply h3 tag for System Information

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -134,6 +134,7 @@ class Settings extends React.Component {
           <NavList aria-label={formatMessage({ id: 'stripes-core.settingSystemInfo' })}>
             <NavListSection
               label={formatMessage({ id: 'stripes-core.settingSystemInfo' })}
+              tag="h3"
               activeLink={activeLink}
               className={css.navListSection}
             >


### PR DESCRIPTION
* Apply heading level (H3) to each second pane Settings > Users section header
* Apply a heading level (H3) to the System Information section header
* Remove the H3 heading from the second pane Settings > Users section header. It appears a H2 heading is already applied.

Ref: https://issues.folio.org/browse/UIU-2037

Replaces #1159