### PR TITLE
STCOR-638 record detail panes are empty when print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add message to indicate user cannot access app/record. Refs STCOR-619.
 * Clear console on logout. Refs STCOR-636.
 * Forgot username/password pages - Not responsive. Refs STCOR-630.
+* Record detail panes are empty when printed. Refs STCOR-638.
 
 ## [8.1.0](https://github.com/folio-org/stripes-core/tree/v8.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.0.0...v8.1.0)

--- a/src/components/ModuleContainer/ModuleContainer.css
+++ b/src/components/ModuleContainer/ModuleContainer.css
@@ -5,4 +5,8 @@
   flex: 1 1 auto;
   overflow-y: auto;
   height: 100%;
+
+  @media print {
+    overflow-y: visible;
+  }
 }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOR-638

This PR relates to [#1835](https://github.com/folio-org/stripes-components/pull/1835) and makes it possible to support pane content printing. (See PR [#1835](https://github.com/folio-org/stripes-components/pull/1835) to more details)