### PR TITLE
STCOR-684 list elements need a key prop. it's the law.

### DIFF
--- a/src/Pluggable.js
+++ b/src/Pluggable.js
@@ -36,7 +36,7 @@ const Pluggable = (props) => {
 
   if (cachedPlugins.length) {
     return cachedPlugins.map(({ plugin, Child }) => (
-      <ModuleHierarchyProvider module={plugin}>
+      <ModuleHierarchyProvider module={plugin} key={plugin}>
         <Child {...props} actAs="plugin" />
       </ModuleHierarchyProvider>
     ));


### PR DESCRIPTION
Provide `key` on children of an array during render. [It's the law](https://reactjs.org/docs/lists-and-keys.html#keys).

Refs [STCOR-684](https://issues.folio.org/browse/STCOR-684)