### PR TITLE
STCOR-815 Add SSO Login path to permissible resources in RTR code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Convert `<SSOLanding />` tests to jest. STCOR-798.
 * Avoid calling `map` on `undefined` via optional-chaining. Refs STCOR-793.
 * Make `<Settings>` a functional component. Update connected modules when `stripes` object changes. Fixes STCOR-797.
+* Include SSO endpoint in permissible resources list for RTR. Refs STCOR-815.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -262,7 +262,6 @@ export class FFetch {
       // So, maybe Michael Stipe is god. Oh, wait, crap, he lost his religion.
       // Look, RTR is complicated, what do you want?
       console.error('All tokens expired'); // eslint-disable-line no-console
-      debugger;
       document.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: 'All tokens expired' }));
       return Promise.resolve(new Response(JSON.stringify({})));
     }

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -100,6 +100,7 @@ export class FFetch {
         '/bl-users/login-with-expiry',
         '/bl-users/password-reset',
         '/saml/check',
+        `/_/invoke/tenant/${okapi.tenant}/saml/login`,
       ];
 
       this.logger.log('rtr', `AT invalid for ${resource}`);
@@ -261,6 +262,7 @@ export class FFetch {
       // So, maybe Michael Stipe is god. Oh, wait, crap, he lost his religion.
       // Look, RTR is complicated, what do you want?
       console.error('All tokens expired'); // eslint-disable-line no-console
+      debugger;
       document.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: 'All tokens expired' }));
       return Promise.resolve(new Response(JSON.stringify({})));
     }


### PR DESCRIPTION
Attempting an inital SSO login (no http cookie present) in browser incognito mode throws a RTR token error. Including the SSO path in `permissibleResources` circumvents the token check from this login.