### PR TITLE
Revert "Update ky"

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "history": "^4.6.3",
     "hoist-non-react-statics": "^3.3.0",
     "jwt-decode": "^2.2.0",
-    "ky": "^0.30.0",
+    "ky": "^0.23.0",
     "localforage": "^1.5.6",
     "lodash": "^4.17.21",
     "miragejs": "^0.1.32",


### PR DESCRIPTION
Reverts folio-org/stripes-core#1171

@BogdanDenis noted the following: 
```
Configuration error:

    Could not locate module ky mapped as:
    ky/umd.

    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/ky/": "ky/umd"
      },
      "resolver": undefined
    }
```