### PR TITLE
STCOR-588 prune ancient and unnecessary react-intl polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,9 +68,6 @@
   },
   "dependencies": {
     "@apollo/client": "^3.2.1",
-    "@formatjs/intl-displaynames": "^2.2.3",
-    "@formatjs/intl-pluralrules": "^2.2.1",
-    "@formatjs/intl-relativetimeformat": "^5.2.3",
     "classnames": "^2.2.5",
     "final-form": "^4.18.2",
     "graphql": "^0.11.7",

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -4,26 +4,6 @@ import { translations } from 'stripes-config';
 import rtlDetect from 'rtl-detect';
 import moment from 'moment';
 
-// polyfills for browsers without full Intl.* support. We include only the
-// polyfill and en data, since that's all we need to keep NightmareJS and
-// its Electron tests happy; adding all the locale data would bloat the bundle
-// from <10 MB to >40 MB. The en data only adds ~470 KB.
-
-import '@formatjs/intl-pluralrules/polyfill';
-import '@formatjs/intl-pluralrules/dist/locale-data/en';
-// import '@formatjs/intl-pluralrules/polyfill-locales;
-// 0.62 MB stat; 0.43 MB parsed; 0.048 MB GZipped
-
-import '@formatjs/intl-relativetimeformat/polyfill';
-import '@formatjs/intl-relativetimeformat/dist/locale-data/en';
-// import '@formatjs/intl-relativetimeformat/polyfill-locales;
-// 2.3MB stat; 1.8 MB parsed; 0.8 MB GZipped
-
-import '@formatjs/intl-displaynames/polyfill';
-import '@formatjs/intl-displaynames/dist/locale-data/en';
-// import '@formatjs/intl-displaynames/polyfill-locales;
-// 13.7 MB stat; 10.7 MB parsed; 1.9 MB GZipped
-
 import { discoverServices } from './discoverServices';
 
 import {


### PR DESCRIPTION
Long ago (#876) we added a bunch of polyfills to stripes-core because
react-intl stopped including them and our e2e tests need them. But those
e2e tests are gone, baby, gone, so there is no reason to balloon our
bundle with a bunch of cruft that no contemporary browser requires.
(RelativeTimeFormat has been in Chrome since 2018 and Safari since 2020; 
PluralRules since 2017 and 2019 respectively, and DisplayNames since 2020 
and early 2021 respectively.)

h/t @skomorokh for noticing this disk pollution.

Refs [STCOR-588](https://issues.folio.org/browse/STCOR-588)