### PR TITLE
Add opt-in "Really logout?" stripes.config.js option

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -51,7 +51,7 @@ export default class StripesCore extends Component {
         logger={this.logger}
         config={config}
         actionNames={this.actionNames}
-        disableAuth={(config && config.disableAuth) || false}
+        disableAuth={(config?.disableAuth) || false}
         {...props}
       />
     );

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -45,9 +45,9 @@ import PreLoginLanding from './components/PreLoginLanding';
 import { setOkapiTenant } from './okapiActions';
 
 export const renderLogoutComponent = (stripes) => {
-  const { okapi } = stripes;
+  const { okapi, config } = stripes;
 
-  if (okapi.authnUrl) {
+  if (okapi.authnUrl && config.confirmLogout) {
     return <Redirect to={`${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/logout?client_id=${okapi.clientId}&post_logout_redirect_uri=${window.location.protocol}//${window.location.host}`} />;
   }
 

--- a/src/RootWithIntl.test.js
+++ b/src/RootWithIntl.test.js
@@ -64,7 +64,7 @@ describe('RootWithIntl', () => {
     it('handles third-party logout', () => {
       const stripes = {
         okapi: { authnUrl: 'https://oppie.com' },
-        config: { },
+        config: { confirmLogout: true },
       };
       render(renderLogoutComponent(stripes));
 


### PR DESCRIPTION
- Fulfills [STCOR-803](https://folio-org.atlassian.net/browse/STCOR-803).
- If `config.confirmLogout` is truthy and `okapi.authnUrl` is set, then user is brought to confirm logout page, otherwise logout happen immediately.
- Small lint fix.