### PR TITLE
STCOR-657 PasswordValidationField swallows error messages from API queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Allow suppression of `react-intl` warnings, in addition to errors. Refs STCOR-659.
 * Catastrophic Messaging | Return to MARC authority. Fixes STCOR-661.
 * Reset App Context Dropdown state when switching apps/unmounting. Fixes STCOR-664.
+* PasswordValidationField swallows error messages from API queries. Fixes STCOR-657.
 
 ## [8.3.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.2.0...v8.3.0)

--- a/src/components/CreateResetPassword/components/PasswordValidationField/PasswordValidationField.js
+++ b/src/components/CreateResetPassword/components/PasswordValidationField/PasswordValidationField.js
@@ -20,7 +20,7 @@ class PasswordValidationField extends React.Component {
   static manifest = Object.freeze({
     validators: {
       type: 'okapi',
-      path: 'tenant/rules?query=(type==RegExp and state==Enabled)',
+      path: 'tenant/rules',
       throwErrors: false,
       fetch: false,
       accumulate: true,


### PR DESCRIPTION
## Purpose
This PR relates to [STCOR-657](https://issues.folio.org/browse/STCOR-657)
## Approach
The query was removed as it was invalid and not used by BE