### PR TITLE
STCOR-795 optionally use users-keycloak endpoint for password reset

### DIFF
--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -107,7 +107,8 @@ class CreateResetPasswordControl extends Component {
       },
     } = stripes;
 
-    const path = `${url}/bl-users/password-reset/${isValidToken ? 'reset' : 'validate'}`;
+    const interfacePath = stripes.hasInterface('users-keycloak') ? 'users-keycloak' : 'bl-users';
+    const path = `${url}/${interfacePath}/password-reset/${isValidToken ? 'reset' : 'validate'}`;
 
     fetch(path, {
       method: 'POST',


### PR DESCRIPTION
When the `users-keycloak` interface is available, use the endpoints it provides in place of the legacy endpoints.

Refs [STCOR-795](https://issues.folio.org/browse/STCOR-795), [UIU-3031](https://issues.folio.org/browse/UIU-3031)