### PR TITLE
STCOR-813 correctly parse .../_self permissions (#1421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Convert `<SSOLanding />` tests to jest. STCOR-798.
 * Avoid calling `map` on `undefined` via optional-chaining. Refs STCOR-793.
 * Make `<Settings>` a functional component. Update connected modules when `stripes` object changes. Fixes STCOR-797.
+* Correctly parse `.../_self` permissions object. Refs STCOR-813.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -397,11 +397,24 @@ export function spreadUserWithPerms(userWithPerms) {
     ...userWithPerms?.user?.personal,
   };
 
-  // remap permissions from [foo, bar, bat] to { foo: true, bar: true, ... }
-  const perms = userWithPerms?.permissions?.permissions?.reduce((acc, i) => {
-    acc[i.permissionName] = true;
-    return acc;
-  }, {});
+  // remap data's array of permission-names to set with
+  // permission-names for keys and `true` for values.
+  //
+  // userWithPerms is shaped differently depending on whether
+  // it comes from a login call or a `.../_self` call, which
+  // is just totally totally awesome. :|
+  // we'll parse it differently depending on what it looks like.
+  let perms = {};
+  const list = userWithPerms?.permissions?.permissions;
+  if (list && Array.isArray(list) && list.length > 0) {
+    // _self sends data like ["foo", "bar", "bat"]
+    // login sends data like [{ "permissionName": "foo" }]
+    if (typeof list[0] === 'string') {
+      perms = Object.assign({}, ...list.map(p => ({ [p]: true })));
+    } else {
+      perms = Object.assign({}, ...list.map(p => ({ [p.permissionName]: true })));
+    }
+  }
 
   return { user, perms };
 }


### PR DESCRIPTION
The shape of the permissions object differs between responses from calls to `login` and calls to `_self`. This is not awesome. We didn't notice this glitch prior to implementing keycloak because when resuming an existing session (i.e. when calling `_self`), permissions are set as the union of permissions in storage (i.e. stored by a call to `login`) and those from the call to `_self`. We just never noticed that the latter was always empty.

With keycloak handling authentication, however, the _only_ permissions we ever receive are in the response from `_self`, so we noticed this immediately.

Why is this relevant outside a keycloak implementation? If you change your permissions and reload, the new permissions will now take effect (because they'll be correctly read from the response from `_self`; previously, you would have to sign out and then back in. 

Refs [STCOR-813](https://folio-org.atlassian.net/browse/STCOR-813)

(cherry picked from commit 6256604f49eb1d079e1f6e78c97fa1dfd1075995)