### PR TITLE
STCOR-785 add tests for Stripes, configureLogger

### DIFF
--- a/src/Stripes.test.js
+++ b/src/Stripes.test.js
@@ -1,0 +1,103 @@
+import Stripes from './Stripes';
+
+describe('Stripes', () => {
+  describe('clone', () => {
+    it('returns a matching copy', () => {
+      const s = new Stripes();
+      const c = s.clone();
+      expect(s).toEqual(c);
+    });
+
+    it('returns a matching copy plus additional properties', () => {
+      const s = new Stripes();
+      const c = s.clone({ monkey: 'bagel' });
+
+      expect(c).toMatchObject(s);
+      expect(c).toHaveProperty('monkey', 'bagel');
+    });
+  });
+
+  describe('hasInterface', () => {
+    describe('returns truthy', () => {
+      it('when the interface is present and the query does not contain a version [boolean, true]', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({ logger, discovery: { interfaces: { 'monkey': '3.0' } } });
+        expect(s.hasInterface('monkey')).toBe(true);
+      });
+
+      it('when the interface is present and compatible with the requested version [string, available interface]', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({ logger, discovery: { interfaces: { 'monkey': '3.0' } } });
+        expect(s.hasInterface('monkey', '3.0')).toBe('3.0');
+      });
+    });
+
+    describe('returns falsy', () => {
+      it('when the interface is present but incompatible with the requested version [number, 0]', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({ logger, discovery: { interfaces: { 'monkey': '3.0' } } });
+        expect(s.hasInterface('monkey', '4.0')).toBe(0);
+      });
+
+      it('when `discovery` is unavailable [undefined]', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({ logger });
+        expect(s.hasInterface('monkey')).toBeUndefined();
+      });
+
+      it('when `discovery.interfaces` is unavailable [undefined]', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({ logger, discovery: {} });
+        expect(s.hasInterface('monkey')).toBeUndefined();
+      });
+
+      it('when the requested interface is absent [undefined]', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({ logger, discovery: { interfaces: { 'funky': '3.0' } } });
+        expect(s.hasInterface('monkey')).toBeUndefined();
+      });
+    });
+  });
+
+  describe('hasPerm', () => {
+    describe('returns true', () => {
+      it('given hasAllPerms', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({ logger, config: { hasAllPerms: true } });
+        expect(s.hasPerm('monkey')).toBe(true);
+      });
+
+      it('when requested permissions are assigned', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({
+          logger,
+          user: {
+            perms: {
+              'monkey': true, 'bagel': true, 'funky': true, 'chicken': true
+            }
+          }
+        });
+        expect(s.hasPerm('monkey,bagel')).toBe(true);
+      });
+    });
+
+    describe('returns falsy', () => {
+      it('when requested permissions are not assigned [boolean, false]', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({
+          logger,
+          user: {
+            perms: { 'monkey': true, 'bagel': true }
+          }
+        });
+        expect(s.hasPerm('monkey,funky')).toBe(false);
+      });
+
+      it('when user perms are uninitialized [undefined]', () => {
+        const logger = { log: jest.fn() };
+        const s = new Stripes({ logger, user: {} });
+        expect(s.hasPerm('monkey')).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/configureLogger.test.js
+++ b/src/configureLogger.test.js
@@ -1,0 +1,24 @@
+import configureLogger from './configureLogger';
+
+describe('configureLogger', () => {
+  it('without an argument, returns a logger with default values', () => {
+    const logger = configureLogger();
+
+    expect(logger.categories).toEqual('core,action,xhr');
+    expect(logger.prefix).toEqual('stripes');
+    expect(logger.timestamp).toBe(false);
+  });
+
+  it('with a config argument, returns a logger with custom values', () => {
+    const config = {
+      logCategories: 'monkey',
+      logPrefix: 'bagel',
+      logTimestamp: true,
+    };
+    const logger = configureLogger(config);
+
+    expect(logger.categories).toEqual(config.logCategories);
+    expect(logger.prefix).toEqual(config.logPrefix);
+    expect(logger.timestamp).toBe(config.logTimestamp);
+  });
+});

--- a/test/jest/__mock__/stripesConfig.mock.js
+++ b/test/jest/__mock__/stripesConfig.mock.js
@@ -3,6 +3,7 @@ jest.mock('stripes-config', () => (
     branding: {
       style: {},
     },
+    config: {},
     metadata: {},
     modules: [],
     okapi: {


### PR DESCRIPTION
Rescue tests from [STCOR-674](https://issues.folio.org/browse/STCOR-674)/PR #1268. That work is stale/outdated/incomplete/unscheduled, but the tests are still nice.

Refs [STCOR-785](https://issues.folio.org/browse/STCOR-785)