### PR TITLE
STCOR-747: Provide optional tenant argument to `useOkapiKy` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs STCOR-744.
 * Bump `stylelint` to `v15` and `stylelint-config-standard` to `v34`. Refs STCOR-745.
 * Read ky timeout from stripes-config value. Refs STCOR-594.
+* Provide optional tenant argument to `useOkapiKy` hook. Refs STCOR-747.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 10.1.0 IN PROGRESS
 
+* Provide optional tenant argument to `useOkapiKy` hook. Refs STCOR-747.
+
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)
 
@@ -26,7 +28,6 @@
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs STCOR-744.
 * Bump `stylelint` to `v15` and `stylelint-config-standard` to `v34`. Refs STCOR-745.
 * Read ky timeout from stripes-config value. Refs STCOR-594.
-* Provide optional tenant argument to `useOkapiKy` hook. Refs STCOR-747.
 
 ## [9.0.0](https://github.com/folio-org/stripes-core/tree/v9.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v8.3.0...v9.0.0)

--- a/src/useOkapiKy.js
+++ b/src/useOkapiKy.js
@@ -1,8 +1,8 @@
 import ky from 'ky';
 import { useStripes } from './StripesContext';
 
-export default () => {
-  const { locale = 'en', timeout = 30000, tenant, token, url } = useStripes().okapi;
+export default (tenant) => {
+  const { locale = 'en', timeout = 30000, tenant: currentTenant, token, url } = useStripes().okapi;
 
   return ky.create({
     prefixUrl: url,
@@ -10,7 +10,7 @@ export default () => {
       beforeRequest: [
         request => {
           request.headers.set('Accept-Language', locale);
-          request.headers.set('X-Okapi-Tenant', tenant);
+          request.headers.set('X-Okapi-Tenant', tenant ?? currentTenant);
           request.headers.set('X-Okapi-Token', token);
         }
       ]


### PR DESCRIPTION
Introduce an optional `tenant` argument to `useOkapiKy` hook to be able to override headers with a provided tenant.

Refs: https://issues.folio.org/browse/STCOR-747