### PR TITLE
STCOR-590 align prop-types for password reset errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 8.2.0 IN PROGRESS
+
+* Align prop-types related to password reset errors. Refs STCOR-590.
+
 ## [8.1.0](https://github.com/folio-org/stripes-core/tree/v8.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.0.0...v8.1.0)
 

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -188,7 +188,7 @@ const mapStateToProps = state => ({ authFailure: state.okapi.authFailure });
 const mapDispatchToProps = dispatch => ({
   handleBadResponse: error => processBadResponse(dispatch, error),
   clearAuthErrors: () => dispatch(setAuthError([])),
-  setDefaultAuthError: error => dispatch(setAuthError(error)),
+  setDefaultAuthError: error => dispatch(setAuthError([error])),
 });
 
 export default withRouter(reduxConnect(mapStateToProps, mapDispatchToProps)(CreateResetPasswordControl));

--- a/src/components/CreateResetPassword/components/PasswordHasNotChanged/PasswordHasNotChanged.js
+++ b/src/components/CreateResetPassword/components/PasswordHasNotChanged/PasswordHasNotChanged.js
@@ -15,7 +15,7 @@ import styles from './PasswordHasNotChanged.css';
 
 class PasswordHasNotChanged extends Component {
   static propTypes = {
-    errors: PropTypes.arrayOf(PropTypes.string),
+    errors: PropTypes.arrayOf(PropTypes.object),
   };
 
   static defaultProps = {
@@ -26,10 +26,12 @@ class PasswordHasNotChanged extends Component {
     const { errors } = this.props;
     const labelNamespace = 'stripes-core.errors';
 
-    const isExpiredLink = includes(errors, changePasswordErrorCodes.EXPIRED_ERROR_CODE);
-    const isUsedLink = includes(errors, changePasswordErrorCodes.USED_ERROR_CODE);
+    const errorCodes = errors.map((e) => e?.code);
+
+    const isExpiredLink = includes(errorCodes, changePasswordErrorCodes.EXPIRED_ERROR_CODE);
+    const isUsedLink = includes(errorCodes, changePasswordErrorCodes.USED_ERROR_CODE);
     const isOutdatedLink = isExpiredLink || isUsedLink;
-    const isInvalidLink = includes(errors, changePasswordErrorCodes.INVALID_ERROR_CODE) && !isOutdatedLink;
+    const isInvalidLink = includes(errorCodes, changePasswordErrorCodes.INVALID_ERROR_CODE) && !isOutdatedLink;
 
     if (isInvalidLink) {
       return `${labelNamespace}.${changePasswordErrorCodes.INVALID_ERROR_CODE}`;


### PR DESCRIPTION
There was general disagreement about the expected prop-types for errors
related to password reset. Generally, more things seem to expect an
array than an object, leading me to think the handling of the one-error
case, where the error is directly dispatched, was just a mistake. At
least, converting that one case resolved a litany of errors, and then
the only downstream change was fixing its message display, which, come
to think of it, was probably already broken and we just never noticed
and always accepted the default error message.

Refs [STCOR-590](https://issues.folio.org/browse/STCOR-590)