### PR TITLE
bump major version to 9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-core
 
-# 8.4.0 (IN PROGRESS)
+# 9.0.0 (IN PROGRESS)
 
 * Allow suppression of `react-intl` warnings, in addition to errors. Refs STCOR-659.
 * Catastrophic Messaging | Return to MARC authority. Fixes STCOR-661.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-core",
-  "version": "8.4.0",
+  "version": "9.0.0",
   "description": "The starting point for Stripes applications",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",
@@ -48,7 +48,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^6.0.0",
     "@folio/stripes-cli": "^2.4.0",
-    "@folio/stripes-components": "^10.0.0",
+    "@folio/stripes-components": "^11.0.0",
     "@folio/stripes-connect": "^7.0.0",
     "@folio/stripes-logger": "^1.0.0",
     "@formatjs/cli": "^4.2.2",
@@ -117,7 +117,7 @@
     "use-deep-compare": "^1.1.0"
   },
   "peerDependencies": {
-    "@folio/stripes-components": "^10.0.0",
+    "@folio/stripes-components": "^11.0.0",
     "@folio/stripes-connect": "^7.0.0",
     "@folio/stripes-logger": "^1.0.0",
     "moment": "^2.29.0",


### PR DESCRIPTION
Bump the major version to accomodate breaking changes, mostly the removal of long-deprecated props in stripes-components but also the removal of service-point handling and slicing off routing into stripes-ui here in stripes-core.