### PR TITLE
STCOR-650 remove setServicePoints, setCurServicePoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * PasswordValidationField swallows error messages from API queries. Fixes STCOR-657.
 * Guarantee a single-row response to the tenant's locale-config query. Fixes STCOR-675.
 * *BREAKING*: Remove SWR, a POC that never took off. Refs STCOR-516, STCOR-611.
-* Upgrade `react-redux` to `v8`. Refs STCOR-678.
+* *BREAKING*: Upgrade `react-redux` to `v8`. Refs STCOR-678.
+* *BREAKING*: Remove `setServicePoints`, `setCurServicePoint`. Refs STCOR-650, UISP-32.
 
 ## [8.3.0](https://github.com/folio-org/stripes-core/tree/v8.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.2.0...v8.3.0)

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ export { useModules } from './src/ModulesContext';
 export { withModule, withModules } from './src/components/Modules';
 export { default as stripesConnect } from './src/stripesConnect';
 export { default as Pluggable } from './src/Pluggable';
-export { setServicePoints, setCurServicePoint } from './src/loginServices';
 export { updateUser } from './src/loginServices';
 export { default as coreEvents } from './src/events';
 export { default as useOkapiKy } from './src/useOkapiKy';

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -21,8 +21,6 @@ import {
   setServerDown,
   setSessionData,
   setLoginData,
-  setCurrentServicePoint,
-  setUserServicePoints,
   updateCurrentUser,
 } from './okapiActions';
 import processBadResponse from './processBadResponse';
@@ -589,46 +587,6 @@ export function requestSSOLogin(okapiUrl, tenant) {
     body: JSON.stringify({ stripesUrl }),
   })
     .then(resp => processSSOLoginResponse(resp));
-}
-
-/**
- * setCurServicePoint
- * 1. store the given service-point as the current one in locale storage,
- * 2. dispatch the current service-point
- * @param {redux store} store
- * @param {object} servicePoint
- *
- * @returns {Promise}
- */
-export function setCurServicePoint(store, servicePoint) {
-  return localforage.getItem('okapiSess')
-    .then((sess) => {
-      sess.user.curServicePoint = servicePoint;
-      return localforage.setItem('okapiSess', sess);
-    })
-    .then(() => {
-      store.dispatch(setCurrentServicePoint(servicePoint));
-    });
-}
-
-/**
- * setServicePoints
- * 1. store the given list in locale storage,
- * 2. dispatch the list of service-points
- * @param {redux store} store redux store
- * @param {Array} servicePoints
- *
- * @returns {Promise}
- */
-export function setServicePoints(store, servicePoints) {
-  return localforage.getItem('okapiSess')
-    .then((sess) => {
-      sess.user.servicePoints = servicePoints;
-      return localforage.setItem('okapiSess', sess);
-    })
-    .then(() => {
-      store.dispatch(setUserServicePoints(servicePoints));
-    });
 }
 
 /**

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -1,12 +1,10 @@
-import localforage from 'localforage';
+// import localforage from 'localforage';
 
 import {
   createOkapiSession,
   handleLoginError,
   loadTranslations,
   processOkapiSession,
-  setCurServicePoint,
-  setServicePoints,
   supportedLocales,
   supportedNumberingSystems,
   updateUser,
@@ -17,20 +15,18 @@ import {
   clearCurrentUser,
   setCurrentPerms,
   setLocale,
-  setTimezone,
-  setCurrency,
-  setPlugins,
-  setBindings,
-  setTranslations,
+  // setTimezone,
+  // setCurrency,
+  // setPlugins,
+  // setBindings,
+  // setTranslations,
   clearOkapiToken,
   setAuthError,
-  checkSSO,
+  // checkSSO,
   setOkapiReady,
   setServerDown,
   setSessionData,
   setLoginData,
-  setCurrentServicePoint,
-  setUserServicePoints,
   updateCurrentUser,
 } from './okapiActions';
 
@@ -218,28 +214,6 @@ describe('processOkapiSession', () => {
 
     expect(store.dispatch).toHaveBeenCalledWith(setOkapiReady());
     expect(store.dispatch).toHaveBeenCalledWith(setAuthError([defaultErrors.DEFAULT_LOGIN_CLIENT_ERROR]));
-  });
-});
-
-describe('setCurServicePoint', () => {
-  it('dispatches setCurrentServicePoint', async () => {
-    const store = {
-      dispatch: jest.fn(),
-    };
-    const sp = 'monkey-bagel';
-    await setCurServicePoint(store, sp);
-    expect(store.dispatch).toHaveBeenCalledWith(setCurrentServicePoint(sp));
-  });
-});
-
-describe('setServicePoints', () => {
-  it('dispatches setUserServicePoints', async () => {
-    const store = {
-      dispatch: jest.fn(),
-    };
-    const data = ['thunder', 'chicken'];
-    await setServicePoints(store, data);
-    expect(store.dispatch).toHaveBeenCalledWith(setUserServicePoints(data));
   });
 });
 

--- a/src/okapiActions.js
+++ b/src/okapiActions.js
@@ -114,20 +114,6 @@ function setSessionData(session) {
   };
 }
 
-function setCurrentServicePoint(servicePoint) {
-  return {
-    type: 'SET_CURRENT_SERVICE_POINT',
-    servicePoint,
-  };
-}
-
-function setUserServicePoints(servicePoints) {
-  return {
-    type: 'SET_USER_SERVICE_POINTS',
-    servicePoints,
-  };
-}
-
 function setLoginData(loginData) {
   return {
     type: 'SET_LOGIN_DATA',
@@ -150,7 +136,6 @@ export {
   setBindings,
   setCurrency,
   setCurrentPerms,
-  setCurrentServicePoint,
   setCurrentUser,
   setLocale,
   setLoginData,
@@ -162,6 +147,5 @@ export {
   setSinglePlugin,
   setTimezone,
   setTranslations,
-  setUserServicePoints,
   updateCurrentUser,
 };

--- a/src/okapiReducer.js
+++ b/src/okapiReducer.js
@@ -38,10 +38,6 @@ export default function okapiReducer(state = {}, action) {
       return Object.assign({}, state, { okapiReady: true });
     case 'SERVER_DOWN':
       return Object.assign({}, state, { serverDown: true });
-    case 'SET_CURRENT_SERVICE_POINT':
-      return { ...state, currentUser: { ...state.currentUser, curServicePoint: action.servicePoint } };
-    case 'SET_USER_SERVICE_POINTS':
-      return { ...state, currentUser: { ...state.currentUser, servicePoints: action.servicePoints } };
     case 'UPDATE_CURRENT_USER':
       return { ...state, currentUser: { ...state.currentUser, ...action.data } };
     default:


### PR DESCRIPTION
*BREAKING*:
Remove functions related to service points. Given this repo does not have a direct dependency on the `inventory` interface, it must not contain code that relies on values provided by that interface. Handling of service point data on login moved to ui-service-points in [UISP-32](https://issues.folio.org/browse/UISP-32), hence the corresponding functions that did that work here can now be removed.

Since these functions were publicly exported, this is a breaking change.

Refs [STCOR-650](https://issues.folio.org/browse/STCOR-650)