### PR TITLE
STCOR-540 - bump up graphql version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@apollo/client": "^3.2.1",
     "classnames": "^2.2.5",
     "final-form": "^4.18.2",
-    "graphql": "^0.11.7",
+    "graphql": "^16.0.0",
     "history": "^4.6.3",
     "hoist-non-react-statics": "^3.3.0",
     "jwt-decode": "^2.2.0",


### PR DESCRIPTION
## Purpose
@apollo/client@"^3.2.1" from stripes-core@7.2.0 causes a peer-dep inconsistency

## Refs
https://issues.folio.org/browse/STCOR-540