### PR TITLE
STCOR-793 avoid potentially unsafe optional chaining

### DIFF
--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -401,7 +401,11 @@ export function spreadUserWithPerms(userWithPerms) {
 
   // remap data's array of permission-names to set with
   // permission-names for keys and `true` for values
-  const perms = Object.assign({}, ...userWithPerms?.permissions?.permissions.map(p => ({ [p.permissionName]: true })));
+  let perms = {};
+  const list = userWithPerms?.permissions?.permissions;
+  if (list && Array.isArray(list)) {
+    perms = Object.assign({}, ...list.map(p => ({ [p.permissionName]: true })));
+  }
 
   return { user, perms };
 }


### PR DESCRIPTION
Optional chaining may return undefined. We fixed this on master in PR #1392 but that fix may not have been cautious enough for the kind of sparse data we may get back when dealing with Keycloak users. When stripes itself handles authentication, it will populate localstorage with permissions derived from that login response, but with keycloak in play that never happens; permissions are only _ever_ read from the response to the `/_self` request and thus never properly initialized.

Refs [STCOR-793](https://issues.folio.org/browse/STCOR-793)