### PR TITLE
STRIPES-820: Expose app initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,3 +37,4 @@ export { supportedLocales } from './src/loginServices';
 export { supportedNumberingSystems } from './src/loginServices';
 export { userLocaleConfig } from './src/loginServices';
 export { default as queryLimit } from './src/queryLimit';
+export { default as init } from './src/init';

--- a/src/init.js
+++ b/src/init.js
@@ -1,0 +1,10 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+import React from 'react';
+import { render } from 'react-dom';
+
+import App from './App';
+
+export default function init() {
+  render(<App />, document.getElementById('root'));
+}


### PR DESCRIPTION
https://issues.folio.org/browse/STRIPES-820

Expose `App` initialization via function so it can be consumed by other modules.

This is a temporary approach to prove that `stripes-ui` will work as expected.

The final goal will be to move the `App` component and all other required parts to `stripes-ui` out of the `stripes-core`.

The other PRs related to this work that should be merged after this one are:

https://github.com/folio-org/stripes/pull/182
https://github.com/folio-org/stripes-webpack/pull/80


