### PR TITLE
STCOR-816 only fetch /saml/check when login-saml is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Correctly parse `.../_self` permissions object. Refs STCOR-813.
 * Export `getEventHandler` to be able to create events in other modules. Refs STCOR-770.
 * Simplify logout workflow to bypass keycloak confirmation page. Refs STCOR-803.
+* After login, only check SSO endpoints when `login-saml` interface is present. Refs STCOR-816.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -451,7 +451,7 @@ export async function logout(okapiUrl, store) {
     .then(localforage.removeItem('loginResponse'))
     .catch((error) => {
       // eslint-disable-next-line no-console
-      console.log(`Error logging out: ${JSON.stringify(error)}`)
+      console.log(`Error logging out: ${JSON.stringify(error)}`);
     });
 }
 

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -750,7 +750,10 @@ export function checkOkapiSession(okapiUrl, store, tenant) {
       return sess !== null ? validateUser(okapiUrl, store, tenant, sess) : null;
     })
     .then(() => {
-      return getSSOEnabled(okapiUrl, store, tenant);
+      if (store.getState().discovery?.interfaces?.['login-saml']) {
+        return getSSOEnabled(okapiUrl, store, tenant);
+      }
+      return Promise.resolve();
     })
     .finally(() => {
       store.dispatch(setOkapiReady());


### PR DESCRIPTION
When restoring an existing session, after discovery, do not fetch from `/saml/check` unless the `login-saml` interface (indicating SSO/SAML is available). The 404 clutters the log.

I don't have tests for this. It's a real simple fix; it's a real PITA to mock, but we can try if that's a deal-breaker.

Refs [STCOR-816](https://folio-org.atlassian.net/browse/STCOR-816)