### PR TITLE
re-export history dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ export { default as coreEvents } from './src/events';
 export { default as useOkapiKy } from './src/useOkapiKy';
 export { default as withOkapiKy } from './src/withOkapiKy';
 export { default as useCustomFields } from './src/useCustomFields';
+export { default as history} from 'history';
 
 /* components */
 export { default as AppContextMenu } from './src/components/MainNav/CurrentApp/AppContextMenu';

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ export { default as coreEvents } from './src/events';
 export { default as useOkapiKy } from './src/useOkapiKy';
 export { default as withOkapiKy } from './src/withOkapiKy';
 export { default as useCustomFields } from './src/useCustomFields';
-export { default as history} from 'history';
+export { default as history } from 'history';
 
 /* components */
 export { default as AppContextMenu } from './src/components/MainNav/CurrentApp/AppContextMenu';


### PR DESCRIPTION
Module runtime code will typically receive this handed down from our `react-router` context, but modules can also import it as a `devDependency` for their local test suites, which means that there can be a difference in major versions/functionality between what runs in the test suite vs what runs in the platform runtime. Re-exporting this will give ui modules something that they can use in their test suites to stay in sync and remove their local `devDependency`.