### PR TITLE
STCOR-659 suppress react-intl warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 8.4.0 (IN PROGRESS)
 
+* Leverage `suppressIntlErrors` to suppress warnings, in addition to errors. Refs STCOR-
+
 ## [8.3.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.2.0...v8.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 8.4.0 (IN PROGRESS)
 
-* Leverage `suppressIntlErrors` to suppress warnings, in addition to errors. Refs STCOR-
+* Allow suppression of `react-intl` warnings, in addition to errors. Refs STCOR-659.
 
 ## [8.3.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.2.0...v8.3.0)

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -165,7 +165,7 @@ class Root extends Component {
                   messages={translations}
                   textComponent={Fragment}
                   onError={config?.suppressIntlErrors ? () => {} : undefined}
-                  onWarn={config?.suppressIntlErrors ? () => {} : undefined}
+                  onWarn={config?.suppressIntlWarnings ? () => {} : undefined}
                   defaultRichTextElements={this.defaultRichTextElements}
                 >
                   <RootWithIntl

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -165,6 +165,7 @@ class Root extends Component {
                   messages={translations}
                   textComponent={Fragment}
                   onError={config?.suppressIntlErrors ? () => {} : undefined}
+                  onWarn={config?.suppressIntlErrors ? () => {} : undefined}
                   defaultRichTextElements={this.defaultRichTextElements}
                 >
                   <RootWithIntl


### PR DESCRIPTION
Leverage `stripes.config.suppressIntlErrors` to suppress warnings in addition to errors, now that there is FINALLY support for the [`onWarn` prop](https://github.com/formatjs/formatjs/issues/3454) as of `v5.25.1`.

See also PR #912 where we added `onError` handling.

Refs [STCOR-659](https://issues.folio.org/browse/STCOR-659)