### PR TITLE
STCOR-797 Make `<Settings>` a functional component. Update connected modules when `stripes` object changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Show app/record when you have permission for that. Refs STCOR-800.
 * Convert `<SSOLanding />` tests to jest. STCOR-798.
 * Avoid calling `map` on `undefined` via optional-chaining. Refs STCOR-793.
+* Make `<Settings>` a functional component. Update connected modules when `stripes` object changes. Fixes STCOR-797.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,17 +1,20 @@
-import React, { createRef, Suspense } from 'react';
-import PropTypes from 'prop-types';
+import React, {
+  useRef,
+  useEffect,
+  useMemo,
+  Suspense,
+} from 'react';
 import {
   FormattedMessage,
-  injectIntl,
+  useIntl,
 } from 'react-intl';
-import { withRouter } from 'react-router';
+import { useLocation } from 'react-router';
 import {
   Switch,
   Route,
 } from 'react-router-dom';
 
 import { connectFor } from '@folio/stripes-connect';
-
 import {
   LoadingView,
   NavList,
@@ -24,7 +27,7 @@ import {
 import About from '../About';
 import { StripesContext } from '../../StripesContext';
 import AddContext from '../../AddContext';
-import { withModules } from '../Modules';
+import { useModules } from '../../ModulesContext';
 import { stripesShape } from '../../Stripes';
 import AppIcon from '../AppIcon';
 import { packageName } from '../../constants';
@@ -33,29 +36,26 @@ import { ModuleHierarchyProvider } from '../ModuleHierarchy';
 
 import css from './Settings.css';
 
-class Settings extends React.Component {
-  static propTypes = {
-    stripes: stripesShape.isRequired,
-    location: PropTypes.shape({
-      pathname: PropTypes.string,
-    }).isRequired,
-    modules: PropTypes.shape({
-      app: PropTypes.arrayOf(PropTypes.object),
-      settings: PropTypes.arrayOf(PropTypes.object),
-    }),
-    intl: PropTypes.shape({
-      formatMessage: PropTypes.func.isRequired,
-    }),
-  };
+const propTypes = {
+  stripes: stripesShape.isRequired,
+};
 
-  constructor(props) {
-    super(props);
+const Settings = ({ stripes }) => {
+  const paneTitleRef = useRef();
+  const location = useLocation();
+  const modules = useModules();
+  const intl = useIntl();
 
-    this.paneTitleRef = createRef();
-    const { stripes, modules } = props;
+  useEffect(() => {
+    if (paneTitleRef.current) {
+      paneTitleRef.current.focus();
+    }
+  }, []);
+
+  const connectedModules = useMemo(() => {
     const settingsModules = modules.settings || [];
 
-    this.connectedModules = settingsModules
+    return settingsModules
       .filter(x => stripes.hasPerm(`settings.${x.module.replace(packageName.PACKAGE_SCOPE_REGEX, '')}.enabled`))
       .sort((x, y) => x.displayName.toLowerCase().localeCompare(y.displayName.toLowerCase()))
       .map((m) => {
@@ -73,99 +73,92 @@ class Settings extends React.Component {
           throw Error(error);
         }
       });
-  }
+  }, [stripes, modules.settings]);
 
-  componentDidMount() {
-    if (this.paneTitleRef.current) {
-      this.paneTitleRef.current.focus();
-    }
-  }
-
-  render() {
-    const { stripes, location, intl: { formatMessage } } = this.props;
-    const navLinks = this.connectedModules.map(({ module }) => {
-      return (
-        <NavListItem
-          key={module.route}
-          to={`/settings${module.route}`}
-        >
-          <AppIcon
-            alt={module.displayName}
-            app={module.module}
-            size="small"
-            iconClassName={css.appIcon}
-          >
-            {module.displayName}
-          </AppIcon>
-        </NavListItem>
-      );
-    });
-
-    const routes = this.connectedModules.map(({ module, Component, moduleStripes }) => {
-      const path = `/settings${module.route}`;
-      return (
-        <Route
-          path={path}
-          key={module.route}
-          render={(props2) => (
-            <RouteErrorBoundary escapeRoute={path} moduleName={module.displayName} isSettings>
-              <StripesContext.Provider value={moduleStripes}>
-                <AddContext context={{ stripes: moduleStripes }}>
-                  <ModuleHierarchyProvider module={module.module}>
-                    <Component {...props2} stripes={moduleStripes} showSettings actAs="settings" />
-                  </ModuleHierarchyProvider>
-                </AddContext>
-                {props2.match.isExact ? <div className={css.panePlaceholder} /> : null}
-              </StripesContext.Provider>
-            </RouteErrorBoundary>
-          )}
-        />
-      );
-    });
-
-    // To keep the top level parent menu item shown as active
-    // when a child settings page is active
-    const activeLink = `/settings/${location.pathname.split('/')[2]}`;
-
+  const navLinks = useMemo(() => connectedModules.map(({ module }) => {
     return (
-      <Suspense fallback={<LoadingView />}>
-        <Paneset id="settings-module-display">
-          <Pane
-            defaultWidth="20%"
-            paneTitle={<FormattedMessage id="stripes-core.settings" />}
-            paneTitleRef={this.paneTitleRef}
-            id="settings-nav-pane"
-          >
-            <NavList aria-label={formatMessage({ id: 'stripes-core.settings' })}>
-              <NavListSection
-                activeLink={activeLink}
-                label={formatMessage({ id: 'stripes-core.settings' })}
-                className={css.navListSection}
-              >
-                {navLinks}
-              </NavListSection>
-            </NavList>
-            <NavList aria-label={formatMessage({ id: 'stripes-core.settingSystemInfo' })}>
-              <NavListSection
-                label={formatMessage({ id: 'stripes-core.settingSystemInfo' })}
-                activeLink={activeLink}
-                className={css.navListSection}
-              >
-                <NavListItem to="/settings/about">
-                  <FormattedMessage id="stripes-core.front.about" />
-                </NavListItem>
-              </NavListSection>
-            </NavList>
-          </Pane>
-          <Switch>
-            {routes}
-            <Route path="/settings/about" component={() => <About stripes={stripes} />} key="about" />
-            <Route component={() => <div style={{ padding: '15px' }}><FormattedMessage id="stripes-core.settingChoose" /></div>} />
-          </Switch>
-        </Paneset>
-      </Suspense>
+      <NavListItem
+        key={module.route}
+        to={`/settings${module.route}`}
+      >
+        <AppIcon
+          alt={module.displayName}
+          app={module.module}
+          size="small"
+          iconClassName={css.appIcon}
+        >
+          {module.displayName}
+        </AppIcon>
+      </NavListItem>
     );
-  }
-}
+  }), [connectedModules]);
 
-export default withRouter(withModules(injectIntl(Settings)));
+  const routes = useMemo(() => connectedModules.map(({ module, Component, moduleStripes }) => {
+    const path = `/settings${module.route}`;
+    return (
+      <Route
+        path={path}
+        key={module.route}
+        render={(props2) => (
+          <RouteErrorBoundary escapeRoute={path} moduleName={module.displayName} isSettings>
+            <StripesContext.Provider value={moduleStripes}>
+              <AddContext context={{ stripes: moduleStripes }}>
+                <ModuleHierarchyProvider module={module.module}>
+                  <Component {...props2} stripes={moduleStripes} showSettings actAs="settings" />
+                </ModuleHierarchyProvider>
+              </AddContext>
+              {props2.match.isExact ? <div className={css.panePlaceholder} /> : null}
+            </StripesContext.Provider>
+          </RouteErrorBoundary>
+        )}
+      />
+    );
+  }), [connectedModules]);
+
+  // To keep the top level parent menu item shown as active
+  // when a child settings page is active
+  const activeLink = `/settings/${location.pathname.split('/')[2]}`;
+
+  return (
+    <Suspense fallback={<LoadingView />}>
+      <Paneset id="settings-module-display">
+        <Pane
+          defaultWidth="20%"
+          paneTitle={<FormattedMessage id="stripes-core.settings" />}
+          paneTitleRef={paneTitleRef.current}
+          id="settings-nav-pane"
+        >
+          <NavList aria-label={intl.formatMessage({ id: 'stripes-core.settings' })}>
+            <NavListSection
+              activeLink={activeLink}
+              label={intl.formatMessage({ id: 'stripes-core.settings' })}
+              className={css.navListSection}
+            >
+              {navLinks}
+            </NavListSection>
+          </NavList>
+          <NavList aria-label={intl.formatMessage({ id: 'stripes-core.settingSystemInfo' })}>
+            <NavListSection
+              label={intl.formatMessage({ id: 'stripes-core.settingSystemInfo' })}
+              activeLink={activeLink}
+              className={css.navListSection}
+            >
+              <NavListItem to="/settings/about">
+                <FormattedMessage id="stripes-core.front.about" />
+              </NavListItem>
+            </NavListSection>
+          </NavList>
+        </Pane>
+        <Switch>
+          {routes}
+          <Route path="/settings/about" component={() => <About stripes={stripes} />} key="about" />
+          <Route component={() => <div style={{ padding: '15px' }}><FormattedMessage id="stripes-core.settingChoose" /></div>} />
+        </Switch>
+      </Paneset>
+    </Suspense>
+  );
+};
+
+Settings.propTypes = propTypes;
+
+export default Settings;

--- a/src/components/Settings/tests/Settings.test.js
+++ b/src/components/Settings/tests/Settings.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import Intl from '../../../../test/jest/helpers/intl';
+import { ModulesContext } from '../../../ModulesContext';
+import Settings from '../Settings';
+
+jest.unmock('@folio/stripes-components');
+
+const STRIPES = {
+  actionNames: [],
+  connect: component => component,
+  config: {},
+  currency: 'USD',
+  hasInterface: () => true,
+  hasPerm: jest.fn(() => true),
+  locale: 'en-US',
+  logger: {
+    log: () => { },
+  },
+  okapi: {
+    tenant: 'diku',
+    url: 'https://folio-testing-okapi.dev.folio.org',
+  },
+  user: {
+    user: {
+      consortia: 'old-consortia',
+    },
+  },
+  clone() { return this; },
+};
+
+const TestApp = ({ stripes }) => ((
+  <div>
+    <span>Test app module</span>
+    <span>Consortia is {stripes.user.user.consortia}</span>
+  </div>
+));
+
+const modules = {
+  settings: [{
+    route: '/test-app',
+    displayName: 'Test app',
+    module: 'ui-test-app',
+    getModule: () => TestApp,
+  }],
+  handler: [],
+};
+
+const getSettings = (props = {}, initialEntries = ['/settings']) => ((
+  <MemoryRouter initialEntries={initialEntries}>
+    <Intl>
+      <ModulesContext.Provider value={modules}>
+        <Settings
+          stripes={STRIPES}
+          {...props}
+        />
+      </ModulesContext.Provider>
+    </Intl>
+  </MemoryRouter>
+));
+
+const renderSettings = (props, initialEntries) => render(getSettings(props, initialEntries));
+
+describe('Settings', () => {
+  it('should render module settings links', () => {
+    const { getByRole } = renderSettings();
+
+    expect(getByRole('link', { name: 'Test app' })).toBeDefined();
+  });
+
+  describe('when location matches a module route', () => {
+    it('should render that module', () => {
+      const { getByText } = renderSettings(null, ['/settings/test-app']);
+
+      expect(getByText('Test app module')).toBeDefined();
+    });
+  });
+
+  describe('when stripes object changes', () => {
+    it('should re-render settings with updated stripes object', () => {
+      const { rerender, getByText } = renderSettings(null, ['/settings/test-app']);
+
+      expect(getByText('Consortia is old-consortia')).toBeDefined();
+
+      const updatedStripes = {
+        ...STRIPES,
+        user: {
+          user: {
+            consortia: 'new-consortia',
+          },
+        },
+      };
+
+      rerender(getSettings({ stripes: updatedStripes }, ['/settings/test-app']));
+
+      expect(getByText('Consortia is new-consortia')).toBeDefined();
+    });
+  });
+});

--- a/test/jest/__mock__/currencies.mock.js
+++ b/test/jest/__mock__/currencies.mock.js
@@ -1,0 +1,1 @@
+jest.mock('currency-codes/data', () => ({ filter: () => [] }));

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -2,3 +2,4 @@ import './stripesConfig.mock';
 import './intl.mock';
 import './stripesIcon.mock';
 import './stripesComponents.mock';
+import './currencies.mock';

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 jest.mock('@folio/stripes-components', () => ({
+  ...jest.requireActual('@folio/stripes-components'),
   Accordion: jest.fn(({ children, ...rest }) => (
     <span {...rest}>{children}</span>
   )),


### PR DESCRIPTION
## Description
Fix issue with permissions not updating when user changes active affiliation
Issue was caused by `connectedModules` only being create once in the component constructor, and all following renders were using old cached `stripes` object
To fix it I refactored the component to make it functional and used `useMemo` to generate `connectedModules`.

## Screenshots

https://github.com/folio-org/stripes-core/assets/19309423/c0a97dcb-6bf1-4f07-9071-ba52b3151d12

## Issues
[STCOR-797](https://issues.folio.org/browse/STCOR-797)