### PR TITLE
STCOR-801 Move async localforage.clear to afterEach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Opt-in: handle access-control via cookies. Refs STCOR-671.
 * Opt-in: disable login when cookies are disabled. Refs STCOR-762.
 * Add arial-label for `ProfileDropdown.js`. Refs STCOR-753.
+* Move `localforage.clear()` to `afterEach` for test suite. Refs STCOR-801.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -95,7 +95,6 @@ export default function setupApplication({
         clearModules();
         clearCookies(cookies);
         reset();
-        localforage.clear();
         this.server?.shutdown();
         this.server = null;
         this.app = null;
@@ -107,5 +106,9 @@ export default function setupApplication({
       visit: { value: visit },
       location: { get: location },
     });
+  });
+
+  afterEach(async () => {
+    await localforage.clear();
   });
 }


### PR DESCRIPTION
The call to `localForage.clear` returns a promise, so it's best to handle it within an async call so that tests can wait for it. This seems to explain some difference we're seeing in timing between local test runs and CI such as the test runs from https://github.com/folio-org/stripes-core/pull/1392