### PR TITLE
[STCOR-752]: Ensure <AppIcon> is not cut off

### DIFF
--- a/src/components/AppIcon/AppIcon.css
+++ b/src/components/AppIcon/AppIcon.css
@@ -72,18 +72,21 @@
 /**
  * Sizes
  */
+.appIcon.large,
 .large .icon {
   height: 48px;
   min-width: 48px;
   width: 48px;
 }
 
+.appIcon.medium,
 .medium .icon {
   width: 24px;
   min-width: 24px;
   height: 24px;
 }
 
+.appIcon.small,
 .small .icon {
   width: 14px;
   min-width: 14px;


### PR DESCRIPTION
This ensures the wrapping element, `.appIcon`, also has minimum height/width constraints.