### PR TITLE
STCOR-689 STCOR-690 Support switch consortium active affiliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Unpin `moment` to reflect what is provided in platforms. Refs STCOR-706, STRIPES-678.
 * Expose additional functionality so it can be consumed via other modules. Refs STCOR-711.
 * Apps icons replaced with blue rectangle on apps menu. Refs STCOR-707.
+* Display consortium active affiliation in the profile dropdown trigger. Refs STCOR-689.
+* Support switch consortium active affiliation. Refs STCOR-690.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ export { useModules } from './src/ModulesContext';
 export { withModule, withModules } from './src/components/Modules';
 export { default as stripesConnect } from './src/stripesConnect';
 export { default as Pluggable } from './src/Pluggable';
-export { updateUser } from './src/loginServices';
+export { updateUser, updateTenant } from './src/loginServices';
 export { default as coreEvents } from './src/events';
 export { default as useOkapiKy } from './src/useOkapiKy';
 export { default as withOkapiKy } from './src/withOkapiKy';

--- a/src/components/HandlerManager/HandlerManager.js
+++ b/src/components/HandlerManager/HandlerManager.js
@@ -20,15 +20,8 @@ class HandlerManager extends React.Component {
   constructor(props) {
     super(props);
     const { event, stripes, modules, data } = props;
-    const uniqueModules = Object.values(modules)
-      .flat()
-      .filter((module, index, self) => {
-        return index === self.findIndex((m) => (
-          m.module === module.module
-        ));
-      });
 
-    this.components = getEventHandlers(event, stripes, uniqueModules, data);
+    this.components = getEventHandlers(event, stripes, modules.handler, data);
   }
 
   render() {

--- a/src/components/HandlerManager/HandlerManager.js
+++ b/src/components/HandlerManager/HandlerManager.js
@@ -20,7 +20,7 @@ class HandlerManager extends React.Component {
   constructor(props) {
     super(props);
     const { event, stripes, modules, data } = props;
-    this.components = getEventHandlers(event, stripes, modules.handler, data);
+    this.components = getEventHandlers(event, stripes, Object.values(modules).flat(), data);
   }
 
   render() {

--- a/src/components/HandlerManager/HandlerManager.js
+++ b/src/components/HandlerManager/HandlerManager.js
@@ -20,7 +20,15 @@ class HandlerManager extends React.Component {
   constructor(props) {
     super(props);
     const { event, stripes, modules, data } = props;
-    this.components = getEventHandlers(event, stripes, Object.values(modules).flat(), data);
+    const uniqueModules = Object.values(modules)
+      .flat()
+      .filter((module, index, self) => {
+        return index === self.findIndex((m) => (
+          m.module === module.module
+        ));
+      });
+
+    this.components = getEventHandlers(event, stripes, uniqueModules, data);
   }
 
   render() {

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.css
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.css
@@ -24,9 +24,16 @@
 
 .button__label {
   margin: 0 0.35rem;
-  display: inline-block;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: start;
   max-width: 15rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  
+  & span {
+    width: 100%;
+    text-align: start;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -79,7 +79,13 @@ class ProfileDropdown extends Component {
 
   getModulesWithLinks = () => {
     const { modules } = this.props;
-    return ([].concat(...Object.values(modules)))
+    return Object.values(modules)
+      .flat()
+      .filter((module, index, self) => {
+        return index === self.findIndex((m) => (
+          m.module === module.module
+        ));
+      })
       .filter(({ links }) => links && Array.isArray(links.userDropdown));
   }
 

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.js
@@ -261,10 +261,10 @@ class ProfileDropdown extends Component {
     const servicePointName = userData?.curServicePoint?.name;
     const tenantName = userData?.tenants?.find(({ id }) => id === okapi.tenant)?.name;
 
-    const withLabel = Boolean(servicePointName || tenantName);
+    const hasLabel = Boolean(servicePointName || tenantName);
 
     return (
-      withLabel ? (
+      hasLabel ? (
         <>
           <span className={css.button__label}>
             {tenantName && <span>{tenantName}</span>}

--- a/src/components/MainNav/ProfileDropdown/ProfileDropdown.test.js
+++ b/src/components/MainNav/ProfileDropdown/ProfileDropdown.test.js
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ModulesContext } from '../../../ModulesContext';
+import TestComponent from './ProfileDropdown';
+
+jest.unmock('@folio/stripes-components');
+jest.mock('currency-codes/data', () => ({ filter: () => [] }));
+
+const checkAction = jest.fn(() => true);
+const eventHandler = jest.fn(() => 'Handler content');
+const modules = {
+  app: [
+    {
+      displayName: 'Test app',
+      handlerName: 'eventHandler',
+      route: '/test',
+      links: {
+        userDropdown: [{
+          event: 'TEST_EVENT',
+          caption: 'Profile dropdown action',
+          check: 'checkAction',
+        }]
+      },
+      getModule: jest.fn(() => ({
+        checkAction,
+        eventHandler,
+      })),
+    },
+  ],
+};
+
+const tenant = 'test';
+const stripes = {
+  user: {
+    user: {
+      id: 'user-id',
+      tenants: [{
+        id: tenant,
+        name: 'Central office',
+      }]
+    },
+  },
+  okapi: {
+    tenant,
+  },
+};
+
+const defaultProps = {
+  onLogout: jest.fn(),
+  stripes,
+};
+
+const wrapper = ({ children }) => (
+  <MemoryRouter>
+    <ModulesContext.Provider value={modules}>
+      {children}
+    </ModulesContext.Provider>
+  </MemoryRouter>
+);
+
+const renderProfileDropdown = (props = {}) => render(
+  <TestComponent
+    {...defaultProps}
+    {...props}
+  />,
+  { wrapper },
+);
+
+describe('ProfileDropdown', () => {
+  it('should display current consortium (if enabled) in the dropdown trigger', () => {
+    renderProfileDropdown();
+
+    expect(screen.getByText('Central office')).toBeInTheDocument();
+  });
+
+  it('should display module profile dropdown item', () => {
+    renderProfileDropdown();
+
+    expect(checkAction).toBeCalled();
+    expect(screen.getByText('Profile dropdown action')).toBeInTheDocument();
+  });
+});

--- a/src/okapiReducer.js
+++ b/src/okapiReducer.js
@@ -25,8 +25,10 @@ export default function okapiReducer(state = {}, action) {
     case 'CLEAR_CURRENT_USER':
       return Object.assign({}, state, { currentUser: {}, currentPerms: {} });
     case 'SET_SESSION_DATA': {
-      const { perms, user, token } = action.session;
-      return { ...state, currentUser: user, currentPerms: perms, token };
+      const { perms, user, token, tenant } = action.session;
+      const sessionTenant = tenant || state.tenant;
+
+      return { ...state, currentUser: user, currentPerms: perms, token, tenant: sessionTenant };
     }
     case 'SET_AUTH_FAILURE':
       return Object.assign({}, state, { authFailure: action.message });

--- a/src/okapiReducer.test.js
+++ b/src/okapiReducer.test.js
@@ -13,4 +13,32 @@ describe('okapiReducer', () => {
     const o = okapiReducer(initialState, { type: 'UPDATE_CURRENT_USER', data });
     expect(o).toMatchObject({ ...initialState, currentUser: { ...data } });
   });
+
+  it('SET_SESSION_DATA', () => {
+    const initialState = {
+      perms: [],
+      user: {},
+      token: 'qwerty',
+      tenant: 'central',
+    };
+    const session = {
+      perms: ['users.collection.get'],
+      user: {
+        user: {
+          id: 'userId',
+          username: 'admin',
+        }
+      },
+      token: 'ytrewq',
+      tenant: 'institutional',
+    };
+    const o = okapiReducer(initialState, { type: 'SET_SESSION_DATA', session });
+    const { user, perms, ...rest } = session;
+    expect(o).toMatchObject({
+      ...initialState,
+      ...rest,
+      currentUser: user,
+      currentPerms: perms,
+    });
+  });
 });


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOR-689
https://issues.folio.org/browse/STCOR-690

As a central tenant of a consortium, it should be able to switch the current context to manage institutional tenants. Header `X-Okapi-Tenant` acts as a pointer to the current context when sending requests to the server.

---

If a user login into the consortium central tenant, he expects to see its name in the top-right corner of the screen (in the profile dropdown trigger, above a current SP name).

## Approach
- Validate user based on current tenant value stored in a session (if absent - use tenant from stripes configs);
- Expose `updateTenant` service, which will update the current tenant, fetch resources (perms, SPs and etc.) and update session;
- Allow `<HandlerManager>` to invoke handlers for other module types (`app`, `settings`);
- Render active tenant (affiliation) name in the profile dropdown trigger;
- Implement unit test;

<details open><summary>Preview</summary>
<p>

![firefox_Wtyh0AQ9Zx](https://user-images.githubusercontent.com/88109087/236771302-5c9e9560-c394-405a-b5f1-b7d573c5b858.gif)

</p>
</details> 
