### PR TITLE
STCOR-767 Fix duplicated FOLIO in document title in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Ensure `<AppIcon>` is not cut off when app name is long. Refs STCOR-752.
 * Allow console to be preserved on logout. STCOR-761.
 * Export `unregisterServiceWorker` to eliminate zombie service workers. Refs FOLIO-3627.
+* Fix duplicated "FOLIO" in document title in some cases. Refs STCOR-767.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/components/TitleManager/TitleManager.js
+++ b/src/components/TitleManager/TitleManager.js
@@ -22,14 +22,24 @@ class TitleManager extends React.Component {
 
   renderTitle = (currentTitle) => {
     const { prefix, page, record } = this.props;
+    const postfix = (this.props.stripes.config || {}).platformName || APP;
 
     if (typeof currentTitle !== 'string') return '';
 
     const tokens = currentTitle.split(' - ');
+
+    /**
+     * When there are 2 items - that means there are page and postfix.
+     * If we don't clear the tokens[1] item then we'll have two postfixes - in tokens[1] and tokens[2] will be added later
+     */
+    if (tokens.length === 2) {
+      tokens[1] = '';
+    }
+
     if (page) tokens[0] = page;
     if (record) tokens[1] = record;
 
-    tokens[2] = (this.props.stripes.config || {}).platformName || APP;
+    tokens[2] = postfix;
 
     return prefix + tokens
       .filter(t => t)


### PR DESCRIPTION
## Description
It seems that number of calls to `renderTitle` affects the resulting document title.
Usually it's just two times:
1. `currentTitle` is empty, we add a postfix and return just `FOLIO`
2. `currentTitle` is `FOLIO` and `page` prop is `Inventory` for example. We return `Inventory - FOLIO`. And that should be it.
But for some unknown reason sometimes there's a third call:
3. `currentTitle` is `Inventory - FOLIO`. The method assumes `Inventory` is page, `FOLIO` is record and adds another `FOLIO` at the end, so we end up with `Inventory - FOLIO - FOLIO`.

Couldn't figure out why there are 3 calls, but this fix checks for duplicate postfix and works around it.
Hopefully my comment in the code explains well enough why we're checking for length of `2`

## Issues
[STCOR-767](https://issues.folio.org/browse/STCOR-767)