### PR TITLE
STCOR-739 Reduce duplicated requests when changing tenant in consortium

### DIFF
--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -1,6 +1,7 @@
 import localforage from 'localforage';
 
 import {
+  spreadUserWithPerms,
   createOkapiSession,
   handleLoginError,
   loadTranslations,
@@ -329,39 +330,29 @@ describe('updateTenant', () => {
   const okapi = {
     currentPerms: {},
   };
-  const store = {
-    dispatch: jest.fn(),
-    getState: jest.fn().mockReturnValue({ okapi }),
-  };
   const tenant = 'test';
   const data = {
-    user: {},
+    user: {
+      id: 'userId',
+      username: 'testuser',
+    },
     permissions: {
-      permissions: [],
+      permissions: [{ permissionName: 'test.permissions' }],
     },
   };
 
   beforeEach(() => {
     localforage.setItem.mockClear();
-    store.dispatch.mockClear();
   });
 
-  it('should set tenant in session', async () => {
+  it('should set tenant and updated user in session', async () => {
     mockFetchSuccess(data);
-    await updateTenant(okapi, store, tenant);
+    await updateTenant(okapi, tenant);
     mockFetchCleanUp();
 
     expect(localforage.setItem).toHaveBeenCalledWith('okapiSess', {
-      user: {},
+      ...spreadUserWithPerms(data),
       tenant,
     });
-  });
-
-  it('should "relogin" user with new tenant', async () => {
-    mockFetchSuccess(data);
-    await updateTenant(okapi, store, tenant);
-    mockFetchCleanUp();
-
-    expect(store.dispatch).toHaveBeenCalledWith(setLoginData(data));
   });
 });


### PR DESCRIPTION
**purpose**: after UAT it was reported that change tenant process is pretty slow, and it was found that initial implementation (https://issues.folio.org/browse/STCOR-690) is not so efficient as it could be because it loads translations etc twice, additionally related data loading triggers storage changes as a result whole page is unnecessary for "change tenant" rerendered several times
**approach**: split existing functionality into smaller pieces and reuse it in `updateTenant` method to just update `okapiSession`, in this case addition data will be loaded 1 time and without any rerenders

Note: changelog is not updated as it's just a tech adjustment of original implementation, so changelog already contains required info