### PR TITLE
rename "stripes" in its different scopes

### DIFF
--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -47,7 +47,7 @@ const AppRoutes = ({ modules, stripes }) => {
     }).filter(x => x);
   }, [modules.app, stripes]);
 
-  return cachedModules.map(({ ModuleComponent, connect, module, name, moduleStripes, stripes, displayName }) => (
+  return cachedModules.map(({ ModuleComponent, connect, module, name, moduleStripes, stripes: propsStripes, displayName }) => (
     <Route
       path={module.route}
       key={module.route}
@@ -55,9 +55,9 @@ const AppRoutes = ({ modules, stripes }) => {
         const data = { displayName, name };
 
         // allow SELECT_MODULE handlers to intervene
-        const components = getEventHandlers(events.SELECT_MODULE, moduleStripes, modules.handler, data);
-        if (components.length) {
-          return components.map(HandlerComponent => (<HandlerComponent stripes={stripes} data={data} />));
+        const handlerComponents = getEventHandlers(events.SELECT_MODULE, moduleStripes, modules.handler, data);
+        if (handlerComponents.length) {
+          return handlerComponents.map(Handler => (<Handler stripes={propsStripes} data={data} />));
         }
 
         return (


### PR DESCRIPTION
Lint whines about `stripes` being declared in multiple scopes in this file. Effectively, we have three different incarnations of `stripes` here (ugh) which is still awful, but at least now they have three different names. All this change does is separate the names to avoid repeating the same name in multiple scopes; it shouldn't actually change any behavior.

We can handle this in a totally separate PR if folks think that would be better.