### PR TITLE
Revert "[STCOR-752]: Ensure <AppIcon> is not cut off"

### DIFF
--- a/src/components/AppIcon/AppIcon.css
+++ b/src/components/AppIcon/AppIcon.css
@@ -72,21 +72,18 @@
 /**
  * Sizes
  */
-.appIcon.large,
 .large .icon {
   height: 48px;
   min-width: 48px;
   width: 48px;
 }
 
-.appIcon.medium,
 .medium .icon {
   width: 24px;
   min-width: 24px;
   height: 24px;
 }
 
-.appIcon.small,
 .small .icon {
   width: 14px;
   min-width: 14px;


### PR DESCRIPTION
Reverts folio-org/stripes-core#1355

`<AppIcon>` may be used like `<AppIcon icon="foo">Title of an instance</AppIcon>` in SearchAndSort results lists, and this sets the width incorrectly. 

<img width="1440" alt="Screenshot 2023-10-25 at 3 54 49 PM (2)" src="https://github.com/folio-org/stripes-core/assets/199241/244e8256-5a4b-45ab-9d6f-9c3558ee7d8d">
