### PR TITLE
STCOR-768 Refactor away from color() function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Allow console to be preserved on logout. STCOR-761.
 * Export `unregisterServiceWorker` to eliminate zombie service workers. Refs FOLIO-3627.
 * Fix duplicated "FOLIO" in document title in some cases. Refs STCOR-767.
+* Refactor away from `color()` function. Refs STCOR-768.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/components/Notification/Toast.css
+++ b/src/components/Notification/Toast.css
@@ -42,7 +42,7 @@
   box-shadow: 0 4px 19px 0 rgba(0, 0, 0, 0.39);
 
   &.error {
-    background-color: color(var(--error, #900) tint(25%));
+    background-color: oklch(from var(--error) calc(l + 0.13) calc(c - 0.03) h);
     border-color: var(--error);
     color: #fff;
     box-shadow: 0 4px 19px 0 rgba(153, 0, 0, 0.39);
@@ -55,7 +55,7 @@
   }
 
   &.success {
-    background-color: color(var(--success, #060) tint(25%));
+    background-color: oklch(from var(--success) calc(l + 0.13) calc(c - 0.03) h);
     border-color: var(--success);
     color: #fff;
     box-shadow: 0 4px 19px 0 rgba(0, 112, 0, 0.39);


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-768

Seeking to eventually eliminate one of our out-of-date dependencies - `postcss-color-function` since the spec was changed a while ago - native `color()` function represent merely a change in color space - they're no longer used for creating blends as this original implementation intended.