### PR TITLE
STRIPES-820 include missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "dependencies": {
     "@apollo/client": "^3.2.1",
     "classnames": "^2.2.5",
+    "core-js": "^3.26.1",
     "final-form": "^4.18.2",
     "graphql": "^16.0.0",
     "history": "^4.6.3",
@@ -108,6 +109,7 @@
     "redux-logger": "^3.0.6",
     "redux-observable": "^1.2.0",
     "redux-thunk": "^2.1.0",
+    "regenerator-runtime": "^0.13.10",
     "rimraf": "^2.5.4",
     "rtl-detect": "^1.0.2",
     "rxjs": "^6.6.3",


### PR DESCRIPTION
It's another entry for the "how did this ever work?" category. `core-js` and `regenerator-runtime` are both used in `./src/index.js` and yet were never included as deps in `package.json`. How ...?

And how did #1256 merge cleanly if subsequent builds are failing? 

CC: @mkuklis 

Refs [STRIPES-820](https://issues.folio.org/browse/STRIPES-820)