### PR TITLE
STCOR-814 useOkapiKy uses || instead of ?? to apply current tenant id when override was not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Convert `<SSOLanding />` tests to jest. STCOR-798.
 * Avoid calling `map` on `undefined` via optional-chaining. Refs STCOR-793.
 * Make `<Settings>` a functional component. Update connected modules when `stripes` object changes. Fixes STCOR-797.
+* `useOkapiKy` uses || instead of ?? to apply current tenant id when override was not provided. Refs STCOR-814.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/useOkapiKy.js
+++ b/src/useOkapiKy.js
@@ -10,7 +10,7 @@ export default ({ tenant } = {}) => {
       beforeRequest: [
         request => {
           request.headers.set('Accept-Language', locale);
-          request.headers.set('X-Okapi-Tenant', tenant ?? currentTenant);
+          request.headers.set('X-Okapi-Tenant', tenant || currentTenant);
           if (token) {
             request.headers.set('X-Okapi-Token', token);
           }

--- a/src/useOkapiKy.test.js
+++ b/src/useOkapiKy.test.js
@@ -77,6 +77,30 @@ describe('useOkapiKy', () => {
 
     expect(r.headers.set).toHaveBeenCalledWith('X-Okapi-Tenant', 'monkey');
   });
+
+  describe('when tenant param is not null, but an empty value', () => {
+    it('should use okapi tenant id', () => {
+      const okapi = {
+        tenant: 'tenant',
+        timeout: 271828,
+        url: 'https://whatever.com'
+      };
+
+      const mockUseStripes = useStripes;
+      mockUseStripes.mockReturnValue({ okapi });
+
+      const r = {
+        headers: {
+          set: jest.fn(),
+        }
+      };
+
+      const { result } = renderHook(() => useOkapiKy({ tenant: '' }));
+      result.current.hooks.beforeRequest[0](r);
+
+      expect(r.headers.set).toHaveBeenCalledWith('X-Okapi-Tenant', 'tenant');
+    });
+  });
 });
 
 


### PR DESCRIPTION
## Description
Fix issue when passing `''`, `0`, `false` as `tenant` to `useOkapiKy` - requests will be sent with that value instead of current tenant id

## Issues
[STCOR-814](https://folio-org.atlassian.net/browse/STCOR-814)