### PR TITLE
STCOR-643 allow customization of login CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.3.0 IN PROGRESS
 
 * Use documenation's root URL in NavBar `?` link. Refs STCOR-621.
+* Allow customization of login page's CSS. Refs STCOR-643.
 
 ## [8.2.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.1.0...v8.2.0)

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field, Form } from 'react-final-form';
 
+import { branding } from 'stripes-config';
+
 import {
   TextField,
   Button,
@@ -11,7 +13,6 @@ import {
   Headline,
 } from '@folio/stripes-components';
 
-import { withStripes } from '../../StripesContext';
 import SSOLogin from '../SSOLogin';
 import OrganizationLogo from '../OrganizationLogo';
 import AuthErrorsContainer from '../AuthErrorsContainer';
@@ -25,7 +26,6 @@ class Login extends Component {
     authErrors: PropTypes.arrayOf(PropTypes.object),
     onSubmit: PropTypes.func.isRequired,
     handleSSOLogin: PropTypes.func.isRequired,
-    stripes: PropTypes.object,
   };
 
   static defaultProps = {
@@ -39,7 +39,6 @@ class Login extends Component {
       handleSSOLogin,
       ssoActive,
       onSubmit,
-      stripes,
     } = this.props;
 
     return (
@@ -53,7 +52,7 @@ class Login extends Component {
           const buttonLabel = submissionStatus ? 'loggingIn' : 'login';
           return (
             <main>
-              <div className={styles.wrapper} style={stripes.config.style?.login ?? {}}>
+              <div className={styles.wrapper} style={branding.style?.login ?? {}}>
                 <div className={styles.container}>
                   <Row center="xs">
                     <Col xs={6}>
@@ -222,4 +221,4 @@ class Login extends Component {
   }
 }
 
-export default withStripes(Login);
+export default Login;

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -11,6 +11,7 @@ import {
   Headline,
 } from '@folio/stripes-components';
 
+import { withStripes } from '../../StripesContext';
 import SSOLogin from '../SSOLogin';
 import OrganizationLogo from '../OrganizationLogo';
 import AuthErrorsContainer from '../AuthErrorsContainer';
@@ -24,6 +25,7 @@ class Login extends Component {
     authErrors: PropTypes.arrayOf(PropTypes.object),
     onSubmit: PropTypes.func.isRequired,
     handleSSOLogin: PropTypes.func.isRequired,
+    stripes: PropTypes.object,
   };
 
   static defaultProps = {
@@ -36,7 +38,8 @@ class Login extends Component {
       authErrors,
       handleSSOLogin,
       ssoActive,
-      onSubmit
+      onSubmit,
+      stripes,
     } = this.props;
 
     return (
@@ -50,7 +53,7 @@ class Login extends Component {
           const buttonLabel = submissionStatus ? 'loggingIn' : 'login';
           return (
             <main>
-              <div className={styles.wrapper}>
+              <div className={styles.wrapper} style={stripes.config.style?.login ?? {}}>
                 <div className={styles.container}>
                   <Row center="xs">
                     <Col xs={6}>
@@ -219,4 +222,4 @@ class Login extends Component {
   }
 }
 
-export default Login;
+export default withStripes(Login);


### PR DESCRIPTION
Allow the `<Login>` component's wrapper-div to be customized via CSS attributes
provided in `stripes.config.js` via `branding.style.login`. e.g.:
```
  branding: {
    logo: { ... },
    favicon: { ... },
    style: {
      login: {
        backgroundColor: "#fcb"
      },
      ...
```

Refs [STCOR-643](https://issues.folio.org/browse/STCOR-643)