### PR TITLE
STCOR-646: Settings > About> stripes-final-form version is not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Use documenation's root URL in NavBar `?` link. Refs STCOR-621.
 * Allow customization of login page's CSS. Refs STCOR-643.
 * Allow customization of navbar CSS. Refs STCOR-644.
+* Settings > About - show stripes-final-form version. Refs STCOR-646.
 
 ## [8.2.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.1.0...v8.2.0)

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@folio/stripes-cli": "^2.4.0",
     "@folio/stripes-components": "^10.0.0",
     "@folio/stripes-connect": "^7.0.0",
+    "@folio/stripes-final-form": "^6.1.0",
     "@folio/stripes-logger": "^1.0.0",
     "@formatjs/cli": "^4.2.2",
     "@jest/globals": "^28.0.1",
@@ -116,6 +117,7 @@
   "peerDependencies": {
     "@folio/stripes-components": "^10.0.0",
     "@folio/stripes-connect": "^7.0.0",
+    "@folio/stripes-final-form": "^6.1.0",
     "@folio/stripes-logger": "^1.0.0",
     "moment": "^2.29.0",
     "react": "^17.0.2",

--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import stripesConnect from '@folio/stripes-connect/package';
 import stripesComponents from '@folio/stripes-components/package';
 import stripesLogger from '@folio/stripes-logger/package';
+import stripesFinalForm from '@folio/stripes-final-form/package';
 
 import {
   Pane,
@@ -147,6 +148,10 @@ const About = (props) => {
               {
                 key: 'stripes-logger',
                 value: `stripes-logger ${stripesLogger.version}`,
+              },
+              {
+                key: 'stripes-final-form',
+                value: `stripes-final-form ${stripesFinalForm.version}`,
               },
             ]}
             itemFormatter={item => (<li key={item.key}>{item.value}</li>)}


### PR DESCRIPTION
## Description
Display `stripes-final-form` version in Settings > About page

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/182619885-480543f0-f9d8-4337-81a5-7603dc16d87f.png)

## Issues
[STCOR-646](https://issues.folio.org/browse/STCOR-646)