### PR TITLE
STCOR-770: Export getEventHandler to be able to create events in other modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Export `unregisterServiceWorker` to eliminate zombie service workers. Refs FOLIO-3627.
 * Fix duplicated "FOLIO" in document title in some cases. Refs STCOR-767.
 * Refactor away from `color()` function. Refs STCOR-768.
+* Export `getEventHandler` to be able to create events in other modules. Refs STCOR-770.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/index.js
+++ b/index.js
@@ -47,3 +47,5 @@ export { default as queryLimit } from './src/queryLimit';
 export { default as init } from './src/init';
 
 export { registerServiceWorker, unregisterServiceWorker } from './src/serviceWorkerRegistration';
+
+export { getEventHandler } from './src/handlerService';


### PR DESCRIPTION
## Purpose
Export `getEventHandler` to be able to create events in other modules.

## Related PRs
https://github.com/folio-org/ui-consortia-settings/pull/101
https://github.com/folio-org/ui-inventory/pull/2373

## Issues
[STCOR-770](https://issues.folio.org/browse/STCOR-770)

