### PR TITLE
Revert "STCOR-619 Add message user cannot access app"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 * Display different message when user attempts to access the set password link when still logged in. Refs STCOR-599.
 * Import stripes-components via its public exports. Refs STCOR-612.
 * Support testing with Jest/RTL. Refs STCOR-618.
-* Add message to indicate user cannot access app/record. Refs STCOR-619.
 
 ## [8.1.0](https://github.com/folio-org/stripes-core/tree/v8.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.0.0...v8.1.0)

--- a/src/moduleRoutes.js
+++ b/src/moduleRoutes.js
@@ -2,7 +2,6 @@ import React, { Suspense } from 'react';
 import { Route } from 'react-router-dom';
 import { useLocation } from 'react-router';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 
 import { connectFor } from '@folio/stripes-connect';
 import { LoadingView } from '@folio/stripes-components';
@@ -67,14 +66,7 @@ function ModuleRoutes({ stripes }) {
               const name = module.module.replace(packageName.PACKAGE_SCOPE_REGEX, '');
               const displayName = module.displayName;
               const perm = `module.${name}.enabled`;
-              if (!stripes.hasPerm(perm)) {
-                return (
-                  <FormattedMessage
-                    id="stripes-core.front.error.noPermission"
-                    tagName="h2"
-                  />
-                );
-              }
+              if (!stripes.hasPerm(perm)) return null;
 
               const connect = connectFor(module.module, stripes.epics, stripes.logger);
 

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -16,7 +16,6 @@
   "front.about": "Software versions",
   "front.error.header": "404 Error",
   "front.error.general.message": "The requested URL {br}{url}{br} was not found on this server.",
-  "front.error.noPermission": "You don't have permission to view this app/record",
   "front.error.setPassword.message": "Please log out of your current FOLIO session to set password. Once logged out please try to set your password with this link again.",
   "button.new": "+ New",
   "button.new_tooltip": "Add {entry}",


### PR DESCRIPTION
Reverts folio-org/stripes-core#1190
to avoid the list of messages for each no permission app.
<img width="1679" alt="Screenshot 2022-05-05 at 16 13 12" src="https://user-images.githubusercontent.com/43407139/166930700-687cfd68-d8df-427e-bfa9-8f0099e636c0.png">
 