### PR TITLE
STCOR-671 provide empty service worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 10.0.4 IN PROGRESS
+
+* Provide empty `service-worker.js`. Refs STCOR-671.
+
 ## [10.0.3](https://github.com/folio-org/stripes-core/tree/v10.0.3) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.0.2...v10.0.3)
 

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,2 @@
+export default () => 'future of libraries is open';
+


### PR DESCRIPTION
`@folio/stripes-webpack` still looks for `service-worker.js`, so we provide a dummy function here to keep the API intact. This API is never invoked; this service worker is never registered (though it wouldn't matter since it doesn't listen for any events).

Refs [STCOR-671](https://issues.folio.org/browse/STCOR-671), [FOLIO-3627](https://issues.folio.org/browse/FOLIO-3627)