### PR TITLE
STCOR-597 remove react-hot-loader cruft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.2.0 IN PROGRESS
 
 * Align prop-types related to password reset errors. Refs STCOR-590.
+* Remove `react-hot-loader` cruft. Refs STCOR-597, STRIPES-725.
 
 ## [8.1.0](https://github.com/folio-org/stripes-core/tree/v8.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.0.0...v8.1.0)

--- a/src/components/Root/index.js
+++ b/src/components/Root/index.js
@@ -1,4 +1,1 @@
-import { hot } from 'react-hot-loader';
-import Root from './Root';
-
-export default hot(module)(Root);
+export { default } from './Root';


### PR DESCRIPTION
Whooops, it wasn't even a dev-dep but we still had it in our source.
It's no longer necessary in any case since react-refresh is totally
self-contained within stripes-webpack.

Refs [STCOR-597](https://issues.folio.org/browse/STCOR-597), [STRIPES-725](https://issues.folio.org/browse/STRIPES-725)