### PR TITLE
STCOR-661 Fix redirect in Production error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 8.4.0 (IN PROGRESS)
 
 * Allow suppression of `react-intl` warnings, in addition to errors. Refs STCOR-659.
+* Catastrophic Messaging | Return to MARC authority. Fixes STCOR-661.
 
 ## [8.3.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.2.0...v8.3.0)

--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -66,7 +66,7 @@ const AppRoutes = ({ modules, stripes }) => {
               <ModuleHierarchyProvider module={module.module}>
                 <div id={`${name}-module-display`} data-module={module.module} data-version={module.version}>
                   <RouteErrorBoundary
-                    escapeRoute={module.home}
+                    escapeRoute={module.route}
                     moduleName={displayName}
                     stripes={moduleStripes}
                   >


### PR DESCRIPTION
## Description
Fix Production error redirect to app's main page
Issue was that `module.home` isn't a real property - need to use `module.route`

## Screenshots

https://user-images.githubusercontent.com/19309423/202692134-be3c87d2-df35-4726-b104-30a9a0092977.mp4

## Issues
[STCOR-661](https://issues.folio.org/browse/STCOR-661)