### PR TITLE
[STCOR-752]: Ensure <AppIcon> is not cut off (for real this time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Provide optional tenant argument to `useOkapiKy` hook. Refs STCOR-747.
 * Avoid private path when import `validateUser` function. Refs STCOR-749.
+* Ensure `<AppIcon>` is not cut off when app name is long. Refs STCOR-752.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/components/AppIcon/AppIcon.css
+++ b/src/components/AppIcon/AppIcon.css
@@ -72,21 +72,30 @@
 /**
  * Sizes
  */
-.appIcon.large,
+.appIcon.large {
+  min-width: 48px;
+}
+
 .large .icon {
   height: 48px;
   min-width: 48px;
   width: 48px;
 }
 
-.appIcon.medium,
+.appIcon.medium {
+  min-width: 24px;
+}
+
 .medium .icon {
   width: 24px;
   min-width: 24px;
   height: 24px;
 }
 
-.appIcon.small,
+.appIcon.small {
+  min-width: 14px;
+}
+
 .small .icon {
   width: 14px;
   min-width: 14px;

--- a/src/components/AppIcon/AppIcon.css
+++ b/src/components/AppIcon/AppIcon.css
@@ -72,18 +72,21 @@
 /**
  * Sizes
  */
+.appIcon.large,
 .large .icon {
   height: 48px;
   min-width: 48px;
   width: 48px;
 }
 
+.appIcon.medium,
 .medium .icon {
   width: 24px;
   min-width: 24px;
   height: 24px;
 }
 
+.appIcon.small,
 .small .icon {
   width: 14px;
   min-width: 14px;


### PR DESCRIPTION
This ensures the wrapping element, `.appIcon`, also has minimum width constraints.

Unlike #1355, we've also made sure that this works both in pane headers and SearchAndSort lists:

![image](https://github.com/folio-org/stripes-core/assets/8005215/b17ee0d3-df82-403c-abb2-d96c2e1147bf)
![image](https://github.com/folio-org/stripes-core/assets/8005215/458d1d5c-4e0e-4c1c-bd3f-25ce1bacb022)
