### PR TITLE
STCOR-680: App context menu does not fully close after switching from "MARC Authority" app to "Inventory"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-core
 
 ## 9.1.0 IN PROGRESS
+* Close app-context menu when its wrapper is undefined, which it will be when switching among apps. Fixes STCOR-680.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/src/components/MainNav/CurrentApp/AppContextMenu.js
+++ b/src/components/MainNav/CurrentApp/AppContextMenu.js
@@ -34,7 +34,7 @@ class AppContextMenu extends React.PureComponent {
   }
 
   render() {
-    const { children, onToggle } = this.props;
+    const { children, onToggle, open } = this.props;
     const menu = children(onToggle);
     const container = document.getElementById('App_context_dropdown_menu');
 
@@ -43,6 +43,8 @@ class AppContextMenu extends React.PureComponent {
         menu,
         container
       );
+    } else if (open) {
+      onToggle();
     }
 
     return null;


### PR DESCRIPTION
The app context dropdown remains open ([screencast](https://issues.folio.org/secure/attachment/56660/2023-01-23_15h04_55.mp4)) when switching from the `MARC Authority` app to `Inventory`. Because in the `Inventory` app, the [AppContextMenu](https://github.com/folio-org/ui-inventory/blob/master/src/index.js#L83) component is not rendered until the [DataProvider](https://github.com/folio-org/ui-inventory/blob/master/src/index.js#L75) has received all the requested data. Because in the [DropdownMenu](https://github.com/folio-org/stripes-components/blob/master/lib/DropdownMenu/DropdownMenu.js#L47) the [mouse listener](https://github.com/react-bootstrap/react-overlays/blob/master/src/useRootClose.ts#L111) in the `useRootClose` hook fires before the listener is [removed](https://github.com/react-bootstrap/react-overlays/blob/master/src/useRootClose.ts#L132) and thereby opens the dropdown. 

This issue can be addressed in two ways:
1) by calling `onToggle`, thereby setting the `open` state to `false` when `open` is `true` and the [container](https://github.com/folio-org/stripes-core/blob/master/src/components/MainNav/CurrentApp/AppContextMenu.js#L39) (`AppContextMenu`) is `undefined`.
2) by moving `AppContextMenu` outside `DataProvider` in `Inventory` [index.js](https://github.com/folio-org/ui-inventory/blob/master/src/index.js#L74). But in the future, we will need to make sure that new modules display the `AppContextMenu` component without waiting for any data to load.
```
<>
  <CommandList commands={defaultKeyboardShortcuts}>
    <HasCommand ... >
      <AppContextMenu>
        {(handleToggle) => ( ... )}
      </AppContextMenu>
      <DataProvider>
        <HoldingsProvider>
          <Switch>
            ...
          </Switch>
        </HoldingsProvider>
      </DataProvider>
    </HasCommand>
  </CommandList>
  {isShortcutsModalOpen && (
    <KeyboardShortcutsModal
      allCommands={defaultKeyboardShortcuts}
      onClose={toggleModal}
    />
  )}
</>
```

## Issues
[STCOR-680](https://issues.folio.org/browse/STCOR-680)

## Screencast



https://user-images.githubusercontent.com/77053927/217207698-85b64d46-9be9-4776-ada8-c0f70d5f3a0b.mp4




