### PR TITLE
STCOR-675 use stricter tenant-locale query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Catastrophic Messaging | Return to MARC authority. Fixes STCOR-661.
 * Reset App Context Dropdown state when switching apps/unmounting. Fixes STCOR-664.
 * PasswordValidationField swallows error messages from API queries. Fixes STCOR-657.
+* Guarantee a single-row response to the tenant's locale-config query. Fixes STCOR-675.
 
 ## [8.3.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.2.0...v8.3.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -182,8 +182,14 @@ function dispatchLocale(url, store, tenant) {
  * @returns {Promise}
  */
 export function getLocale(okapiUrl, store, tenant) {
+  const query = [
+    'module==ORG',
+    'configName == localeSettings',
+    '(cql.allRecords=1 NOT userId="" NOT code="")'
+  ].join(' AND ');
+
   return dispatchLocale(
-    `${okapiUrl}/configurations/entries?query=(module==ORG and configName==localeSettings)`,
+    `${okapiUrl}/configurations/entries?query=(${query})`,
     store,
     tenant
   );


### PR DESCRIPTION
The additional clause
```
(cql.allRecords=1 NOT userId="" NOT code="")
```
guarantees the response will contain only a single row. Without that clause, the clause was limited to
```
module==ORG and configName==localeSettings
```
which allowed it to be potentially be polluted by other rows that included `userId` or `code` values, meaning the result was non-deterministic.

Refs [STCOR-675](https://issues.folio.org/browse/STCOR-675)