### PR TITLE
STCOR-761 allow console to be preserved on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Use cookies and RTR instead of directly handling the JWT. Refs STCOR-671, FOLIO-3627.
 * Shrink the token lifespan so we are less likely to use an expired one. Refs STCOR-754.
 * Correctly evaluate token lifespan; use consistent protocol for service worker messages. Refs STCOR-756.
+* Allow console to be preserved on logout. STCOR-761.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -5,7 +5,7 @@ import { compose } from 'redux';
 import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router';
 
-import { branding } from 'stripes-config';
+import { branding, config } from 'stripes-config';
 
 import { Icon } from '@folio/stripes-components';
 

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -126,7 +126,9 @@ class MainNav extends Component {
 
   // return the user to the login screen, but after logging in they will be brought to the default screen.
   logout() {
-    console.clear(); // eslint-disable-line no-console
+    if (!config.preserveConsole) {
+      console.clear(); // eslint-disable-line no-console
+    }
     this.returnToLogin().then(() => {
       this.props.history.push('/');
     });


### PR DESCRIPTION
Normally the console is cleared on logout. This is good for security but bad for debugging in the case where a user may be automatically logged out due to RTR.

Refs [STCOR-761](https://issues.folio.org/browse/STCOR-761)