### PR TITLE
STCOR-733 Added new isUserInCentralTenant helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Use tenant query param for password reset. Refs STCOR-724.
 * Improve login error message when back-end not ready. Refs STCOR-723.
 * Replace `align-items: start` with `flex-start`; it is more widely supported. Refs STCOR-722.
+* Added `consortiaServices` utils to hold common consortia helpers. Refs STCOR-733.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/index.js
+++ b/index.js
@@ -39,5 +39,6 @@ export {
 export { supportedLocales } from './src/loginServices';
 export { supportedNumberingSystems } from './src/loginServices';
 export { userLocaleConfig } from './src/loginServices';
+export * from './src/consortiaServices';
 export { default as queryLimit } from './src/queryLimit';
 export { default as init } from './src/init';

--- a/src/consortiaServices.js
+++ b/src/consortiaServices.js
@@ -1,0 +1,17 @@
+/* eslint-disable import/prefer-default-export */
+
+export function checkIfUserInCentralTenant(stripes) {
+  if (!stripes.hasInterface('consortia')) {
+    return false;
+  }
+
+  return stripes.okapi.tenant === stripes.user.user?.consortium?.centralTenantId;
+}
+
+export function checkIfUserInMemberTenant(stripes) {
+  if (!stripes.hasInterface('consortia')) {
+    return false;
+  }
+
+  return stripes.okapi.tenant !== stripes.user.user?.consortium?.centralTenantId;
+}

--- a/src/consortiaServices.test.js
+++ b/src/consortiaServices.test.js
@@ -1,0 +1,110 @@
+import {
+  checkIfUserInCentralTenant,
+  checkIfUserInMemberTenant,
+} from './consortiaServices';
+
+describe('consortiaServices', () => {
+  describe('checkIfUserInCentralTenant', () => {
+    describe('when consortia interface is not available', () => {
+      it('should return false', () => {
+        const stripes = {
+          hasInterface: jest.fn().mockReturnValue(false),
+        };
+
+        expect(checkIfUserInCentralTenant(stripes)).toBeFalsy();
+      });
+    });
+
+    describe('when tenant matches central tenant id', () => {
+      it('should return true', () => {
+        const stripes = {
+          hasInterface: jest.fn().mockReturnValue(true),
+          okapi: {
+            tenant: 'consortia',
+          },
+          user: {
+            user: {
+              consortium: {
+                centralTenantId: 'consortia',
+              },
+            },
+          },
+        };
+
+        expect(checkIfUserInCentralTenant(stripes)).toBeTruthy();
+      });
+    });
+
+    describe('when tenant does not match central tenant id', () => {
+      it('should return false', () => {
+        const stripes = {
+          hasInterface: jest.fn().mockReturnValue(true),
+          okapi: {
+            tenant: 'university',
+          },
+          user: {
+            user: {
+              consortium: {
+                centralTenantId: 'consortia',
+              },
+            },
+          },
+        };
+
+        expect(checkIfUserInCentralTenant(stripes)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('checkIfUserInMemberTenant', () => {
+    describe('when consortia interface is not available', () => {
+      it('should return false', () => {
+        const stripes = {
+          hasInterface: jest.fn().mockReturnValue(false),
+        };
+
+        expect(checkIfUserInMemberTenant(stripes)).toBeFalsy();
+      });
+    });
+
+    describe('when tenant matches central tenant id', () => {
+      it('should return false', () => {
+        const stripes = {
+          hasInterface: jest.fn().mockReturnValue(true),
+          okapi: {
+            tenant: 'consortia',
+          },
+          user: {
+            user: {
+              consortium: {
+                centralTenantId: 'consortia',
+              },
+            },
+          },
+        };
+
+        expect(checkIfUserInMemberTenant(stripes)).toBeFalsy();
+      });
+    });
+
+    describe('when tenant does not match central tenant id', () => {
+      it('should return true', () => {
+        const stripes = {
+          hasInterface: jest.fn().mockReturnValue(true),
+          okapi: {
+            tenant: 'university',
+          },
+          user: {
+            user: {
+              consortium: {
+                centralTenantId: 'consortia',
+              },
+            },
+          },
+        };
+
+        expect(checkIfUserInMemberTenant(stripes)).toBeTruthy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
With many modules implementing Consortia features it's a good idea to move common code into shared modules
Added two functions:
 - `checkIfUserInCentralTenant` checks if user is in a central tenant
- `checkIfUserInMemberTenant` checks if user is in a member tenant

We need two because in a case when we're not in a Consortia environment both will return `false`.
So code like:
```js
if (!checkIfUserInCentralTenant(stripes)) {
  // do something only for member tenants
}
```
will do `something` on non-Consortia environment because `checkIfUserInCentralTenant` returns `false` when the interface is not present

## Issues
[STCOR-733](https://issues.folio.org/browse/STCOR-733)