### PR TITLE
STCOR-640: Add `button.duplicate` translation key

### DIFF
--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -22,6 +22,7 @@
   "button.new": "+ New",
   "button.new_tooltip": "Add {entry}",
   "button.edit": "Edit",
+  "button.duplicate": "Duplicate",
   "button.delete": "Delete",
   "button.deleteEntry": "Delete {entry}",
   "button.saveAndClose": "Save and close",

--- a/translations/stripes-core/fr.json
+++ b/translations/stripes-core/fr.json
@@ -5,6 +5,7 @@
     "button.new": "+ New",
     "button.new_tooltip": "Add {entry}",
     "button.edit": "Edit",
+    "button.duplicate": "Dupliquer",
     "button.delete": "Delete",
     "button.deleteEntry": "Delete {entry}",
     "button.saveAndClose": "Save and close",

--- a/translations/stripes-core/fr_FR.json
+++ b/translations/stripes-core/fr_FR.json
@@ -5,6 +5,7 @@
     "button.new": "Nouveau",
     "button.new_tooltip": "Ajouter {entry}",
     "button.edit": "Modifier",
+    "button.duplicate": "Dupliquer",
     "button.delete": "Supprimer",
     "button.deleteEntry": "Supprimer {entry}",
     "button.saveAndClose": "Sauvegarder et fermer",


### PR DESCRIPTION
# [Jira](https://issues.folio.org/projects/STCOR/issues/STCOR-640)

This is consistent with the UX pattern, as described [here](https://ux.folio.org/docs/guidelines/ux-patterns/duplicate-a-record/).  Adds a centralized duplicate button key to prevent modules having to provide separate translations for this common use. 



_Je parle un peu français_, so I added translations for fr and fr_FR.