### PR TITLE
Add back button support to multi-tenant workflow

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -46,7 +46,6 @@ import { setOkapiTenant } from './okapiActions';
 class RootWithIntl extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
-      config: PropTypes.object,
       epics: PropTypes.object,
       logger: PropTypes.object.isRequired,
       clone: PropTypes.func.isRequired,
@@ -113,15 +112,6 @@ class RootWithIntl extends React.Component {
     const stripes = this.props.stripes.clone({ connect });
 
     const logoutUrl = `${stripes.okapi.authnUrl}/realms/${stripes.okapi.tenant}/protocol/openid-connect/logout?client_id=${stripes.okapi.clientId}&post_logout_redirect_uri=${window.location.protocol}//${window.location.host}`;
-    const LoginComponent = stripes.okapi.authnUrl ?
-      <PreLoginLanding
-        onSelectTenant={this.handleSelectTenant}
-      />
-      :
-      <Login
-        autoLogin={stripes.config.autoLogin}
-        stripes={stripes}
-      />;
 
     return (
       <StripesContext.Provider value={stripes}>

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -16,7 +16,7 @@ function PreLoginLanding({ onSelectTenant }) {
   const getLoginUrl = () => {
     if (!okapi.tenant) return '';
     if (okapi.authnUrl) {
-      return `${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/auth?client_id=${okapi.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
+      return `${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/auth?client_id=${okapi.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid&isConsortium=true`;
     }
     return '';
   };

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -51,7 +51,7 @@ function PreLoginLanding({ onSelectTenant }) {
               <Button
                 buttonClass={styles.submitButton}
                 disabled={!okapi.tenant}
-                onClick={() => window.location.replace(getLoginUrl())}
+                onClick={() => window.location.assign(getLoginUrl())}
                 buttonStyle="primary"
                 fullWidth
               >


### PR DESCRIPTION
- When navigating from tenant selection screen to login screen, this allows user to navigate back with the browser back button.
- Removed duplicate `config` propType definition.
- Removed unused `LoginComponent`.