### PR TITLE
STCOR-696: If you choose a numbering system and language in Settings > Tenant > Language and localization, saving the new values does not change the locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Close app-context menu when its wrapper is undefined, which it will be when switching among apps. Fixes STCOR-680.
 * Move `miragejs` to dev-deps; remove `clean` script and `rimraf`. Refs STCOR-668, STCOR-681.
+* If you choose a numbering system and language in Settings > Tenant > Language and localization, saving the new values does not change the locale. Fixes STCOR-696.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -107,6 +107,7 @@ export function loadTranslations(store, locale, defaultTranslations = {}) {
   // Since moment.js don't support translations like it or it-IT-u-nu-latn
   // we need to build string like it_IT for fetch call
   const loadedLocale = locale.replace('-', '_').split('-')[0];
+  const momentLocale = locale.split('-', 2).join('-');
 
   // react-intl provides things like pt-BR.
   // lokalise provides things like pt_BR.
@@ -125,8 +126,8 @@ export function loadTranslations(store, locale, defaultTranslations = {}) {
     // For moment, we want to import and load the most-specific
     // locale possible without the numbering system suffix,
     // e.g. it-IT if available, falling back to it if that fails.
-    import(`moment/locale/${locale}`).then(() => {
-      moment.locale(locale);
+    import(`moment/locale/${momentLocale}`).then(() => {
+      moment.locale(momentLocale);
     }).catch(() => {
       import(`moment/locale/${parentLocale}`).then(() => {
         moment.locale(parentLocale);

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -104,6 +104,9 @@ function canReadConfig(store) {
  */
 export function loadTranslations(store, locale, defaultTranslations = {}) {
   const parentLocale = locale.split('-')[0];
+  // Since moment.js don't support translations like it or it-IT-u-nu-latn
+  // we need to build string like it_IT for fetch call
+  const loadedLocale = locale.replace('-', '_').split('-')[0];
 
   // react-intl provides things like pt-BR.
   // lokalise provides things like pt_BR.
@@ -113,21 +116,32 @@ export function loadTranslations(store, locale, defaultTranslations = {}) {
 
   // Update dir- and lang-attributes on the HTML element
   // when the locale changes
-  document.documentElement.setAttribute('lang', parentLocale);
-  document.documentElement.setAttribute('dir', rtlDetect.getLangDir(locale));
+  document.documentElement.setAttribute('lang', locale);
+  document.documentElement.setAttribute('dir', rtlDetect.getLangDir(parentLocale));
 
   // Set locale for Moment.js (en is not importable as it is not stored separately)
   if (parentLocale === 'en') moment.locale(parentLocale);
   else {
-    import(`moment/locale/${parentLocale}`).then(() => {
-      moment.locale(parentLocale);
-    }).catch(e => {
-      // eslint-disable-next-line no-console
-      console.error(`Error loading locale ${parentLocale} for Moment.js`, e);
+    // For moment, we want to import and load the most-specific
+    // locale possible without the numbering system suffix,
+    // e.g. it-IT if available, falling back to it if that fails.
+    import(`moment/locale/${locale}`).then(() => {
+      moment.locale(locale);
+    }).catch(() => {
+      import(`moment/locale/${parentLocale}`).then(() => {
+        moment.locale(parentLocale);
+      }).catch(e => {
+        // eslint-disable-next-line no-console
+        console.error(`Error loading locale ${parentLocale} for Moment.js`, e);
+      });
     });
   }
 
-  return fetch(translations[region] ? translations[region] : translations[parentLocale])
+  // Here we put additional condition because languages
+  // like Japan we need to use like ja, but with numeric system
+  // Japan language builds like ja_u, that incorrect. We need to be safe from that bug.
+  return fetch(translations[region] ? translations[region] :
+    translations[loadedLocale] || translations[[parentLocale]])
     .then((response) => {
       if (response.ok) {
         response.json().then((stripesTranslations) => {


### PR DESCRIPTION
Ticket: [STCOR-696](https://issues.folio.org/browse/STCOR-696)
Goal: Fix bug when we choose language with numeric system fail with error in console and language not changing
Result: 

https://user-images.githubusercontent.com/72550466/220290773-9d9fdf98-e0db-4380-9635-460f94955fc3.mov

