### PR TITLE
STCOR-635 wrap pluggable in suspense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Update NodeJS to v16 in GitHub Actions. Refs STCOR-623.
 * Provide `useCallout` hook. Refs STCOR-631.
 * Add message to indicate user cannot access app/record. Refs STCOR-619.
+* Wrapp `<Pluggable>` in `<Suspense>` to avoid whole-tree re-render. Refs STCOR-635.
 
 ## [8.1.0](https://github.com/folio-org/stripes-core/tree/v8.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.0.0...v8.1.0)

--- a/src/Pluggable.js
+++ b/src/Pluggable.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { modules } from 'stripes-config';
 import { withStripes } from './StripesContext';
-import { ModuleHierarchyProvider } from './components';
+import { LoadingView, ModuleHierarchyProvider } from './components';
 
 const Pluggable = (props) => {
   const plugins = modules.plugin || [];
@@ -37,7 +37,9 @@ const Pluggable = (props) => {
   if (cachedPlugins.length) {
     return cachedPlugins.map(({ plugin, Child }) => (
       <ModuleHierarchyProvider module={plugin}>
-        <Child {...props} actAs="plugin" />
+        <Suspense fallback={<LoadingView />}>
+          <Child {...props} actAs="plugin" />
+        </Suspense>
       </ModuleHierarchyProvider>
     ));
   }
@@ -47,7 +49,11 @@ const Pluggable = (props) => {
     // eslint-disable-next-line no-console
     console.error(`<Pluggable type="${props.type}"> has ${props.children.length} children, can only return one`);
   }
-  return props.children;
+  return (
+    <Suspense fallback={<LoadingView />}>
+      {props.children}
+    </Suspense>
+  );
 };
 
 Pluggable.propTypes = {


### PR DESCRIPTION
Wrap Pluggable's return value in Suspense in order to avoid whole-tree
re-renders, since the whole tree from the components up to the nearest
`<Suspense>` is removed and replaced with its fallback. For us, this is
particularly a problem when a plugin is part of a dropdown menu that
uses calculations to set its position. Because the entire tree will be
unmounted, the calculations all return zero, resulting in incorrect
placement with zero offset from the let margin ([STRWEB-53](https://issues.folio.org/browse/STRWEB-53)).

h/t @bogdandenis and @mkuklis for figuring this all out.

Refs [STCOR-635](https://issues.folio.org/browse/STCOR-635)