### PR TITLE
STCOR-652: Extend Prop-Types of Route

### DIFF
--- a/src/components/NestedRouter.js
+++ b/src/components/NestedRouter.js
@@ -39,7 +39,10 @@ export function Route({ component: Component, children, ...props }) {
 }
 
 Route.propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object,
+  ]),
   component: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.object,

--- a/src/components/NestedRouter.js
+++ b/src/components/NestedRouter.js
@@ -40,8 +40,9 @@ export function Route({ component: Component, children, ...props }) {
 
 Route.propTypes = {
   children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
     PropTypes.func,
-    PropTypes.object,
   ]),
   component: PropTypes.oneOfType([
     PropTypes.func,


### PR DESCRIPTION
We are in a situation where passing information down from the top level Route is necessary, and can be accomplised y passing props to a child function, however this trips PropTypes.

Currently working around by using Route from react-router-dom, but would be nice to expand PropTypes here so we don't need a separate import for this use case