### PR TITLE
STCOR-759 return non-okapi request fetches as-is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Use cookies and RTR instead of directly handling the JWT. Refs STCOR-671, FOLIO-3627.
 * Shrink the token lifespan so we are less likely to use an expired one. Refs STCOR-754.
 * Correctly evaluate token lifespan; use consistent protocol for service worker messages. Refs STCOR-756.
+* Do not catch and reject non-okapi request errors. Refs STCOR-759, UILDP-129.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -417,11 +417,7 @@ export const passThrough = (event, te, oUrl) => {
 
   // default: pass requests through to the network
   // console.log('-- (rtr-sw) passThrough NON-OKAPI', req.url)
-  return fetch(event.request, { credentials: 'include' })
-    .catch(e => {
-      console.error(e); // eslint-disable-line no-console
-      return Promise.reject(new Error(e));
-    });
+  return fetch(event.request);
 };
 
 /**

--- a/src/service-worker.test.js
+++ b/src/service-worker.test.js
@@ -268,7 +268,7 @@ describe('passThrough', () => {
       try {
         await passThrough(event, tokenExpiration, oUrl);
       } catch (e) {
-        expect(e).toMatchObject(new Error(error));
+        expect(e).toEqual(error);
       }
     });
   });


### PR DESCRIPTION
Instead of catching errors from non-Okapi requests and converting them to rejected promises, just `return fetch()` straight up, whatever that response contains.

h/t @miketaylor for pointing me in this direction, and reading minified code to try to suss the problem. That's dedication!

Refs [STCOR-759](https://issues.folio.org/browse/STCOR-759), [UILDP-129](https://issues.folio.org/browse/UILDP-129)