### PR TITLE
STCOR-718 load remote translations

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -77,7 +77,7 @@ class RootWithIntl extends React.Component {
     return (
       <StripesContext.Provider value={stripes}>
         <CalloutContext.Provider value={this.state.callout}>
-          <RegistryLoader>
+          <RegistryLoader stripes={stripes}>
             <TitleManager>
               <HotKeys
                 keyMap={stripes.bindings}

--- a/src/components/RegistryLoader.js
+++ b/src/components/RegistryLoader.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
+import { setTranslations } from '../okapiActions';
 import { ModulesContext } from '../ModulesContext';
 import loadRemoteComponent from '../loadRemoteComponent';
 
@@ -20,28 +21,89 @@ const parseModules = (remotes) => {
 // TODO: pass it via stripes config
 const registryUrl = 'http://localhost:3001/registry';
 
-const RegistryLoader = ({ children }) => {
+const appTranslations = [];
+
+/**
+ * loadTranslations
+ * return a promise that fetches translations for the given app and then
+ * dispatches the translations.
+ * @param {redux store} store
+ * @param {string} locale
+ * @param {string} url
+ *
+ * @returns {Promise}
+ */
+const loadTranslations = (stripes, module) => {
+  const url = `${module.host}:${module.port}`;
+
+  const parentLocale = stripes.locale.split('-')[0];
+  // Since moment.js don't support translations like it or it-IT-u-nu-latn
+  // we need to build string like it_IT for fetch call
+  const loadedLocale = stripes.locale.replace('-', '_').split('-')[0];
+
+  // react-intl provides things like pt-BR.
+  // lokalise provides things like pt_BR.
+  // so we have to translate '-' to '_' because the translation libraries
+  // don't know how to talk to each other. sheesh.
+  const region = stripes.locale.replace('-', '_');
+
+  // Here we put additional condition because languages
+  // like Japan we need to use like ja, but with numeric system
+  // Japan language builds like ja_u, that incorrect. We need to be safe from that bug.
+  if (!appTranslations.includes(url)) {
+    appTranslations.push(url);
+    return fetch(`${url}/translations/${region}.json`)
+      .then((response) => {
+        if (response.ok) {
+          response.json().then((translations) => {
+            // translation entries look like "key: val"
+            // but we want "ui-${app}.key: val"
+            const prefix = module.name.replace('folio_', 'ui-');
+            const keyed = [];
+            Object.keys(translations).forEach(key => {
+              keyed[`${prefix}.${key}`] = translations[key];
+            });
+
+            console.log(`translations for ${prefix}`, keyed);
+            stripes.store.dispatch(setTranslations({ ...stripes.okapi.translations, ...keyed }));
+          });
+        }
+      });
+  } else {
+    console.log(`ALREADY loaded tx for ${module.name} from ${url}/translations/${region}.json`);
+    return Promise.resolve();
+  }
+};
+
+
+const RegistryLoader = ({ stripes, children }) => {
   const { formatMessage } = useIntl();
   const [modules, setModules] = useState();
 
   useEffect(() => {
-    const translateModule = (module) => ({
-      ...module,
-      displayName: module.displayName ? formatMessage({ id: module.displayName }) : undefined,
-    });
+    const translateModule = (module) => {
+      console.log(`translating ${module.module}`);
+      return loadTranslations(stripes, module).then(() => {
+        return {
+          ...module,
+          displayName: module.displayName ? formatMessage({ id: module.displayName }) : undefined,
+        };
+      });
+      // await loadTranslations(stripes, module, appTranslations);
+    };
 
-    const translateModules = ({ app, plugin, settings, handler }) => ({
-      app: app.map(translateModule),
-      plugin: plugin.map(translateModule),
-      settings: settings.map(translateModule),
-      handler: handler.map(translateModule),
+    const translateModules = async ({ app, plugin, settings, handler }) => ({
+      app: await Promise.all(app.map(translateModule)),
+      plugin: await Promise.all(plugin.map(translateModule)),
+      settings: await Promise.all(settings.map(translateModule)),
+      handler: await Promise.all(handler.map(translateModule)),
     });
 
     const fetchRegistry = async () => {
       const response = await fetch(registryUrl);
       const registry = await response.json();
       const remotes = Object.entries(registry.remotes).map(([name, metadata]) => ({ name, ...metadata }));
-      const parsedModules = translateModules(parseModules(remotes));
+      const parsedModules = await translateModules(parseModules(remotes));
       const { handler: handlerModules } = parsedModules;
 
       // prefetch all handlers so they can be executed in a sync way.
@@ -72,7 +134,8 @@ RegistryLoader.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
     PropTypes.func,
-  ])
+  ]),
+  stripes: PropTypes.object.isRequired,
 };
 
 

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -144,7 +144,7 @@ class Root extends Component {
       <ErrorBoundary>
         <ConnectContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store }}>
           <ApolloProvider client={this.apolloClient}>
-            <QueryClientProvider client={this.reactQueryClient}>
+            <QueryClientProvider client={this.reactQueryClient} contextSharing={true} >
               <IntlProvider
                 locale={locale}
                 key={locale}

--- a/src/okapiReducer.js
+++ b/src/okapiReducer.js
@@ -31,7 +31,7 @@ export default function okapiReducer(state = {}, action) {
     case 'SET_AUTH_FAILURE':
       return Object.assign({}, state, { authFailure: action.message });
     case 'SET_TRANSLATIONS':
-      return Object.assign({}, state, { translations: action.translations });
+      return { ...state, translations: { ...state.translations, ...action.translations } };
     case 'CHECK_SSO':
       return Object.assign({}, state, { ssoEnabled: action.ssoEnabled });
     case 'OKAPI_READY':


### PR DESCRIPTION
Load translations when loading remote modules. 

App-icon sizing is off now. Those must load before translations are processed. 

Refs [STCOR-718](https://issues.folio.org/browse/STCOR-718), [STRIPES-861](https://issues.folio.org/browse/STRIPES-861)