### PR TITLE
STCOR-711: Expose additional functionality so it can be consumed via other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Align version of `@folio/stripes-connect` in dev/peer deps. Refs STCOR-705.
 * Use 'Log in' consistently. Refs STCOR-697.
 * Unpin `moment` to reflect what is provided in platforms. Refs STCOR-706, STRIPES-678.
+* Expose additional functionality so it can be consumed via other modules. Refs STCOR-711.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 /* external utilities */
 export { ConnectContext as RootContext, withConnect as withRoot } from '@folio/stripes-connect';
-export { CalloutContext, useCallout, StripesContext } from './src/CalloutContext';
+export { CalloutContext, useCallout } from './src/CalloutContext';
 
 /* internal utilities */
 export { stripesShape } from './src/Stripes';
-export { withStripes, useStripes } from './src/StripesContext';
+export { withStripes, useStripes, StripesContext } from './src/StripesContext';
 export { useModules } from './src/ModulesContext';
 export { withModule, withModules } from './src/components/Modules';
 export { default as stripesConnect } from './src/stripesConnect';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* external utilities */
 export { ConnectContext as RootContext, withConnect as withRoot } from '@folio/stripes-connect';
-export { CalloutContext, useCallout } from './src/CalloutContext';
+export { CalloutContext, useCallout, StripesContext } from './src/CalloutContext';
 
 /* internal utilities */
 export { stripesShape } from './src/Stripes';
@@ -29,6 +29,8 @@ export {
   useModuleHierarchy,
   useNamespace,
   withNamespace,
+  LastVisitedContext,
+  withLastVisited,
 } from './src/components';
 
 /* misc */


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-711

This PR exposes `StripesContext`, `LastVisitedContext` and `withLastVisited` so the can be accessible via `@folio/stripes/core`