### PR TITLE
STCOR-798 fully populate /bl-users/_self API response in tests

### DIFF
--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -44,7 +44,33 @@ export default function configure() {
     configs: []
   });
 
-  this.get('/bl-users/_self', {});
+  this.get('/bl-users/_self', {
+    'user': {
+      'username': 'diku_admin',
+      'id': '882c886a-2d9a-5ffa-afc5-13912c257b99',
+      'active': true,
+      'patronGroup': '3684a786-6671-4268-8ed0-9db82ebca60b',
+      'proxyFor': [
+      ],
+      'personal': {
+        'lastName': 'ADMINISTRATOR',
+        'firstName': 'DIKU',
+        'email': 'admin@diku.example.org',
+        'addresses': [
+        ]
+      },
+      'createdDate': '2024-01-22T01:55:50.661+00:00',
+      'updatedDate': '2024-01-22T01:55:50.661+00:00',
+      'metadata': {
+        'createdDate': '2024-01-22T01:52:08.076+00:00',
+        'updatedDate': '2024-01-22T01:55:50.656+00:00',
+        'updatedByUserId': '882c886a-2d9a-5ffa-afc5-13912c257b99'
+      },
+      'departments': [
+      ]
+    }
+  });
+
   this.post('/bl-users/password-reset/validate', () => {
     return new Response(204, {}, '');
   });


### PR DESCRIPTION
Provide a fully-populated user object, instead of an empty one, from `/bl-users/_self` in tests. Tests that expect an authenticated user may fail if they end up calling the endpoint and don't receive the expected data. It's unclear exactly why we're hitting this glitch now, but here we are. 🤷 

h/t @JohnC-80 for figuring this out. He deserves the credit here; I'm just the codemonkey who happened to be available to implement his suggested fix.

Refs [STCOR-798](https://issues.folio.org/browse/STCOR-798)