### PR TITLE
STCOR-645 add cs_CZ to supported locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Use documenation's root URL in NavBar `?` link. Refs STCOR-621.
 * Allow customization of login page's CSS. Refs STCOR-643.
 * Allow customization of navbar CSS. Refs STCOR-644.
+* Add `cs_CZ` (Czech, Czechia) to the supported locales. Refs STCOR-645.
 
 ## [8.2.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.1.0...v8.2.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -31,7 +31,7 @@ export const supportedLocales = [
   'ar',     // arabic
   'zh-CN',  // chinese, china
   'zh-TW',  // chinese, taiwan
-  'cs_CZ',  // czech, czechia
+  'cs-CZ',  // czech, czechia
   'da-DK',  // danish, denmark
   'en-GB',  // british english
   'en-SE',  // english, sweden

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -31,6 +31,7 @@ export const supportedLocales = [
   'ar',     // arabic
   'zh-CN',  // chinese, china
   'zh-TW',  // chinese, taiwan
+  'cs_CZ',  // czech, czechia
   'da-DK',  // danish, denmark
   'en-GB',  // british english
   'en-SE',  // english, sweden


### PR DESCRIPTION
Add `cs-CZ` (Czech, Czechia) to the list of supported locales.

Refs [STCOR-645](https://issues.folio.org/browse/STCOR-645)