### PR TITLE
STCOR-736: Add `checkIfSharedRecord` and `checkIfLocalRecord` to consortia utils to store common helpers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Replace `align-items: start` with `flex-start`; it is more widely supported. Refs STCOR-722.
 * *BREAKING* bump `react` to `v18`, and dev-deps accordingly. Refs STCOR-729.
 * Added `consortiaServices` utils to hold common consortia helpers. Refs STCOR-733.
+* Add `checkIfSharedRecord` and `checkIfLocalRecord` to consortia utils to store common helpers. Refs STCOR-736.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/src/consortiaServices.js
+++ b/src/consortiaServices.js
@@ -15,3 +15,11 @@ export function checkIfUserInMemberTenant(stripes) {
 
   return stripes.okapi.tenant !== stripes.user.user?.consortium?.centralTenantId;
 }
+
+export function checkIfSharedRecord(stripes, source) {
+  return source.includes('CONSORTIUM-') || checkIfUserInCentralTenant(stripes);
+}
+
+export function checkIfLocalRecord(stripes, source) {
+  return ['MARC', 'FOLIO'].includes(source) && checkIfUserInMemberTenant(stripes);
+}

--- a/src/consortiaServices.test.js
+++ b/src/consortiaServices.test.js
@@ -1,6 +1,8 @@
 import {
   checkIfUserInCentralTenant,
   checkIfUserInMemberTenant,
+  checkIfSharedRecord,
+  checkIfLocalRecord,
 } from './consortiaServices';
 
 describe('consortiaServices', () => {
@@ -104,6 +106,61 @@ describe('consortiaServices', () => {
         };
 
         expect(checkIfUserInMemberTenant(stripes)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('checkIfSharedRecord', () => {
+    describe('when source contains the `CONSORTIUM-` prefix', () => {
+      it('should return true', () => {
+        const source = 'CONSORTIUM-FOLIO';
+        const stripes = {};
+
+        expect(checkIfSharedRecord(stripes, source)).toBeTruthy();
+      });
+    });
+
+    describe('when the user is in the central tenant', () => {
+      it('should return true', () => {
+        const source = 'FOLIO';
+        const stripes = {
+          hasInterface: jest.fn().mockReturnValue(true),
+          okapi: {
+            tenant: 'consortia',
+          },
+          user: {
+            user: {
+              consortium: {
+                centralTenantId: 'consortia',
+              },
+            },
+          },
+        };
+
+        expect(checkIfSharedRecord(stripes, source)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('checkIfLocalRecord', () => {
+    describe('when the source is either `FOLIO` or `MARC` and the user is in a member tenant', () => {
+      it('should return true', () => {
+        const source = 'FOLIO';
+        const stripes = {
+          hasInterface: jest.fn().mockReturnValue(true),
+          okapi: {
+            tenant: 'university',
+          },
+          user: {
+            user: {
+              consortium: {
+                centralTenantId: 'consortia',
+              },
+            },
+          },
+        };
+
+        expect(checkIfLocalRecord(stripes, source)).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
## Purpose
Add `checkIfSharedRecord` and `checkIfLocalRecord` to consortia utils to store common helpers.

## Issues
[STCOR-736](https://issues.folio.org/browse/STCOR-736)