### PR TITLE
STCOR-629 provide @bigtest/mirage dev-dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Support testing with Jest/RTL. Refs STCOR-618.
 * Export `queryLimit` to provide a default API query limit. Refs STCOR-615.
 * Update NodeJS to v16 in GitHub Actions. Refs STCOR-623.
+* Add `@bigtest/miragejs` dev-dep since tests rely on it. Refs STCOR-629.
 
 ## [8.1.0](https://github.com/folio-org/stripes-core/tree/v8.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.0.0...v8.1.0)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/eslint-parser": "^7.15.0",
     "@bigtest/convergence": "^0.10.0",
     "@bigtest/interactor": "^0.7.2",
+    "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^6.0.0",


### PR DESCRIPTION
[Tests use it](https://github.com/folio-org/stripes-core/blob/be772d924fca97e2189e954a1c9075c629b6f645/test/bigtest/network/start.js#L24), so we gotta provide it. This was probably erroneously
moved into stripes-webpack, where [it isn't used and was finally removed](https://github.com/folio-org/stripes-webpack/pull/61),
which surfaced the fact that it was missing here.

Refs [STCOR-629](https://issues.folio.org/browse/STCOR-629)