### PR TITLE
STCOR-603 show supplemental data on the /settings/about page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.3.0 IN PROGRESS
 
 * Use documenation's root URL in NavBar `?` link. Refs STCOR-621.
+* Optionally display Okapi env, mod-configuration, or stripes.config values on about page. Refs STCOR-603.
 
 ## [8.2.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.1.0...v8.2.0)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,28 +1,32 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const path = require('path');
 
-const esModules = ['@folio', 'ky'].join('|');
+const esModules = ['@folio'].join('|');
 
 module.exports = {
   collectCoverageFrom: [
     '**/(lib|src)/**/*.{js,jsx}',
     '!**/node_modules/**',
-    '!**/test/jest/**',
+    '!**/test/**',
   ],
   coverageDirectory: './artifacts/coverage-jest/',
   coverageReporters: ['lcov'],
   reporters: ['jest-junit', 'default'],
-  transform: { '^.+\\.(js|jsx)$': path.join(__dirname, './test/jest/jest-transformer.js') },
+  transform: {
+    '^.+\\.(js|jsx)$': path.join(__dirname, './test/jest/jest-transformer.js'),
+  },
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
   moduleNameMapper: {
     '^.+\\.(css)$': 'identity-obj-proxy',
     '^.+\\.(svg)$': 'identity-obj-proxy',
+    'ky': 'ky/umd',
   },
+  testEnvironment: 'jsdom',
   testMatch: ['**/(lib|src)/**/?(*.)test.{js,jsx}'],
-  testPathIgnorePatterns: ['/node_modules/', '/test/bigtest/', '/test/ui-testing/'],
-  setupFiles: [
-    path.join(__dirname, './test/jest/setupTests.js'),
-    'jest-canvas-mock'
-  ],
+  testPathIgnorePatterns: ['/node_modules/', '/test/ui-testing/', '/test/bigtest/'],
+  setupFiles: [path.join(__dirname, './test/jest/setupTests.js')],
   setupFilesAfterEnv: [path.join(__dirname, './test/jest/jest.setup.js')],
+
+  roots: ['<rootDir>', './src'],
+  modulePaths: ['<rootDir>', './src'],
 };

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/stripes-core ./translations/stripes-core/compiled",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json"
   },
-  "engines": {
-    "node": ">=10.0.0"
-  },
   "stripes": {
     "okapiInterfaces": {
       "users-bl": "5.0 6.0",
@@ -59,13 +56,17 @@
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.1.1",
     "babel-jest": "^28.0.1",
     "babel-plugin-module-resolver": "^4.1.0",
     "chai": "^4.1.2",
     "eslint": "^7.32.0",
+    "eslint-plugin-jest-dom": "^4.0.2",
+    "eslint-plugin-testing-library": "^5.6.0",
     "jest": "^28.0.1",
     "jest-canvas-mock": "^2.3.1",
+    "jest-environment-jsdom": "^28.1.3",
     "jest-junit": "^13.2.0",
     "moment": "^2.29.0",
     "react": "^17.0.2",

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -13,9 +13,9 @@ import {
   Loading,
 } from '@folio/stripes-components';
 import AboutEnabledModules from './AboutEnabledModules';
+import AboutInstallMessages from './AboutInstallMessages';
 import WarningBanner from './WarningBanner';
 import { withModules } from '../Modules';
-
 import stripesCore from '../../../package';
 import css from './About.css';
 
@@ -113,6 +113,7 @@ const About = (props) => {
           modules={props.modules}
         />
       )}
+      <AboutInstallMessages stripes={props.stripes} />
       <div className={css.versionsContainer}>
         <div className={css.versionsColumn}>
           <Headline size="large">
@@ -219,6 +220,7 @@ About.propTypes = {
       interfaces: PropTypes.object,
     }),
     connect: PropTypes.func,
+    hasPerm: PropTypes.func.isRequired,
   }).isRequired,
 };
 

--- a/src/components/About/AboutInstallMessages.js
+++ b/src/components/About/AboutInstallMessages.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedDate } from 'react-intl';
+
+import {
+  Headline,
+} from '@folio/stripes-components';
+import {
+  useConfigurations,
+  useOkapiEnv,
+} from '../../queries';
+
+
+export function entryFor(config, code) {
+  const entry = config?.configs?.find(i => i.code === code);
+  return entry ? entry.value : '';
+}
+
+/**
+ * installVersion
+ * Search environment, the mod-configuration, then stripes.config.js
+ * for installed-version and installed-date information. Return them,
+ * or an empty element.
+ *
+ * @param {object} env
+ * @param {object} conf
+ * @param {object} stripesConf stripes.config.js's config object
+ * @returns string
+ */
+export function installVersion(env, conf, stripesConf) {
+  return env?.ABOUT_INSTALL_VERSION || entryFor(conf, 'version') || stripesConf?.aboutInstallVersion || '';
+}
+
+/**
+ * installDate
+ * Search environment, the mod-configuration, then stripes.config.js
+ * for installed-date information. Return it or an empty string.
+ *
+ * @param {object} env
+ * @param {object} conf
+ * @param {object} stripesConf stripes.config.js's config object
+ * @returns Component
+ */
+export function installDate(env, conf, stripesConf) {
+  return env?.ABOUT_INSTALL_DATE || entryFor(conf, 'date') || stripesConf?.aboutInstallDate || '';
+}
+
+/**
+ * installMessage
+ * Search environment, then mod-configuration, then stripes.config.js for
+ * a configuration message. Return it, or an empty element.
+ *
+ * @param {object} env
+ * @param {object} conf
+ * @param {object} stripesConf stripes.config.js's config object
+ * @returns Component
+ */
+export function installMessage(env, conf, stripesConf) {
+  return env?.ABOUT_INSTALL_MESSAGE || entryFor(conf, 'message') || stripesConf?.aboutInstallMessage || '';
+}
+
+/**
+ * Display install-releated information from one of three sources,
+ * in descending order of preference (i.e. use a higher-ranked source
+ * if available):
+ *
+ * 1. Environment variables (/_/env)
+ *    Search for ABOUT_INSTALL_DATE, ABOUT_INSTALL_VERSION, ABOUT_INSTALL_MESSAGE.
+ * 2. mod-configuration (/configurations/entries)
+ *    In { module: '@folio/stripes-core', configName: 'aboutInstall' } search for
+ *    date, version, message.
+ * 3. stripes.config (stripes.config.js).
+ *    Search for aboutInstallDate, aboutInstallVersion, aboutInstallVersion
+ *
+ * @param {} props
+ * @returns
+ */
+const AboutInstallMessages = (props) => {
+  const aboutEnv = useOkapiEnv();
+  const aboutConfig = useConfigurations({
+    module: '@folio/stripes-core',
+    configName: 'aboutInstall',
+  });
+
+  const version = installVersion(aboutEnv.data, aboutConfig.data, props.stripes.config);
+  const date = installDate(aboutEnv.data, aboutConfig.data, props.stripes.config);
+  const message = installMessage(aboutEnv.data, aboutConfig.data, props.stripes.config);
+
+  let formattedDate = '';
+  if (date) {
+    formattedDate = <>(<FormattedDate value={date} />)</>;
+  }
+
+  return (
+    <>
+      {(version || formattedDate) && <Headline size="large">{version} {formattedDate}</Headline>}
+      {message && <div>{message}</div>}
+    </>
+  );
+};
+
+AboutInstallMessages.propTypes = {
+  stripes: PropTypes.shape({
+    config: PropTypes.object,
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+export default AboutInstallMessages;

--- a/src/components/About/AboutInstallMessages.test.js
+++ b/src/components/About/AboutInstallMessages.test.js
@@ -1,0 +1,242 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+
+import AboutInstallMessages, {
+  entryFor,
+  installDate,
+  installMessage,
+  installVersion,
+} from './AboutInstallMessages';
+
+import Harness from '../../../test/jest/helpers/harness';
+import useOkapiEnv from '../../queries/useOkapiEnv';
+import useConfigurations from '../../queries/useConfigurations';
+
+jest.mock('../../queries/useOkapiEnv');
+jest.mock('../../queries/useConfigurations');
+
+describe('entryFor', () => {
+  const config = {
+    configs: [{
+      code: 'thunder',
+      value: 'chicken',
+    }]
+  };
+  it('should find a matching entry', () => {
+    expect(entryFor(config, 'thunder')).toBe('chicken');
+  });
+
+  it('should return empty string for missing entry', () => {
+    expect(entryFor(config, 'monkey')).toBe('');
+  });
+
+  it('should return empty string for missing configs', () => {
+    expect(entryFor({}, 'monkey')).toBe('');
+  });
+});
+
+describe('installVersion', () => {
+  it('should prefer env over conf, stripesConf', () => {
+    const env = { ABOUT_INSTALL_VERSION: 'env' };
+    const conf = { configs: [{ code: 'version', value: 'conf' }] };
+    const stripesConf = { aboutInstallVersion: 'stripes.config' };
+
+    expect(installVersion(env, conf, stripesConf)).toBe(env.ABOUT_INSTALL_VERSION);
+  });
+
+  it('should prefer conf over stripesConf', () => {
+    const env = { };
+    const conf = { configs: [{ code: 'version', value: 'conf' }] };
+    const stripesConf = { aboutInstallVersion: 'stripes.config' };
+
+    expect(installVersion(env, conf, stripesConf)).toBe(conf.configs[0].value);
+  });
+
+  it('should find a stripesConf value', () => {
+    const env = { };
+    const conf = { };
+    const stripesConf = { aboutInstallVersion: 'stripes.config' };
+
+    expect(installVersion(env, conf, stripesConf)).toBe(stripesConf.aboutInstallVersion);
+  });
+
+  it('should return empty string for missing configs', () => {
+    expect(installDate()).toBe('');
+  });
+});
+
+describe('installDate', () => {
+  it('should prefer env over conf, stripesConf', () => {
+    const env = { ABOUT_INSTALL_DATE: 'env' };
+    const conf = { configs: [{ code: 'date', value: 'conf' }] };
+    const stripesConf = { aboutInstallDate: 'stripes.config' };
+
+    expect(installDate(env, conf, stripesConf)).toBe(env.ABOUT_INSTALL_DATE);
+  });
+
+  it('should prefer conf over stripesConf', () => {
+    const env = { };
+    const conf = { configs: [{ code: 'date', value: 'conf' }] };
+    const stripesConf = { aboutInstallDate: 'stripes.config' };
+
+    expect(installDate(env, conf, stripesConf)).toBe(conf.configs[0].value);
+  });
+
+  it('should find a stripesConf value', () => {
+    const env = { };
+    const conf = { };
+    const stripesConf = { aboutInstallDate: 'stripes.config' };
+
+    expect(installDate(env, conf, stripesConf)).toBe(stripesConf.aboutInstallDate);
+  });
+
+  it('should return empty string for missing configs', () => {
+    expect(installDate()).toBe('');
+  });
+});
+
+describe('installMessage', () => {
+  it('should prefer env over conf, stripesConf', () => {
+    const env = { ABOUT_INSTALL_MESSAGE: 'env' };
+    const conf = { configs: [{ code: 'message', value: 'conf' }] };
+    const stripesConf = { aboutInstallMessage: 'stripes.config' };
+
+    expect(installMessage(env, conf, stripesConf)).toBe(env.ABOUT_INSTALL_MESSAGE);
+  });
+
+  it('should prefer conf over stripesConf', () => {
+    const env = { };
+    const conf = { configs: [{ code: 'message', value: 'conf' }] };
+    const stripesConf = { aboutInstallMessage: 'stripes.config' };
+
+    expect(installMessage(env, conf, stripesConf)).toBe(conf.configs[0].value);
+  });
+
+  it('should find a stripesConf value', () => {
+    const env = { };
+    const conf = { };
+    const stripesConf = { aboutInstallMessage: 'stripes.config' };
+
+    expect(installMessage(env, conf, stripesConf)).toBe(stripesConf.aboutInstallMessage);
+  });
+
+  it('should return empty string for missing configs', () => {
+    expect(installMessage()).toBe('');
+  });
+});
+
+describe('AboutInstallMessages', () => {
+  beforeEach(async () => {
+    const mockUseOkapiEnv = useOkapiEnv;
+    mockUseOkapiEnv.mockReturnValue({
+      data: {
+        ABOUT_INSTALL_VERSION: '1.2.3',
+        ABOUT_INSTALL_DATE: '2022-08-01T13:25:00Z',
+        ABOUT_INSTALL_MESSAGE: 'Don\'t pussyfoot the thunder chicken',
+      }
+    });
+
+    const mockUseConfigurations = useConfigurations;
+    mockUseConfigurations.mockReturnValue({
+      data: {
+        configs: [
+          // { code: 'version', value: 'monkey' },
+        ]
+      }
+    });
+
+    const stripes = {
+      config: {},
+      hasPerm: jest.fn(),
+    };
+
+    const history = createMemoryHistory();
+    render(
+      <Harness history={history} stripes={stripes}>
+        <AboutInstallMessages stripes={stripes} />
+      </Harness>
+    );
+  });
+
+
+  it('finds a version', () => {
+    expect(screen.getByText(/1\.2\.3/)).toBeInTheDocument();
+  });
+
+  it('finds an install date', () => {
+    expect(screen.getByText(/2022/)).toBeInTheDocument();
+  });
+
+  it('finds an install message', () => {
+    expect(screen.getByText(/thunder chicken/)).toBeInTheDocument();
+  });
+});
+
+describe('finds conditional fields', () => {
+  it('finds an install-date even when no install-version is present', () => {
+    const mockUseOkapiEnv = useOkapiEnv;
+    mockUseOkapiEnv.mockReturnValue({
+      data: {
+        ABOUT_INSTALL_DATE: '2022-08-01T13:25:00Z',
+        ABOUT_INSTALL_MESSAGE: 'Don\'t pussyfoot the thunder chicken',
+      }
+    });
+
+    const mockUseConfigurations = useConfigurations;
+    mockUseConfigurations.mockReturnValue({
+      data: {
+        configs: [
+          // { code: 'version', value: 'monkey' },
+        ]
+      }
+    });
+
+    const stripes = {
+      config: {},
+      hasPerm: jest.fn(),
+    };
+
+    const history = createMemoryHistory();
+    render(
+      <Harness history={history} stripes={stripes}>
+        <AboutInstallMessages stripes={stripes} />
+      </Harness>
+    );
+
+    expect(screen.getByText(/2022/)).toBeInTheDocument();
+  });
+});
+
+describe('finds conditional fields', () => {
+  it('finds an install-version when no install-date is present', () => {
+    const mockUseOkapiEnv = useOkapiEnv;
+    mockUseOkapiEnv.mockReturnValue({
+      data: {
+        ABOUT_INSTALL_VERSION: '1.2.3',
+      }
+    });
+
+    const mockUseConfigurations = useConfigurations;
+    mockUseConfigurations.mockReturnValue({
+      data: {
+        configs: [
+          // { code: 'version', value: 'monkey' },
+        ]
+      }
+    });
+
+    const stripes = {
+      config: {},
+      hasPerm: jest.fn(),
+    };
+
+    const history = createMemoryHistory();
+    render(
+      <Harness history={history} stripes={stripes}>
+        <AboutInstallMessages stripes={stripes} />
+      </Harness>
+    );
+
+    expect(screen.getByText(/1\.2\.3/)).toBeInTheDocument();
+  });
+});

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,0 +1,3 @@
+
+export { default as useConfigurations } from './useConfigurations';
+export { default as useOkapiEnv } from './useOkapiEnv';

--- a/src/queries/useConfigurations.js
+++ b/src/queries/useConfigurations.js
@@ -29,7 +29,7 @@ const useConfigurations = ({ module, configName, code }) => {
 
   const { isFetching, data, error } = useQuery(
     [namespace, configName, code],
-    async () => {
+    () => {
       if (stripes.hasPerm('configuration.entries.collection.get')) {
         return ky.get(configurationsApi(module, configName, code))
           .json();

--- a/src/queries/useConfigurations.js
+++ b/src/queries/useConfigurations.js
@@ -1,0 +1,48 @@
+import { useQuery } from 'react-query';
+
+import queryLimit from '../queryLimit';
+import useOkapiKy from '../useOkapiKy';
+import { useStripes } from '../StripesContext';
+
+
+export const configurationsApi = (module, configName, code) => {
+  const params = [];
+  if (module) {
+    params.push(`module=="${module}"`);
+  }
+  if (configName) {
+    params.push(`configName=="${configName}"`);
+  }
+  if (code) {
+    params.push(`code=="${code}"`);
+  }
+
+  const query = params.join(' and ');
+
+  return `configurations/entries?${query ? `query=(${query})` : ''}&limit=${queryLimit()}`;
+};
+
+const useConfigurations = ({ module, configName, code }) => {
+  const stripes = useStripes();
+  const ky = useOkapiKy();
+  const namespace = '@folio/stripes-core:QUERY_KEY_CONFIGURATIONS';
+
+  const { isFetching, data, error } = useQuery(
+    [namespace, configName, code],
+    async () => {
+      if (stripes.hasPerm('configuration.entries.collection.get')) {
+        return ky.get(configurationsApi(module, configName, code))
+          .json();
+      }
+      throw new Error('missing permission: configuration.entries.collection.get');
+    },
+  );
+
+  return ({
+    data,
+    isLoading: isFetching,
+    error,
+  });
+};
+
+export default useConfigurations;

--- a/src/queries/useConfigurations.js
+++ b/src/queries/useConfigurations.js
@@ -17,9 +17,9 @@ export const configurationsApi = (module, configName, code) => {
     params.push(`code=="${code}"`);
   }
 
-  const query = params.join(' and ');
+  const query = params.length ? `query=(${params.join(' and ')})` : '';
 
-  return `configurations/entries?${query ? `query=(${query})` : ''}&limit=${queryLimit()}`;
+  return `configurations/entries?${query}&limit=${queryLimit()}`;
 };
 
 const useConfigurations = ({ module, configName, code }) => {

--- a/src/queries/useConfigurations.test.js
+++ b/src/queries/useConfigurations.test.js
@@ -1,0 +1,114 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+import { renderHook } from '@testing-library/react-hooks';
+
+import useConfigurations, { configurationsApi } from './useConfigurations';
+import { useStripes } from '../StripesContext';
+import useOkapiKy from '../useOkapiKy';
+
+jest.mock('../useOkapiKy');
+jest.mock('../StripesContext');
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false
+    }
+  }
+});
+
+describe('Given useConfigurations', () => {
+  describe('configurationsApi', () => {
+    const module = 'module';
+    const configName = 'configName';
+    const code = 'code';
+
+    it('includes module in the API query', () => {
+      expect(configurationsApi(module)).toContain(`module=="${module}"`);
+    });
+
+    it('includes configName in the API query', () => {
+      expect(configurationsApi(module, configName)).toContain(`configName=="${configName}"`);
+    });
+
+    it('includes code in the API query', () => {
+      expect(configurationsApi(module, configName, code)).toContain(`code=="${code}"`);
+    });
+
+    it('joins criteria with "AND"', () => {
+      expect(configurationsApi(module, configName, code)).toContain(`module=="${module}" and configName=="${configName}" and code=="${code}"`);
+    });
+
+    it('retrieves all values without any criteria', () => {
+      expect(configurationsApi()).toContain('configurations/entries?&limit=');
+    });
+  });
+
+  describe('correctly checks permissions: with permissions', () => {
+    const response = { configs: [], totalRecords: 1 };
+    beforeEach(() => {
+      const mockUseStripes = useStripes;
+      mockUseStripes.mockReturnValue({
+        hasPerm: () => true,
+      });
+
+      const mockUseOkapiKy = useOkapiKy;
+      mockUseOkapiKy.mockReturnValue({
+        get: () => ({
+          json: () => Promise.resolve(response),
+        }),
+      });
+    });
+
+    it('with permission, calls get', async () => {
+      const wrapper = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+
+      const { result, waitFor } = renderHook(() => useConfigurations({}), { wrapper });
+
+      await waitFor(() => {
+        return !result.current.isLoading;
+      });
+
+      expect(result.current.data).toEqual(response);
+    });
+  });
+
+  describe('correctly checks permissions: without permissions', () => {
+    beforeEach(() => {
+      const mockUseStripes = useStripes;
+      mockUseStripes.mockReturnValue({
+        hasPerm: () => false,
+      });
+
+      const mockUseOkapiKy = useOkapiKy;
+      mockUseOkapiKy.mockReturnValue({
+        get: () => ({
+          json: () => Promise.resolve({ configs: [], totalRecords: 1 }),
+        }),
+      });
+    });
+
+    it('without permission, throws an error', async () => {
+      const wrapper = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+
+      const { result, waitFor } = renderHook(() => useConfigurations({}), { wrapper });
+
+      await waitFor(() => {
+        return !!result.current.error;
+      });
+
+      expect(result.current.error.message).toMatch(/configuration.entries.collection.get/);
+    });
+  });
+});
+

--- a/src/queries/useConfigurations.test.js
+++ b/src/queries/useConfigurations.test.js
@@ -11,6 +11,10 @@ import useOkapiKy from '../useOkapiKy';
 jest.mock('../useOkapiKy');
 jest.mock('../StripesContext');
 
+// set query retries to false. otherwise, react-query will thoughtfully
+// (but unhelpfully, in the context of testing) retry a failed query
+// several times causing the test to timeout when what we really want
+// is for it to throw so we can catch and test the exception.
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/src/queries/useOkapiEnv.js
+++ b/src/queries/useOkapiEnv.js
@@ -12,7 +12,7 @@ const useOkapiEnv = () => {
 
   const { isFetching, data, error } = useQuery(
     [namespace],
-    async () => {
+    () => {
       if (stripes.hasPerm('okapi.env.list')) {
         return ky.get(OKAPI_ENV_API).json();
       }

--- a/src/queries/useOkapiEnv.js
+++ b/src/queries/useOkapiEnv.js
@@ -1,0 +1,39 @@
+import { useQuery } from 'react-query';
+
+import useOkapiKy from '../useOkapiKy';
+import { useStripes } from '../StripesContext';
+
+const OKAPI_ENV_API = '_/env';
+
+const useOkapiEnv = () => {
+  const stripes = useStripes();
+  const ky = useOkapiKy();
+  const namespace = '@folio/stripes-core:QUERY_KEY_OKAPI_ENV';
+
+  const { isFetching, data, error } = useQuery(
+    [namespace],
+    async () => {
+      if (stripes.hasPerm('okapi.env.list')) {
+        return ky.get(OKAPI_ENV_API).json();
+      }
+
+      throw new Error('missing permissions: okapi.env.list');
+    },
+  );
+
+  // transform the array of { name, value} objects to a set
+  const hash = {};
+  if (Array.isArray(data)) {
+    data.forEach(i => {
+      hash[i.name] = i.value;
+    });
+  }
+
+  return ({
+    data: hash,
+    isLoading: isFetching,
+    error,
+  });
+};
+
+export default useOkapiEnv;

--- a/src/queries/useOkapiEnv.test.js
+++ b/src/queries/useOkapiEnv.test.js
@@ -1,0 +1,89 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+import { renderHook } from '@testing-library/react-hooks';
+
+import useOkapiEnv from './useOkapiEnv';
+import { useStripes } from '../StripesContext';
+import useOkapiKy from '../useOkapiKy';
+
+jest.mock('../useOkapiKy');
+jest.mock('../StripesContext');
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false
+    }
+  }
+});
+
+describe('Given useOkapiEnv', () => {
+  describe('correctly checks permissions: with permissions', () => {
+    const response = [{ name: 'MONKEY', value: 'bagel' }];
+
+    beforeEach(() => {
+      const mockUseStripes = useStripes;
+      mockUseStripes.mockReturnValue({
+        hasPerm: () => true,
+      });
+
+      const mockUseOkapiKy = useOkapiKy;
+      mockUseOkapiKy.mockReturnValue({
+        get: () => ({
+          json: () => Promise.resolve(response),
+        }),
+      });
+    });
+
+    it('with permission, calls get', async () => {
+      const wrapper = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+
+      const { result, waitFor } = renderHook(() => useOkapiEnv({}), { wrapper });
+
+      await waitFor(() => {
+        return !result.current.isLoading;
+      });
+
+      expect(result.current.data).toEqual({ MONKEY: 'bagel' });
+    });
+  });
+
+  describe('correctly checks permissions: without permissions', () => {
+    beforeEach(() => {
+      const mockUseStripes = useStripes;
+      mockUseStripes.mockReturnValue({
+        hasPerm: () => false,
+      });
+
+      const mockUseOkapiKy = useOkapiKy;
+      mockUseOkapiKy.mockReturnValue({
+        get: () => ({
+          json: () => Promise.resolve({ configs: [], totalRecords: 1 }),
+        }),
+      });
+    });
+
+    it('without permission, throws an error', async () => {
+      const wrapper = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+
+      const { result, waitFor } = renderHook(() => useOkapiEnv({}), { wrapper });
+
+      await waitFor(() => {
+        return !!result.current.error;
+      });
+
+      expect(result.current.error.message).toMatch(/okapi.env.list/);
+    });
+  });
+});
+

--- a/src/queries/useOkapiEnv.test.js
+++ b/src/queries/useOkapiEnv.test.js
@@ -11,6 +11,10 @@ import useOkapiKy from '../useOkapiKy';
 jest.mock('../useOkapiKy');
 jest.mock('../StripesContext');
 
+// set query retries to false. otherwise, react-query will thoughtfully
+// (but unhelpfully, in the context of testing) retry a failed query
+// several times causing the test to timeout when what we really want
+// is for it to throw so we can catch and test the exception.
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/test/jest/helpers/harness.js
+++ b/test/jest/helpers/harness.js
@@ -1,0 +1,53 @@
+import { Router as DefaultRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import { StripesContext } from '../../../src/StripesContext';
+
+import IntlProvider from './intl';
+// import buildStripes from '../__mock__/stripesCore.mock';
+
+const STRIPES = {
+  actionNames: [],
+  connect: component => component,
+  config: {},
+  currency: 'USD',
+  hasInterface: () => true,
+  hasPerm: jest.fn(() => true),
+  locale: 'en-US',
+  logger: {
+    log: () => { },
+  },
+  okapi: {
+    tenant: 'diku',
+    url: 'https://folio-testing-okapi.dev.folio.org',
+  },
+};
+
+const defaultHistory = createMemoryHistory();
+
+const queryClient = new QueryClient();
+
+const Harness = ({
+  Router = DefaultRouter,
+  stripes,
+  children,
+  history = defaultHistory,
+}) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <StripesContext.Provider value={stripes || STRIPES}>
+        <Router history={history}>
+          <IntlProvider>
+            {children}
+          </IntlProvider>
+        </Router>
+      </StripesContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+export default Harness;

--- a/test/jest/helpers/intl.js
+++ b/test/jest/helpers/intl.js
@@ -1,0 +1,29 @@
+import { IntlProvider } from 'react-intl';
+
+import translationsJson from '../../../translations/stripes-core/en';
+
+const prefixKeys = (translations, prefix) => {
+  return Object
+    .keys(translations)
+    .reduce((acc, key) => (
+      {
+        ...acc,
+        [`${prefix}.${key}`]: translations[key],
+      }
+    ), {});
+};
+
+const translations = {
+  ...prefixKeys(translationsJson, 'stripes-core'),
+};
+
+const Intl = ({ children }) => (
+  <IntlProvider
+    locale="en"
+    messages={translations}
+  >
+    {children}
+  </IntlProvider>
+);
+
+export default Intl;

--- a/test/jest/jest.setup.js
+++ b/test/jest/jest.setup.js
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import './turn-off-warnings';

--- a/test/jest/turn-off-warnings.js
+++ b/test/jest/turn-off-warnings.js
@@ -1,0 +1,37 @@
+// eslint-disable-next-line no-console
+const warn = console.warn;
+const blacklist = [
+  /[@formatjs/intl]/,
+];
+
+// eslint-disable-next-line no-console
+const error = console.error;
+const errorBlacklist = [
+  /React Intl/,
+  /Cannot update a component from inside the function body of a different component/,
+  /Can't perform a React state update on an unmounted component./,
+  /Invalid prop `component` supplied to.*Field/,
+  /@formatjs\/intl Error MISSING_TRANSLATION/,
+  /Warning: React does not recognize the `%s` prop on a DOM element/,
+  /Warning: Unknown event handler property `%s`./,
+  /No metadata harvested from package files, so you will not get app icons./,
+  /Warning: Failed prop type: Invalid prop `icon` supplied to `Icon`/,
+];
+
+global.beforeAll(() => {
+  // eslint-disable-next-line no-console
+  console.warn = function (...args) {
+    if (blacklist.some(rx => rx.test(args[0]))) {
+      return;
+    }
+    warn.apply(console, args);
+  };
+
+  // eslint-disable-next-line no-console
+  console.error = function (...args) {
+    if (errorBlacklist.some(rx => rx.test(args[0]))) {
+      return;
+    }
+    error.apply(console, args);
+  };
+});


### PR DESCRIPTION
Optionally decorate the `/settings/about` (Settings: Software versions)
page with information from Okapi Environment variables,
mod-configuration values, or stripes.config, in descending order. Three
values may be displayed: a version, an install date, and a message.

The Okapi Environment keys are `ABOUT_INSTALL_DATE`,
`ABOUT_INSTALL_VERSION`, and `ABOUT_INSTALL_MESSAGE`. The mod-configuration
values all correspond to `module`: `@folio/stripes-core`, `configName`:
`aboutInstall` and the `code`s `date`, `version`, and `message`. The
`stripes.config.js` values are from the `stripes.config` object with the
keys `aboutInstallDate`, `aboutInstallVersion`, and
`aboutInstallMessage`.

Refs [STCOR-603](https://issues.folio.org/browse/STCOR-603), NH-603 (No taxes, no services! Live Free or Die!)