### PR TITLE
STCOR-664 Close Context Dropdown when switching apps.

### DIFF
--- a/src/components/MainNav/CurrentApp/AppCtxMenuProvider.js
+++ b/src/components/MainNav/CurrentApp/AppCtxMenuProvider.js
@@ -30,6 +30,7 @@ class AppCtxMenuProvider extends React.Component {
   deregister() {
     this.setState({
       displayDropdownButton: false, // eslint-disable-line react/no-unused-state
+      open: false, // eslint-disable-line react/no-unused-state
     });
   }
 


### PR DESCRIPTION
The app context dropdown (with shortcuts etc, will remain open when switching modules. Due to the 'open' state of the component not being reset when the app's context menu unmounts. This PR simply sets the state back to `open: false` when the component unmounts.