### PR TITLE
STCOR-724 Use tenant query param for password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Apps icons replaced with blue rectangle on apps menu. Refs STCOR-707.
 * Display consortium active affiliation in the profile dropdown trigger. Refs STCOR-689.
 * Support switch consortium active affiliation. Refs STCOR-690.
+* Use tenant query param for password reset. Refs STCOR-724.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { connect as reduxConnect } from 'react-redux';
+import queryString from 'query-string';
 
 import processBadResponse from '../../processBadResponse';
 import { stripesShape } from '../../Stripes';
@@ -16,6 +17,9 @@ import OrganizationLogo from '../OrganizationLogo';
 class CreateResetPasswordControl extends Component {
   static propTypes = {
     authFailure: PropTypes.arrayOf(PropTypes.object),
+    location: PropTypes.shape({
+      search: PropTypes.string.isRequired,
+    }),
     match: PropTypes.shape({
       params: PropTypes.shape({
         token: PropTypes.string.isRequired,
@@ -85,12 +89,28 @@ class CreateResetPasswordControl extends Component {
     }
   };
 
+  getTenant = () => {
+    const {
+      stripes: {
+        okapi: {
+          tenant: originalTenant,
+        }
+      },
+      location: {
+        search,
+      },
+    } = this.props;
+
+    const tenant = search ? queryString.parse(search).tenant : undefined;
+
+    return tenant || originalTenant;
+  }
+
   makeCall = (body) => {
     const {
       stripes: {
         okapi: {
           url,
-          tenant,
         }
       },
       match: {
@@ -109,7 +129,7 @@ class CreateResetPasswordControl extends Component {
       headers: {
         'Content-Type': 'application/json',
         'x-okapi-token': token,
-        'x-okapi-tenant': tenant,
+        'x-okapi-tenant': this.getTenant(),
       },
       ...(body && { body: JSON.stringify(body) }),
     })

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -2,17 +2,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { connect as reduxConnect } from 'react-redux';
-import queryString from 'query-string';
 
 import processBadResponse from '../../processBadResponse';
 import { stripesShape } from '../../Stripes';
 import { setAuthError } from '../../okapiActions';
 import { defaultErrors } from '../../constants';
+import OrganizationLogo from '../OrganizationLogo';
 
 import CreateResetPassword from './CreateResetPassword';
 import PasswordHasNotChanged from './components/PasswordHasNotChanged';
 import PasswordSuccessfullyChanged from './components/PasswordSuccessfullyChanged';
-import OrganizationLogo from '../OrganizationLogo';
+import { getTenant } from './utils';
 
 class CreateResetPasswordControl extends Component {
   static propTypes = {
@@ -89,30 +89,10 @@ class CreateResetPasswordControl extends Component {
     }
   };
 
-  getTenant = () => {
-    const {
-      stripes: {
-        okapi: {
-          tenant: originalTenant,
-        }
-      },
-      location: {
-        search,
-      },
-    } = this.props;
-
-    const tenant = search ? queryString.parse(search).tenant : undefined;
-
-    return tenant || originalTenant;
-  }
-
   makeCall = (body) => {
     const {
-      stripes: {
-        okapi: {
-          url,
-        }
-      },
+      stripes,
+      location,
       match: {
         params: {
           token,
@@ -121,6 +101,11 @@ class CreateResetPasswordControl extends Component {
       handleBadResponse,
     } = this.props;
     const { isValidToken } = this.state;
+    const {
+      okapi: {
+        url,
+      },
+    } = stripes;
 
     const path = `${url}/bl-users/password-reset/${isValidToken ? 'reset' : 'validate'}`;
 
@@ -129,7 +114,7 @@ class CreateResetPasswordControl extends Component {
       headers: {
         'Content-Type': 'application/json',
         'x-okapi-token': token,
-        'x-okapi-tenant': this.getTenant(),
+        'x-okapi-tenant': getTenant(location),
       },
       ...(body && { body: JSON.stringify(body) }),
     })

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -114,7 +114,7 @@ class CreateResetPasswordControl extends Component {
       headers: {
         'Content-Type': 'application/json',
         'x-okapi-token': token,
-        'x-okapi-tenant': getTenant(location),
+        'x-okapi-tenant': getTenant(stripes, location),
       },
       ...(body && { body: JSON.stringify(body) }),
     })

--- a/src/components/CreateResetPassword/utils.js
+++ b/src/components/CreateResetPassword/utils.js
@@ -1,0 +1,6 @@
+import queryString from 'query-string';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getTenant = (stripes, location) => {
+  return queryString.parse(location.search).tenant || stripes.okapi.tenant;
+};

--- a/src/components/CreateResetPassword/utils.test.js
+++ b/src/components/CreateResetPassword/utils.test.js
@@ -1,0 +1,23 @@
+import { getTenant } from './utils';
+
+describe('CreateResetPassword utils', () => {
+  describe('getTenant', () => {
+    const searchTenant = 'searchTenant';
+    const okapiTenant = 'okapiTenant';
+
+    const stripes = {
+      okapi: { tenant: okapiTenant },
+    };
+
+    it('should return tenant value from location ?search when defined', () => {
+      expect(getTenant(stripes, { search: `?tenant=${searchTenant}` })).toBe(searchTenant);
+      expect(getTenant(stripes, { search: `tenant=${searchTenant}` })).toBe(searchTenant);
+    });
+
+    it('should return tenant value from okapi when location search is empty', () => {
+      expect(getTenant(stripes, { search: '' })).toBe(okapiTenant);
+      expect(getTenant(stripes, { search: undefined })).toBe(okapiTenant);
+      expect(getTenant(stripes, { search: null })).toBe(okapiTenant);
+    });
+  });
+});


### PR DESCRIPTION
purpose:
for consortia we have one UI bundle for central tenant as a result there is no way to identify correct tenant to reset password
https://issues.folio.org/browse/STCOR-724

approach:
BE defines tenant in query param that can be used in headers, in case it's not defined (old links) bundle tenant is used instead