### PR TITLE
STCOR-810 CORRECTLY clean up deprecated entitlement params

### DIFF
--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { okapi as okapiConfig } from 'stripes-config';
+import { config } from 'stripes-config';
 import {
   Headline,
   Loading,
@@ -63,7 +63,7 @@ const About = (props) => {
       )}
       <AboutInstallMessages />
       <div className={css.versionsContainer}>
-        {okapiConfig.tenantEntitlementUrl ? (
+        {config.tenantOptions ? (
           <>
             <div className={css.versionsColumn} data-test-stripes-core-about-module-versions>
               <AboutApplicationVersions message={numApplicationsMsg} applications={applications} />

--- a/src/components/About/About.test.js
+++ b/src/components/About/About.test.js
@@ -36,7 +36,7 @@ jest.mock('./AboutUIModuleDetails', () => () => 'AboutUIModuleDetails');
 jest.mock('./WarningBanner', () => () => 'WarningBanner');
 
 jest.mock('stripes-config', () => ({
-  okapi: { tenantEntitlementUrl: true },
+  config: { tenantOptions: true },
 }));
 
 // set query retries to false. otherwise, react-query will thoughtfully

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -1,5 +1,5 @@
 import { some } from 'lodash';
-import { okapi as okapiConfig } from 'stripes-config';
+import { config } from 'stripes-config';
 
 function getHeaders(tenant, token) {
   return {
@@ -220,7 +220,7 @@ function fetchModules(store) {
  */
 export function discoverServices(store) {
   const promises = [];
-  if (okapiConfig.tenantEntitlementUrl) {
+  if (config.tenantOptions) {
     promises.push(fetchApplicationDetails(store));
     promises.push(fetchGatewayVersion(store));
   } else {

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -1,4 +1,5 @@
 import localforage from 'localforage';
+import { config } from 'stripes-config';
 
 import {
   createOkapiSession,
@@ -15,8 +16,6 @@ import {
   updateUser,
   validateUser,
 } from './loginServices';
-
-
 
 import {
   clearCurrentUser,
@@ -61,6 +60,19 @@ jest.mock('localforage', () => ({
   getItem: jest.fn(() => Promise.resolve({ user: {} })),
   setItem: jest.fn(() => Promise.resolve()),
   removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('stripes-config', () => ({
+  config: {
+    tenantOptions: {
+      romulus: { name: 'romulus', clientId: 'romulus-application' },
+      remus: { name: 'remus', clientId: 'remus-application' },
+    }
+  },
+  okapi: {
+    authnUrl: 'https://authn.url',
+  },
+  translations: {}
 }));
 
 // fetch success: resolve promise with ok == true and $data in json()


### PR DESCRIPTION
Remove references to the `stripes.config.js::config` values `tenantManagerUrl` and `applicationManagerUrl`. These were present in early drafts of the new discovery work but have since been deprecated and therefore must be removed from code as well.

Replaces #1418, which did this work incorrectly (referring to `okapi.[...]` instead of `config.[...]`).

Refs [STCOR-810](https://folio-org.atlassian.net/browse/STCOR-810)