### PR TITLE
STCOR-574 rotate tokens well before they expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Provide optional tenant argument to `useOkapiKy` hook. Refs STCOR-747.
 * Avoid private path when import `validateUser` function. Refs STCOR-749.
 * Ensure `<AppIcon>` is not cut off when app name is long. Refs STCOR-752.
+* Use cookies and RTR instead of directly handling the JWT. Refs STCOR-671, FOLIO-3627.
+* Shrink the token lifespan so we are less likely to use an expired one. Refs STCOR-754.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -82,10 +82,10 @@ const IS_ROTATING_INTERVAL = 100;
  *
  * Value is a float, 0 to 1, inclusive. Closer to 0 means more frequent
  * rotation; 1 means a token is valid up the very last moment of its TTL.
- * 0.95 is just a SWAG at a "likely to be useful" value. Given a 600 second
- * TTL (the current default for ATs) it corresponds to 570 seconds.
+ * 0.8 is just a SWAG at a "likely to be useful" value. Given a 600 second
+ * TTL (the current default for ATs) it corresponds to 480 seconds.
  */
-export const TTL_WINDOW = 0.95;
+export const TTL_WINDOW = 0.8;
 
 /**
  * isValidAT

--- a/src/service-worker.test.js
+++ b/src/service-worker.test.js
@@ -8,6 +8,7 @@ import {
   passThrough,
   passThroughLogout,
   rtr,
+  TTL_WINDOW,
 } from './service-worker';
 
 // reassign console.log to keep things quiet
@@ -25,8 +26,12 @@ afterAll(() => {
 });
 
 describe('isValidAT', () => {
-  it('returns true for valid ATs', () => {
-    expect(isValidAT({ atExpires: Date.now() + 1000 })).toBe(true);
+  it('returns true for ATs with 95% or more of their TTL remaining', () => {
+    expect(isValidAT({ atExpires: (Date.now() / TTL_WINDOW) + 10000 })).toBe(true);
+  });
+
+  it('returns false for ATs 5% or less of their TTL remaining', () => {
+    expect(isValidAT({ atExpires: Date.now() + 1000 })).toBe(false);
   });
 
   it('returns false for expired ATs', () => {
@@ -39,8 +44,12 @@ describe('isValidAT', () => {
 });
 
 describe('isValidRT', () => {
-  it('returns true for valid ATs', () => {
-    expect(isValidRT({ rtExpires: Date.now() + 1000 })).toBe(true);
+  it('returns true for valid RTs', () => {
+    expect(isValidRT({ rtExpires: (Date.now() / TTL_WINDOW) + 1000 })).toBe(true);
+  });
+
+  it('returns false for RTs 5% or less of their TTL remaining', () => {
+    expect(isValidRT({ rtExpires: Date.now() + 1000 })).toBe(false);
   });
 
   it('returns false for expired RTs', () => {
@@ -118,7 +127,7 @@ describe('isPermissibleRequest', () => {
   describe('when AT is valid', () => {
     it('when AT is valid, accepts any endpoint', () => {
       const req = { url: 'monkey' };
-      const te = { atExpires: Date.now() + 1000, rtExpires: Date.now() + 1000 };
+      const te = { atExpires: (Date.now() / TTL_WINDOW) + 1000, rtExpires: (Date.now() / TTL_WINDOW) + 1000 };
       expect(isPermissibleRequest(req, te, '')).toBe(true);
     });
   });
@@ -295,7 +304,7 @@ describe('passThrough', () => {
           clone: () => req,
         }
       };
-      const tokenExpiration = { atExpires: Date.now() + 10000 };
+      const tokenExpiration = { atExpires: (Date.now() / TTL_WINDOW) + 10000 };
 
       const response = { ok: true };
       global.fetch = jest.fn(() => Promise.resolve(response));
@@ -313,7 +322,7 @@ describe('passThrough', () => {
           clone: () => req,
         }
       };
-      const tokenExpiration = { atExpires: Date.now() + 10000 };
+      const tokenExpiration = { atExpires: (Date.now() / TTL_WINDOW) + 10000 };
 
       const response = {
         ok: false,
@@ -338,8 +347,8 @@ describe('passThrough', () => {
         }
       };
       const tokenExpiration = {
-        atExpires: Date.now() + 1000, // at says it's valid, but ok == false
-        rtExpires: Date.now() + 1000
+        atExpires: (Date.now() / TTL_WINDOW) + 1000, // at says it's valid, but ok == false
+        rtExpires: (Date.now() / TTL_WINDOW) + 1000
       };
 
       const response = 'los alamos';
@@ -373,7 +382,7 @@ describe('passThrough', () => {
       };
       const tokenExpiration = {
         atExpires: Date.now() - 1000,
-        rtExpires: Date.now() + 1000
+        rtExpires: (Date.now() / TTL_WINDOW) + 1000
       };
 
       const response = 'los alamos';


### PR DESCRIPTION
Rotate tokens slightly before they expire. This solves a problem in ui-data-export where every-five-second polling has caused some requests to land in a gap of about three seconds between when the AT was actually minted and when we stored it on the client side. i.e. it makes it much less likely that a token will expire in flight.

Refs [STCOR-574](https://issues.folio.org/browse/STCOR-754)