### PR TITLE
STCOR-671 handle access-control via cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Bump `@formatjs/cli` to `^6.1.3`.
 * Forgot password and Forgot username : add placeholder to input box. Refs STCOR-728.
 * Include `yarn.lock`. Refs STCOR-679.
+* *BREAKING* Handle access-control via cookies. Refs STCOR-484.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "graphql": "^16.0.0",
     "history": "^4.6.3",
     "hoist-non-react-statics": "^3.3.0",
+    "inactivity-timer": "^1.0.0",
     "jwt-decode": "^3.1.2",
     "ky": "^0.23.0",
     "localforage": "^1.5.6",

--- a/src/StripesSession.js
+++ b/src/StripesSession.js
@@ -1,0 +1,217 @@
+import { okapi } from 'stripes-config';
+import createInactivityTimer from 'inactivity-timer';
+
+import {
+  setAuthError,
+} from './okapiActions';
+import { defaultErrors } from './constants';
+
+/**
+ * StripesSession
+ * Given access- and refresh-token expiration timestamps, start a timer
+ * to generate an API request to keep the cookie fresh as long as there
+ * has been some keyboard/mouse activity in the meantime.
+ *
+ * If the cookie cannot be renewed, dispatch clearCurrentUser and
+ * clearOkapiToken.
+ *
+ * For any error condition, dispatch setAuthError as well as clearCurrentUser
+ * and clearOkapiToken.
+ *
+ * @param {redux store} store
+ * @param {object} tokenExpiration shaped like:
+ * {
+ *   'accessTokenExpiration': 'yyyy-mm-ddThh:ii:ssZ',
+ *   'refreshTokenExpiration': 'yyyy-mm-ddThh:ii:ssZ',
+ * }
+ * @param {function} function to call on session expiration
+ * @param {number} ttlFraction how much of the access-token's TTL should expire before refreshing
+ */
+export default class StripesSession {
+  constructor(store, tokenExpiration, onLogout, ttlFraction = 0.9) {
+    console.log('StripesSession init');
+    this.store = store;
+    this.onLogout = onLogout;
+    this.ttlFraction = ttlFraction;
+
+    this.processAuthnResponse(tokenExpiration);
+
+    // logout via clearSession() when the access token expires
+    //
+    // configure an inactivity timer that fires when the access-token expires
+    // if there hasn't been any keyboard or mouse activity. when activity
+    // is detected, update the last-access timestamp and signal the timer
+    // to keep the session active.
+    //
+    const ttl = Math.floor(new Date(tokenExpiration.accessTokenExpiration).getTime() / 1000) - this.now();
+    console.log('clearing session in seconds: ', ttl);
+    this.inactivityTimer = createInactivityTimer(`${ttl}s`, () => {
+      this.clearSession();
+    });
+
+    // on any event, set the last-access timestamp and restart the inactivity timer.
+    // if the access token has expired, renew it.
+    ['keydown', 'mousedown'].forEach((event) => {
+      document.addEventListener(event, () => {
+        this.setLastAccess();
+        if (this.inactivityTimer) {
+          this.inactivityTimer.signal();
+        }
+
+        if (!this.accessTokenIsValid()) {
+          this.exchangeRefresh();
+        }
+      });
+    });
+  }
+
+  /**
+   * clearSession
+   * End the session, logging the user out. Stop listening for activity,
+   * dispatch clear-user, dispatch clear-token.
+   */
+  clearSession = () => {
+    console.trace('StripesSession::clearSession');
+    if (this.inactivityTimer) {
+      this.inactivityTimer.clear();
+    }
+    return this.onLogout(this.store);
+  }
+
+  /**
+   * processAuthnResponse
+   * Store an authentication response and set a timer to exchange the refresh-
+   * token when the refresh-token is most of through its TTL. Wait, wait, wait, the
+   * ACCESS-token? Yeah. Token-exchange is an async process, but all the legacy
+   * code here just retrieves the token from the store in a sync process, meaning
+   * there is no easy way to force it to await the resolution of that promise.
+   * In other words, we just have to keep the access-token fresh because if it
+   * goes stale, we don't have any mechanism to cause legacy code to wait while
+   * we conduct the exchange.
+   *
+   * Kinda sucks, but what can you do?
+   *
+   * @param {object} { accessTokenExpiration, refreshTokenExpiration }
+   */
+  processAuthnResponse = (tokenExpiration) => {
+    console.log('StripesSession::processAuthnResponse', tokenExpiration);
+    Object.assign(this, tokenExpiration);
+
+    // save token expiration times
+    this.expiresAt = Math.floor(new Date(tokenExpiration.accessTokenExpiration).getTime() / 1000);
+    this.refreshExpiresAt = Math.floor(new Date(tokenExpiration.refreshTokenExpiration).getTime() / 1000);
+
+    this.setLastAccess();
+    this.setLastRefresh();
+
+    // configure next token-exchange
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+    }
+    const ttl = this.expiresAt - this.now();
+    console.log(`StripesSession::processAuthnResponse::setTimeout(${ttl * this.ttlFraction * 1000})`);
+    this.timeoutId = setTimeout(() => this.exchangeRefresh(), ttl * this.ttlFraction * 1000);
+  }
+
+  /**
+   * now
+   * Return epoch time in seconds
+   * @returns {number}
+   */
+  now = () => {
+    return Math.floor(new Date().getTime() / 1000);
+  }
+
+  /**
+   * setLastAccess
+   * Log activity, i.e. keep the session alive.
+   */
+  setLastAccess = () => {
+    this.lastAccess = this.now();
+  }
+
+  /**
+   * setLastRefresh
+   * Log the refresh-token's creation date so we can calculate when it expires.
+   */
+  setLastRefresh = () => {
+    this.lastRefresh = this.now();
+  }
+
+  /**
+   * accessTokenIsValid
+   * return true if the access token is still valid.
+   * @returns {boolean}
+   */
+  accessTokenIsValid = () => {
+    return this.now() < this.expiresAt;
+  };
+
+  /**
+   * refreshTokenIsValid
+   * return true if the refresh token is still valid.
+   * @returns {boolean}
+   */
+  refreshTokenIsValid = () => {
+    console.log(`StripesSession::refreshTokenIsValid:: ${this.now()} < ${this.refreshExpiresAt}`);
+    return this.now() < this.refreshExpiresAt;
+  };
+
+  /**
+   * sessionIsActive
+   * Return true if there has been activity since the refresh-token
+   * was received.
+   *
+   * @returns {boolean}
+   */
+  sessionIsActive = () => {
+    return this.lastAccess > this.lastRefresh;
+  }
+
+  /**
+   * exchangeRefresh
+   * Exchange the refresh token if the following are true:
+   * 1. session is not idle
+   * 2. refresh token is still valid
+   *
+   * for a new access token if the refresh token
+   * is still valid and there has been session access since the refresh token
+   * was instantiated.
+   */
+  exchangeRefresh = () => {
+    console.trace('StripesSession::exchangeRefresh');
+
+    if (this.sessionIsActive() && this.refreshTokenIsValid()) {
+      // flag that a refresh request is currently in process
+      fetch(`${okapi.url}/authn/refresh`, {
+        method: 'POST',
+        credentials: 'include',
+        mode: 'cors',
+      })
+        .then(response => {
+          if (response.ok) {
+            response.json()
+              .then(json => {
+                this.processAuthnResponse(json);
+              });
+          } else {
+            // if there are authn errors, warn about them. sorry, eslint.
+            // eslint-disable-next-line no-console
+            console.error('>>> ERROR IN REFRESH RESPONSE', response);
+            throw Error(response.statusText);
+          }
+        })
+        .catch(error => {
+          // if there are authn errors, warn about them. sorry, eslint.
+          // eslint-disable-next-line no-console
+          console.error('>>> ERROR IN REFRESH', error);
+          // @@ this.store.dispatch(setAuthError(error));
+          this.store.dispatch(setAuthError([defaultErrors.DEFAULT_LOGIN_CLIENT_ERROR]));
+          this.clearSession();
+        });
+    } else {
+      console.log(`>>> SESSION LOGOUT: exchangeRefresh: not active/not valid ${this.sessionIsActive()} && ${this.refreshTokenIsValid()}`);
+      this.clearSession();
+    }
+  }
+}

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -14,7 +14,7 @@ import { withModules } from '../Modules';
 import { LastVisitedContext } from '../LastVisited';
 import { clearOkapiToken, clearCurrentUser } from '../../okapiActions';
 import { resetStore } from '../../mainActions';
-import { getLocale } from '../../loginServices';
+import { getLocale, logout as sessionLogout } from '../../loginServices';
 import {
   updateQueryResource,
   getLocationQuery,
@@ -123,12 +123,8 @@ class MainNav extends Component {
   returnToLogin() {
     const { okapi } = this.store.getState();
 
-    return getLocale(okapi.url, this.store, okapi.tenant).then(() => {
-      this.store.dispatch(clearOkapiToken());
-      this.store.dispatch(clearCurrentUser());
-      this.store.dispatch(resetStore());
-      localforage.removeItem('okapiSess');
-    });
+    return getLocale(okapi.url, this.store, okapi.tenant)
+      .then(sessionLogout(this.store));
   }
 
   // return the user to the login screen, but after logging in they will be brought to the default screen.

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -1,9 +1,8 @@
 import { some } from 'lodash';
 
-function getHeaders(tenant, token) {
+function getHeaders(tenant) {
   return {
     'X-Okapi-Tenant': tenant,
-    'X-Okapi-Token': token,
     'Content-Type': 'application/json'
   };
 }
@@ -12,7 +11,9 @@ function fetchOkapiVersion(store) {
   const okapi = store.getState().okapi;
 
   return fetch(`${okapi.url}/_/version`, {
-    headers: getHeaders(okapi.tenant, okapi.token)
+    headers: getHeaders(okapi.tenant),
+    credentials: 'include',
+    mode: 'cors',
   }).then((response) => { // eslint-disable-line consistent-return
     if (response.status >= 400) {
       store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });
@@ -31,7 +32,9 @@ function fetchModules(store) {
   const okapi = store.getState().okapi;
 
   return fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules?full=true`, {
-    headers: getHeaders(okapi.tenant, okapi.token)
+    headers: getHeaders(okapi.tenant),
+    credentials: 'include',
+    mode: 'cors',
   }).then((response) => { // eslint-disable-line consistent-return
     if (response.status >= 400) {
       store.dispatch({ type: 'DISCOVERY_FAILURE', code: response.status });

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -4,6 +4,7 @@ import rtlDetect from 'rtl-detect';
 import moment from 'moment';
 
 import { discoverServices } from './discoverServices';
+import { resetStore } from './mainActions';
 
 import {
   clearCurrentUser,
@@ -24,6 +25,7 @@ import {
   updateCurrentUser,
 } from './okapiActions';
 import processBadResponse from './processBadResponse';
+import StripesSession from './StripesSession';
 
 // export supported locales, i.e. the languages we provide translations for
 export const supportedLocales = [
@@ -56,6 +58,8 @@ export const supportedLocales = [
   'zh-TW',  // chinese, taiwan
 ];
 
+const SESSION_NAME = 'okapiSess';
+
 // export supported numbering systems, i.e. the systems tenants may chose
 // for numeral display
 export const supportedNumberingSystems = [
@@ -69,10 +73,9 @@ export const userLocaleConfig = {
   'module': '@folio/stripes-core',
 };
 
-function getHeaders(tenant, token) {
+function getHeaders(tenant) {
   return {
     'X-Okapi-Tenant': tenant,
-    'X-Okapi-Token': token,
     'Content-Type': 'application/json',
   };
 }
@@ -164,8 +167,11 @@ export function loadTranslations(store, locale, defaultTranslations = {}) {
  * @returns {Promise}
  */
 function dispatchLocale(url, store, tenant) {
-  return fetch(url,
-    { headers: getHeaders(tenant, store.getState().okapi.token) })
+  return fetch(url, {
+    headers: getHeaders(tenant),
+    credentials: 'include',
+    mode: 'cors',
+  })
     .then((response) => {
       if (response.status === 200) {
         response.json().then((json) => {
@@ -240,8 +246,11 @@ export function getUserLocale(okapiUrl, store, tenant, userId) {
  * @returns {Promise}
  */
 export function getPlugins(okapiUrl, store, tenant) {
-  return fetch(`${okapiUrl}/configurations/entries?query=(module==PLUGINS)`,
-    { headers: getHeaders(tenant, store.getState().okapi.token) })
+  return fetch(`${okapiUrl}/configurations/entries?query=(module==PLUGINS)`, {
+    headers: getHeaders(tenant),
+    credentials: 'include',
+    mode: 'cors',
+  })
     .then((response) => {
       if (response.status < 400) {
         response.json().then((json) => {
@@ -266,8 +275,11 @@ export function getPlugins(okapiUrl, store, tenant) {
  * @returns {Promise}
  */
 export function getBindings(okapiUrl, store, tenant) {
-  return fetch(`${okapiUrl}/configurations/entries?query=(module==ORG and configName==bindings)`,
-    { headers: getHeaders(tenant, store.getState().okapi.token) })
+  return fetch(`${okapiUrl}/configurations/entries?query=(module==ORG and configName==bindings)`, {
+    headers: getHeaders(tenant),
+    credentials: 'include',
+    mode: 'cors',
+  })
     .then((response) => {
       let bindings = {};
       if (response.status >= 400) {
@@ -348,12 +360,26 @@ export function spreadUserWithPerms(userWithPerms) {
 }
 
 /**
+ * logout
+ * dispatch events to clear the store, then clear the session too.
+ *
+ * @param {object} redux store
+ *
+ * @returns {Promise}
+ */
+export async function logout(store) {
+  store.dispatch(clearOkapiToken());
+  store.dispatch(clearCurrentUser());
+  store.dispatch(resetStore());
+  return localforage.removeItem(SESSION_NAME);
+}
+
+/**
  * createOkapiSession
  * Remap the given data into a session object shaped like:
  * {
  *   user: { id, username, personal }
  *   perms: { permNameA: true, permNameB: true, ... }
- *   token: token
  * }
  * Dispatch the session object, then return a Promise that fetches
  * and dispatches tenant resources.
@@ -361,12 +387,11 @@ export function spreadUserWithPerms(userWithPerms) {
  * @param {*} okapiUrl
  * @param {*} store
  * @param {*} tenant
- * @param {*} token
  * @param {*} data
  *
  * @returns {Promise}
  */
-export function createOkapiSession(okapiUrl, store, tenant, token, data) {
+export function createOkapiSession(okapiUrl, store, tenant, data) {
   // clear any auth-n errors
   store.dispatch(setAuthError(null));
 
@@ -380,53 +405,29 @@ export function createOkapiSession(okapiUrl, store, tenant, token, data) {
 
   const sessionTenant = data.tenant || tenant;
   const okapiSess = {
-    token,
+    // @@ still gotta provide `token` because RootWithIntl relies on it
+    token: '>>> MAKE COOKIES, NOT TOKENS <<<',
     user,
     perms,
     tenant: sessionTenant,
+    tokenExpiration: data.tokenExpiration,
   };
 
+  // configure a StripesSession object which will set up a timer internally
+  // and auto-logout unless it detects user interaction
+  //
+  // eslint-disable-next-line no-unused-vars
+  const ss = new StripesSession(store, data.tokenExpiration, logout);
+
   return localforage.setItem('loginResponse', data)
-    .then(() => localforage.setItem('okapiSess', okapiSess))
+    .then(() => localforage.setItem(SESSION_NAME, okapiSess))
     .then(() => {
       store.dispatch(setSessionData(okapiSess));
       return loadResources(okapiUrl, store, sessionTenant, user.id);
     });
 }
 
-/**
- * validateUser
- * return a promise that fetches from bl-users/self.
- * if successful, dispatch the result to create a session
- * if not, clear the session and token.
- *
- * @param {string} okapiUrl
- * @param {redux store} store
- * @param {string} tenant
- * @param {object} session
- *
- * @returns {Promise}
- */
-export function validateUser(okapiUrl, store, tenant, session) {
-  const { token, user, perms, tenant: sessionTenant = tenant } = session;
 
-  return fetch(`${okapiUrl}/bl-users/_self`, { headers: getHeaders(sessionTenant, token) }).then((resp) => {
-    if (resp.ok) {
-      return resp.json().then((data) => {
-        store.dispatch(setLoginData(data));
-        store.dispatch(setSessionData({ token, user, perms, tenant: sessionTenant }));
-        return loadResources(okapiUrl, store, sessionTenant, user.id);
-      });
-    } else {
-      store.dispatch(clearCurrentUser());
-      store.dispatch(clearOkapiToken());
-      return localforage.removeItem('okapiSess');
-    }
-  }).catch((error) => {
-    store.dispatch(setServerDown());
-    return error;
-  });
-}
 
 /**
  * getSSOEnabled
@@ -438,7 +439,9 @@ export function validateUser(okapiUrl, store, tenant, session) {
  * @returns {Promise}
  */
 export function getSSOEnabled(okapiUrl, store, tenant) {
-  return fetch(`${okapiUrl}/saml/check`, { headers: { 'X-Okapi-Tenant': tenant, 'Accept': 'application/json' } })
+  return fetch(`${okapiUrl}/saml/check`, {
+    headers: { 'X-Okapi-Tenant': tenant, 'Accept': 'application/json' }
+  })
     .then((response) => {
       if (response.status >= 400) {
         store.dispatch(checkSSO(false));
@@ -502,7 +505,7 @@ function processSSOLoginResponse(resp) {
  * @returns {Promise} resolving to the response's JSON
  */
 export function handleLoginError(dispatch, resp) {
-  return localforage.removeItem('okapiSess')
+  return localforage.removeItem(SESSION_NAME)
     .then(() => processBadResponse(dispatch, resp))
     .then(responseBody => {
       dispatch(setOkapiReady());
@@ -518,18 +521,16 @@ export function handleLoginError(dispatch, resp) {
  * @param {redux store} store
  * @param {string} tenant
  * @param {Response} resp HTTP response
- * @param {string} ssoToken
  *
  * @returns {Promise} resolving with login response body, rejecting with, ummmmm
  */
-export function processOkapiSession(okapiUrl, store, tenant, resp, ssoToken) {
-  const token = resp.headers.get('X-Okapi-Token') || ssoToken;
+export function processOkapiSession(okapiUrl, store, tenant, resp) {
   const { dispatch } = store;
 
   if (resp.ok) {
     return resp.json()
       .then(json => {
-        return createOkapiSession(okapiUrl, store, tenant, token, json)
+        return createOkapiSession(okapiUrl, store, tenant, json)
           .then(() => json);
       })
       .then((json) => {
@@ -539,6 +540,53 @@ export function processOkapiSession(okapiUrl, store, tenant, resp, ssoToken) {
   } else {
     return handleLoginError(dispatch, resp);
   }
+}
+
+/**
+ * validateUser
+ * return a promise that fetches from bl-users/self.
+ * if successful, dispatch the result to create a session
+ * if not, clear the session and token.
+ *
+ * @param {string} okapiUrl
+ * @param {redux store} store
+ * @param {string} tenant
+ * @param {object} session
+ *
+ * @returns {Promise}
+ */
+export function validateUser(okapiUrl, store, tenant, session) {
+  const { user, perms, tenant: sessionTenant = tenant, token, tokenExpiration } = session;
+
+  return fetch(`${okapiUrl}/bl-users/_self`, {
+    headers: getHeaders(sessionTenant),
+    credentials: 'include',
+    mode: 'cors',
+  }).then((resp) => {
+    if (resp.ok) {
+      console.log('>>> validateUser::resp.ok');
+      return resp.json().then((data) => {
+        console.log('session', session);
+
+        // configure a StripesSession object which will set up a timer internally
+        // and auto-logout unless it detects user interaction
+        //
+        // eslint-disable-next-line no-unused-vars
+        const ss = new StripesSession(store, session.tokenExpiration, logout);
+
+        store.dispatch(setLoginData(data));
+        store.dispatch(setSessionData({ user, perms, tenant: sessionTenant, token, tokenExpiration }));
+        return loadResources(okapiUrl, store, sessionTenant, user.id);
+      });
+    } else {
+      console.error('>>> validateUser !resp.ok');
+      return logout(store);
+    }
+  }).catch((error) => {
+    console.error('validateUser', error);
+    store.dispatch(setServerDown());
+    return error;
+  });
 }
 
 /**
@@ -552,7 +600,7 @@ export function processOkapiSession(okapiUrl, store, tenant, resp, ssoToken) {
  * @param {string} tenant
  */
 export function checkOkapiSession(okapiUrl, store, tenant) {
-  localforage.getItem('okapiSess')
+  localforage.getItem(SESSION_NAME)
     .then((sess) => {
       return sess !== null ? validateUser(okapiUrl, store, tenant, sess) : null;
     })
@@ -576,10 +624,12 @@ export function checkOkapiSession(okapiUrl, store, tenant) {
  * @returns {Promise}
  */
 export function requestLogin(okapiUrl, store, tenant, data) {
-  return fetch(`${okapiUrl}/bl-users/login?expandPermissions=true&fullPermissions=true`, {
-    method: 'POST',
-    headers: { 'X-Okapi-Tenant': tenant, 'Content-Type': 'application/json' },
+  return fetch(`${okapiUrl}/bl-users/login-with-expiry?expandPermissions=true&fullPermissions=true`, {
     body: JSON.stringify(data),
+    credentials: 'include',
+    headers: { 'X-Okapi-Tenant': tenant, 'Content-Type': 'application/json' },
+    method: 'POST',
+    mode: 'cors',
   })
     .then(resp => processOkapiSession(okapiUrl, store, tenant, resp));
 }
@@ -589,15 +639,15 @@ export function requestLogin(okapiUrl, store, tenant, data) {
  * retrieve currently-authenticated user
  * @param {string} okapiUrl
  * @param {string} tenant
- * @param {string} token
  *
  * @returns {Promise} Promise resolving to the response of the request
  */
-function fetchUserWithPerms(okapiUrl, tenant, token) {
-  return fetch(
-    `${okapiUrl}/bl-users/_self?expandPermissions=true&fullPermissions=true`,
-    { headers: getHeaders(tenant, token) },
-  );
+function fetchUserWithPerms(okapiUrl, tenant) {
+  return fetch(`${okapiUrl}/bl-users/_self?expandPermissions=true&fullPermissions=true`, {
+    headers: getHeaders(tenant),
+    credentials: 'include',
+    mode: 'cors',
+  });
 }
 
 /**
@@ -606,13 +656,12 @@ function fetchUserWithPerms(okapiUrl, tenant, token) {
  * @param {string} okapiUrl
  * @param {redux store} store
  * @param {string} tenant
- * @param {string} token
  *
  * @returns {Promise} Promise resolving to the response-body (JSON) of the request
  */
-export function requestUserWithPerms(okapiUrl, store, tenant, token) {
-  return fetchUserWithPerms(okapiUrl, tenant, token)
-    .then(resp => processOkapiSession(okapiUrl, store, tenant, resp, token));
+export function requestUserWithPerms(okapiUrl, store, tenant) {
+  return fetchUserWithPerms(okapiUrl, tenant)
+    .then(resp => processOkapiSession(okapiUrl, store, tenant, resp));
 }
 
 /**
@@ -648,10 +697,10 @@ export function requestSSOLogin(okapiUrl, tenant) {
  * @returns {Promise}
  */
 export function updateUser(store, data) {
-  return localforage.getItem('okapiSess')
+  return localforage.getItem(SESSION_NAME)
     .then((sess) => {
       sess.user = { ...sess.user, ...data };
-      return localforage.setItem('okapiSess', sess);
+      return localforage.setItem(SESSION_NAME, sess);
     })
     .then(() => {
       store.dispatch(updateCurrentUser(data));
@@ -669,8 +718,9 @@ export function updateUser(store, data) {
  */
 export async function updateTenant(okapi, tenant) {
   const okapiSess = await localforage.getItem('okapiSess');
-  const userWithPermsResponse = await fetchUserWithPerms(okapi.url, tenant, okapi.token);
+  const userWithPermsResponse = await fetchUserWithPerms(okapi.url, tenant);
   const userWithPerms = await userWithPermsResponse.json();
 
-  await localforage.setItem('okapiSess', { ...okapiSess, tenant, ...spreadUserWithPerms(userWithPerms) });
+  await localforage.setItem(SESSION_NAME, { ...okapiSess, tenant, ...spreadUserWithPerms(userWithPerms) });
 }
+

--- a/src/useOkapiKy.js
+++ b/src/useOkapiKy.js
@@ -2,18 +2,19 @@ import ky from 'ky';
 import { useStripes } from './StripesContext';
 
 export default () => {
-  const { locale = 'en', tenant, token, url } = useStripes().okapi;
+  const { locale = 'en', tenant, url } = useStripes().okapi;
   return ky.create({
-    prefixUrl: url,
+    credentials: 'include',
     hooks: {
       beforeRequest: [
         request => {
           request.headers.set('Accept-Language', locale);
           request.headers.set('X-Okapi-Tenant', tenant);
-          request.headers.set('X-Okapi-Token', token);
         }
       ]
     },
+    mode: 'cors',
+    prefixUrl: url,
     retry: 0,
     timeout: 30000,
   });


### PR DESCRIPTION
## WIP warning

Handle access-control via HTTP-only cookies instead of storing `X-Okapi-Token` in local storage. By keeping the token in an HTTP-only cookie, this prevents any JS code from accessing and tampering with the value.

Notable changes:
* Sessions now time out instead of being valid indefinitely.
* Authentication requests are processed at `/bl-users/login-with-expiry` instead of `/bl-users/login`.
* "Activity" is tracked by an event listener that silently refreshes the cookie in the background, before it expires, as long as it detects activity (currently, mouse-clicks and keyboard events).

Refs [STCOR-671](https://issues.folio.org/browse/STCOR-671), [FOLIO-3627](https://issues.folio.org/browse/FOLIO-3627)