### PR TITLE
STCOR-749: Allow to import validateUser function from @folio/stripes/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 10.1.0 IN PROGRESS
 
 * Provide optional tenant argument to `useOkapiKy` hook. Refs STCOR-747.
+* Avoid private path when import `validateUser` function. Refs STCOR-749.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ export { useModules } from './src/ModulesContext';
 export { withModule, withModules } from './src/components/Modules';
 export { default as stripesConnect } from './src/stripesConnect';
 export { default as Pluggable } from './src/Pluggable';
-export { updateUser, updateTenant } from './src/loginServices';
+export { updateUser, updateTenant, validateUser } from './src/loginServices';
 export { default as coreEvents } from './src/events';
 export { default as useOkapiKy } from './src/useOkapiKy';
 export { default as withOkapiKy } from './src/withOkapiKy';


### PR DESCRIPTION
## Links
[STCOR-749](https://issues.folio.org/browse/STCOR-749)

## Description
Since `validateUser` method is used in `ui-inventory`, we need to import this one from `@folio/stripes/core` instead of `@folio/stripes/core/src/loginServices`