### PR TITLE
STCOR-705 align stripes-connect's dev/peer versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Close app-context menu when its wrapper is undefined, which it will be when switching among apps. Fixes STCOR-680.
 * Move `miragejs` to dev-deps; remove `clean` script and `rimraf`. Refs STCOR-668, STCOR-681.
 * If you choose a numbering system and language in Settings > Tenant > Language and localization, saving the new values does not change the locale. Fixes STCOR-696.
+* Align version of `@folio/stripes-connect` in dev/peer deps. Refs STCOR-705.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "peerDependencies": {
     "@folio/stripes-components": "^11.0.0",
-    "@folio/stripes-connect": "^7.0.0",
+    "@folio/stripes-connect": "^8.1.0",
     "@folio/stripes-logger": "^1.0.0",
     "moment": "^2.29.0",
     "react": "^17.0.2",


### PR DESCRIPTION
Align the versions of stripes-connect referred to in package.json on the version that is part of stripes v8. This will prevent a noisy yarn warning during install at the application/platform level.

Refs [STCOR-705](https://issues.folio.org/browse/STCOR-705)