### PR TITLE
STCOR-759 read okapi config from micro-stripes-config

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,4 +45,7 @@ export { userLocaleConfig } from './src/loginServices';
 export * from './src/consortiaServices';
 export { default as queryLimit } from './src/queryLimit';
 export { default as init } from './src/init';
+
+/* RTR and service worker */
+export { postTokenExpiration } from './src/loginServices';
 export { registerServiceWorker, unregisterServiceWorker } from './src/serviceWorkerRegistration';

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -179,7 +179,7 @@ function dispatchLocale(url, store, tenant) {
     .then((response) => {
       if (response.status === 200) {
         response.json().then((json) => {
-          if (json.configs.length) {
+          if (json.configs?.length) {
             const localeValues = JSON.parse(json.configs[0].value);
             const { locale, timezone, currency } = localeValues;
             if (locale) {
@@ -258,7 +258,7 @@ export function getPlugins(okapiUrl, store, tenant) {
     .then((response) => {
       if (response.status < 400) {
         response.json().then((json) => {
-          const configs = json.configs.reduce((acc, val) => ({
+          const configs = json.configs?.reduce((acc, val) => ({
             ...acc,
             [val.configName]: val.value,
           }), {});
@@ -291,7 +291,7 @@ export function getBindings(okapiUrl, store, tenant) {
       } else {
         response.json().then((json) => {
           const configs = json.configs;
-          if (configs.length > 0) {
+          if (Array.isArray(configs) && configs.length > 0) {
             const string = configs[0].value;
             try {
               const tmp = JSON.parse(string);
@@ -387,10 +387,12 @@ export async function logout(okapiUrl, store) {
 /**
  * postTokenExpiration
  * send SW a TOKEN_EXPIRATION message
+ * @param {object} tokenExpiration shaped like { atExpires, rtExpires} where both are millisecond timestamps
+ *
  * @returns {Promise}
  */
-const postTokenExpiration = (tokenExpiration) => {
-  if ('serviceWorker' in navigator) {
+export const postTokenExpiration = (tokenExpiration) => {
+  if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
     return navigator.serviceWorker.ready
       .then((reg) => {
         const sw = reg.active;

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -96,6 +96,7 @@ describe('createOkapiSession', () => {
 
     const postMessage = jest.fn();
     navigator.serviceWorker = {
+      controller: true,
       ready: Promise.resolve({
         active: {
           postMessage,
@@ -309,6 +310,7 @@ describe('validateUser', () => {
 
     const postMessage = jest.fn();
     navigator.serviceWorker = {
+      controller: true,
       ready: Promise.resolve({
         active: {
           postMessage,

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -425,7 +425,6 @@ export const passThrough = (event, te, oUrl) => {
  * on install, force this SW to be the active SW
  */
 self.addEventListener('install', (event) => {
-  console.log('in install', self.stripesConfig);
   if (shouldLog) console.log('-- (rtr-sw) => install', event);
   return self.skipWaiting();
 });

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -43,14 +43,12 @@
  *
  */
 
+import { okapiUrl, okapiTenant } from 'micro-stripes-config.js';
 
 /** { atExpires, rtExpires } both are JS millisecond timestamps */
 let tokenExpiration = null;
 
 /** string FQDN including protocol, e.g. https://some-okapi.somewhere.org */
-let okapiUrl = null;
-
-let okapiTenant = null;
 
 /** whether to emit console logs */
 let shouldLog = false;
@@ -62,6 +60,7 @@ const IS_ROTATING_RETRIES = 100;
 /** how long to wait before rechecking the lock, in milliseconds (100 * 100) === 10 seconds */
 const IS_ROTATING_INTERVAL = 100;
 
+console.log('okapiUrl', okapiUrl, 'okapiTenant', okapiTenant);
 /**
  * TTL_WINDOW
  * How much of a token's TTL can elapse before it is considered expired?
@@ -426,6 +425,7 @@ export const passThrough = (event, te, oUrl) => {
  * on install, force this SW to be the active SW
  */
 self.addEventListener('install', (event) => {
+  console.log('in install', self.stripesConfig);
   if (shouldLog) console.log('-- (rtr-sw) => install', event);
   return self.skipWaiting();
 });
@@ -456,10 +456,10 @@ self.addEventListener('message', (event) => {
     if (shouldLog) console.info('-- (rtr-sw) reading', event.data);
 
     // OKAPI_CONFIG
-    if (event.data.type === 'OKAPI_CONFIG') {
-      okapiUrl = event.data.value.url;
-      okapiTenant = event.data.value.tenant;
-    }
+    // if (event.data.type === 'OKAPI_CONFIG') {
+    //   okapiUrl = event.data.value.url;
+    //   okapiTenant = event.data.value.tenant;
+    // }
 
     // LOGGER_CONFIG
     if (event.data.type === 'LOGGER_CONFIG') {

--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -1,5 +1,3 @@
-/* eslint no-console: 0 */
-
 /**
  * registerSW
  * * register SW
@@ -57,11 +55,12 @@ export const registerServiceWorker = async (okapiConfig, config, logger) => {
     }
 
     // talk to me, goose
-    if (navigator.serviceWorker.controller) {
-      logger.log('rtr', 'This page is currently controlled by: ', navigator.serviceWorker.controller);
-    }
     navigator.serviceWorker.oncontrollerchange = () => {
-      logger.log('rtr', 'This page is now controlled by: ', navigator.serviceWorker.controller);
+      if (navigator.serviceWorker.controller) {
+        logger.log('rtr', 'This page is currently controlled by: ', navigator.serviceWorker.controller);
+      } else {
+        logger.log('rtr', 'SERVICE WORKER NOT ACTIVE');
+      }
     };
   }
 };

--- a/src/serviceWorkerRegistration.test.js
+++ b/src/serviceWorkerRegistration.test.js
@@ -27,13 +27,11 @@ describe('registerServiceWorker', () => {
 
         await registerServiceWorker(okapiConfig, config, l);
 
-        const oConfig = { source: '@folio/stripes-core', type: 'OKAPI_CONFIG', value: okapiConfig };
         const lConfig = { source: '@folio/stripes-core', type: 'LOGGER_CONFIG', value: { categories: config.logCategories } };
 
-        expect(sw.postMessage).toHaveBeenNthCalledWith(1, oConfig);
-        expect(sw.postMessage).toHaveBeenNthCalledWith(2, lConfig);
+        expect(sw.postMessage).toHaveBeenCalledWith(lConfig);
         expect(typeof navigator.serviceWorker.oncontrollerchange).toBe('function');
-        expect(l.log).toHaveBeenCalledTimes(4);
+        expect(l.log).toHaveBeenCalledTimes(3);
       });
     };
 

--- a/test/bigtest/tests/login-test.js
+++ b/test/bigtest/tests/login-test.js
@@ -348,7 +348,7 @@ describe('Login', () => {
   //
   // we'll need to cover these components with jest/RTL tests
   // eventually.
-  describe.skip('with valid credentials', () => {
+  describe('with valid credentials', () => {
     beforeEach(async () => {
       const { username, password, submit } = login;
 

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -1,3 +1,4 @@
+import './microStripesConfig.mock';
 import './stripesConfig.mock';
 import './intl.mock';
 import './stripesIcon.mock';

--- a/test/jest/__mock__/microStripesConfig.mock.js
+++ b/test/jest/__mock__/microStripesConfig.mock.js
@@ -1,0 +1,5 @@
+jest.mock('micro-stripes-config', () => ({
+  okapiUrl: 'https://los-alamos-barbie-has-a-nice-tan.oh-wa.it',
+  okapiTenant: 'kenough',
+}),
+{ virtual: true });


### PR DESCRIPTION
A service worker's global state is reset after each sleep/wake cycle,
meaning the `okapiUrl` and `okapiTenant` values so lovingly sent to the
service worker during registration are likely to be promptly forgotten
as soon as the browser is idle for a few minutes and decides it would be
good to clean up inactive processes.

Here, those values are directly imported from a virtual module created
at build-time by stripes-webpack, which forwards the values from the
stripes-config object (most likely, the `stripes.config.js` file) and
allows them to be compiled directly into the generated
`service-worker.js` asset.

An alternative approach would be to pass in those values as URL
parameters when the service worker is registered.

h/t @mkuklis and @JohnC-80 who did the heavy lifting here, both in
thinking through the potential solutions and actually figuring out how
to implement this in our highly customized build process.

* Requires https://github.com/folio-org/stripes-webpack/pull/132

Refs [STCOR-759](https://issues.folio.org/browse/STCOR-759)