### PR TITLE
Graceful handling when provides array is null in API response

### DIFF
--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -246,9 +246,9 @@ export function discoveryReducer(state = {}, action) {
             modules: action.data.moduleDescriptors.map((d) => {
               return {
                 name: d.id,
-                interfaces: d.provides.map((i) => {
+                interfaces: d.provides?.map((i) => {
                   return { name: i.id + ' ' + i.version };
-                }),
+                }) || [],
               };
             }),
           },


### PR DESCRIPTION
Previously only showed first application in the list before quietly failing on a null exception. Now shows all applications returned in API response.

<img width="915" alt="image" src="https://github.com/folio-org/stripes-core/assets/28395235/f092532e-52fe-470c-b45d-dd1ee6bb0d2b">
