### PR TITLE
STCOR-738 use NodeJS v18 in CI

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -27,7 +27,7 @@ jobs:
       PUBLISH_MOD_DESCRIPTOR: 'true'
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       BIGTEST_JUNIT_OUTPUT_DIR: 'artifacts/runTest'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -23,7 +23,7 @@ jobs:
       PUBLISH_MOD_DESCRIPTOR: 'true'
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       BIGTEST_JUNIT_OUTPUT_DIR: 'artifacts/runTest'


### PR DESCRIPTION
In CI, bump NodeJS v16 to v18.

Refs [STCOR-738](https://issues.folio.org/browse/STCOR-738)