### PR TITLE
test cleanup

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -67,12 +67,12 @@ jobs:
         run: yarn lint
         continue-on-error: true
 
-      - name: Run yarn test
-        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
-
       - name: Run yarn formatjs-compile
         if : ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}
         run: yarn formatjs-compile
+
+      - name: Run yarn test
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
 
       - name: Generate FOLIO module descriptor
         if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
@@ -165,7 +165,7 @@ jobs:
 
       - name: Exclude some CI-generated artifacts in package
         if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
-        run: | 
+        run: |
           echo ".github" >> .npmignore
           echo ".scannerwork" >> .npmignore
           cat .npmignore

--- a/src/components/About/WarningBanner.js
+++ b/src/components/About/WarningBanner.js
@@ -46,7 +46,7 @@ const WarningBanner = ({
     <div className={css.warningContainer}>
       <MessageBanner
         type="warning"
-        show={missingModulesCount}
+        show={!!missingModulesCount}
         dismissable
       >
         <Headline>{missingModulesMsg}</Headline>
@@ -58,7 +58,7 @@ const WarningBanner = ({
 
       <MessageBanner
         type="warning"
-        show={incompatibleModulesCount}
+        show={!!incompatibleModulesCount}
         dismissable
       >
         <Headline>{incompatibleModuleMsg}</Headline>

--- a/src/components/AppIcon/tests/appIcon-test.js
+++ b/src/components/AppIcon/tests/appIcon-test.js
@@ -121,7 +121,7 @@ describe('AppIcon', () => {
     });
   });
 
-  Object.keys(iconSizes).forEach(size => {
+  const sizeTest = async (size) => {
     describe(`Passing a size of "${size}"`, async () => {
       beforeEach(async () => {
         await mount(
@@ -138,5 +138,9 @@ describe('AppIcon', () => {
         expect(appIcon.img.offsetHeight).to.equal(iconSizes[size]);
       });
     });
-  });
+  };
+
+  sizeTest('small');
+  sizeTest('medium');
+  sizeTest('large');
 });

--- a/src/components/AppIcon/tests/appIcon-test.js
+++ b/src/components/AppIcon/tests/appIcon-test.js
@@ -121,9 +121,8 @@ describe('AppIcon', () => {
     });
   });
 
-
   Object.keys(iconSizes).forEach(size => {
-    describe(`Passing a size of "${size}"`, () => {
+    describe(`Passing a size of "${size}"`, async () => {
       beforeEach(async () => {
         await mount(
           <AppIcon

--- a/src/components/CreateResetPassword/CreateResetPassword.js
+++ b/src/components/CreateResetPassword/CreateResetPassword.js
@@ -36,9 +36,6 @@ class CreateResetPassword extends Component {
     onPasswordInputFocus: PropTypes.func.isRequired,
     submitting: PropTypes.bool,
     submitIsFailed: PropTypes.bool,
-    form: PropTypes.shape({
-      getState: PropTypes.func.isRequired,
-    }).isRequired,
   };
 
   static defaultProps = {

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -43,6 +43,7 @@ class CreateResetPasswordControl extends Component {
   }
 
   async componentDidMount() {
+    this._isMounted = true;
     await this.makeCall();
 
     this.setState({ isLoading: false });
@@ -50,6 +51,7 @@ class CreateResetPasswordControl extends Component {
 
   componentWillUnmount() {
     this.props.clearAuthErrors();
+    this._isMounted = false;
   }
 
   handleResponse = (response) => {
@@ -83,7 +85,7 @@ class CreateResetPasswordControl extends Component {
     }
   };
 
-  makeCall = async (body) => {
+  makeCall = (body) => {
     const {
       stripes: {
         okapi: {
@@ -102,21 +104,23 @@ class CreateResetPasswordControl extends Component {
 
     const path = `${url}/bl-users/password-reset/${isValidToken ? 'reset' : 'validate'}`;
 
-    try {
-      const response = await fetch(path, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-okapi-token': token,
-          'x-okapi-tenant': tenant,
-        },
-        ...(body && { body: JSON.stringify(body) }),
+    fetch(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-okapi-token': token,
+        'x-okapi-tenant': tenant,
+      },
+      ...(body && { body: JSON.stringify(body) }),
+    })
+      .then((response) => {
+        if (this._isMounted) {
+          this.handleResponse(response);
+        }
+      })
+      .catch(error => {
+        handleBadResponse(error);
       });
-
-      this.handleResponse(response);
-    } catch (error) {
-      handleBadResponse(error);
-    }
   };
 
   handleSubmit = async (values) => {

--- a/src/components/CreateResetPassword/components/PasswordHasNotChanged/PasswordHasNotChanged.js
+++ b/src/components/CreateResetPassword/components/PasswordHasNotChanged/PasswordHasNotChanged.js
@@ -55,7 +55,6 @@ class PasswordHasNotChanged extends Component {
           <Headline
             size="x-large"
             tag="p"
-            bold={false}
             faded
             data-test-message
           >

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -40,7 +40,7 @@ export default function configure() {
   this.get('/bl-users/_self', {});
   this.post('/bl-users/password-reset/validate', () => {
     return new Response(204, {}, '');
-  }, 204);
+  });
   this.post('/bl-users/password-reset/reset', {}, 401);
 
 

--- a/test/bigtest/network/scenarios/changePasswordSuccess.js
+++ b/test/bigtest/network/scenarios/changePasswordSuccess.js
@@ -1,3 +1,18 @@
+// the CORRECT implementation of this response is:
+//
+// export default (server) => {
+//   server.post('/bl-users/password-reset/reset', () => {
+//     return new Response(204, {}, '');
+//   });
+// };
+//
+// but for reasons unclear this results in a 201 instead of a 204.
+// for other responses, e.g. forgotUsernameSuccess, a 204 is returned.
+// without the additional 204, createResetPassword-test will fail.
+// there's gotta be a config glitch somewhere, but I have not been
+// able to find it. so SO frustrating.
+//
+
 export default (server) => {
   server.post('/bl-users/password-reset/reset', () => {
     return new Response(204, {}, '');

--- a/test/bigtest/network/scenarios/forgotUsernameSuccess.js
+++ b/test/bigtest/network/scenarios/forgotUsernameSuccess.js
@@ -1,5 +1,5 @@
 export default (server) => {
   server.post('bl-users/forgotten/username', () => {
     return new Response(204, {}, '');
-  }, 204);
+  });
 };

--- a/test/bigtest/tests/useCustomFields-test.js
+++ b/test/bigtest/tests/useCustomFields-test.js
@@ -27,6 +27,7 @@ const setupWithApp = (App, title) => setupApplication({
   }],
   translations: {
     'dummy.title': title,
+    'login.title': 'login title',
   },
 });
 


### PR DESCRIPTION
* provide missing translation to avoid console pollution
* await promises in loops. otherwise, iteration will will proceed
  asynchronously and check the icon sizes incorrectly, I think.
* clean some 204 responses
* do not set deprecated props on `Headline`
* avoid `setState` in then blocks if component is unmounted
* compile translations _before_ running test to avoid console noise