### PR TITLE
STCOR-594 read ky timeout from stripes-config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Include `yarn.lock`. Refs STCOR-679.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs STCOR-744.
 * Bump `stylelint` to `v15` and `stylelint-config-standard` to `v34`. Refs STCOR-745.
+* Read ky timeout from stripes-config value. Refs STCOR-594.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/src/useOkapiKy.js
+++ b/src/useOkapiKy.js
@@ -2,7 +2,8 @@ import ky from 'ky';
 import { useStripes } from './StripesContext';
 
 export default () => {
-  const { locale = 'en', tenant, token, url } = useStripes().okapi;
+  const { locale = 'en', timeout = 30000, tenant, token, url } = useStripes().okapi;
+
   return ky.create({
     prefixUrl: url,
     hooks: {
@@ -15,6 +16,6 @@ export default () => {
       ]
     },
     retry: 0,
-    timeout: 30000,
+    timeout,
   });
 };


### PR DESCRIPTION
Based on the [STCOR-594](https://issues.folio.org/browse/STCOR-594), timout inside useOkapiKy should be configurable