### PR TITLE
STCOR-644 allow customization of mainnav CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.3.0 IN PROGRESS
 
 * Use documenation's root URL in NavBar `?` link. Refs STCOR-621.
+* Allow customization of navbar CSS. Refs STCOR-644.
 
 ## [8.2.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.1.0...v8.2.0)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -6,6 +6,8 @@ import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router';
 import localforage from 'localforage';
 
+import { branding } from 'stripes-config';
+
 import { Icon } from '@folio/stripes-components';
 
 import { withModules } from '../Modules';
@@ -40,7 +42,6 @@ class MainNav extends Component {
       config: PropTypes.shape({
         showPerms: PropTypes.bool,
         helpUrl: PropTypes.string,
-        style: PropTypes.object,
       }),
       store: PropTypes.shape({
         dispatch: PropTypes.func.isRequired,
@@ -203,7 +204,7 @@ class MainNav extends Component {
           const helpUrl = stripes.config.helpUrl ?? 'https://docs.folio.org';
 
           return (
-            <header className={css.navRoot} style={stripes.config.style?.navBar ?? {}}>
+            <header className={css.navRoot} style={branding.style?.mainNav ?? {}}>
               <div className={css.startSection}>
                 <SkipLink />
                 <CurrentAppGroup selectedApp={selectedApp} config={stripes.config} />

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -40,6 +40,7 @@ class MainNav extends Component {
       config: PropTypes.shape({
         showPerms: PropTypes.bool,
         helpUrl: PropTypes.string,
+        style: PropTypes.object,
       }),
       store: PropTypes.shape({
         dispatch: PropTypes.func.isRequired,
@@ -202,7 +203,7 @@ class MainNav extends Component {
           const helpUrl = stripes.config.helpUrl ?? 'https://docs.folio.org';
 
           return (
-            <header className={css.navRoot}>
+            <header className={css.navRoot} style={stripes.config.style?.navBar ?? {}}>
               <div className={css.startSection}>
                 <SkipLink />
                 <CurrentAppGroup selectedApp={selectedApp} config={stripes.config} />


### PR DESCRIPTION
Allow customization of the navigation bar's CSS via values provided in
`stripes.config.js` in `branding.style.mainNav`. e.g.
```
  okapi: { 'url':'http://localhost:9130', 'tenant':'diku' },
  config: {
    style: {
      mainNav: {
        backgroundColor: "#036",
       }
    },
```

Refs [STCOR-644](https://issues.folio.org/browse/STCOR-644)