### PR TITLE
Revert "STCOR-810 cleanup deprecated entitlement params"

### DIFF
--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -63,7 +63,7 @@ const About = (props) => {
       )}
       <AboutInstallMessages />
       <div className={css.versionsContainer}>
-        {okapiConfig.tenantOptions ? (
+        {okapiConfig.tenantEntitlementUrl ? (
           <>
             <div className={css.versionsColumn} data-test-stripes-core-about-module-versions>
               <AboutApplicationVersions message={numApplicationsMsg} applications={applications} />

--- a/src/components/About/About.test.js
+++ b/src/components/About/About.test.js
@@ -36,7 +36,7 @@ jest.mock('./AboutUIModuleDetails', () => () => 'AboutUIModuleDetails');
 jest.mock('./WarningBanner', () => () => 'WarningBanner');
 
 jest.mock('stripes-config', () => ({
-  okapi: { tenantOptions: true },
+  okapi: { tenantEntitlementUrl: true },
 }));
 
 // set query retries to false. otherwise, react-query will thoughtfully

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -220,7 +220,7 @@ function fetchModules(store) {
  */
 export function discoverServices(store) {
   const promises = [];
-  if (okapiConfig.tenantOptions) {
+  if (okapiConfig.tenantEntitlementUrl) {
     promises.push(fetchApplicationDetails(store));
     promises.push(fetchGatewayVersion(store));
   } else {


### PR DESCRIPTION
Reverts folio-org/stripes-core#1418

The conditional here checked `okapi.tenantOptions`; it must check `config.tenantOptions`.