### PR TITLE
STCOR-742 Remove autoComplete attribute from 'forgot' fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Make `<Settings>` a functional component. Update connected modules when `stripes` object changes. Fixes STCOR-797.
 * `useOkapiKy` uses || instead of ?? to apply current tenant id when override was not provided. Refs STCOR-814.
 * Correctly parse `.../_self` permissions object. Refs STCOR-813.
+* Remove `autoComplete` from `<ForgotPassword>`, `<ForgotUsername>` fields. Refs STCOR-742.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/components/ForgotPassword/ForgotPasswordForm.js
+++ b/src/components/ForgotPassword/ForgotPasswordForm.js
@@ -75,7 +75,6 @@ class ForgotPasswordForm extends Component {
                     inputClass={formStyles.input}
                     validationEnabled={false}
                     hasClearIcon={false}
-                    autoComplete="on"
                     autoCapitalize="none"
                     autoFocus
                     placeholder={formatMessage({ id: 'stripes-core.placeholder.forgotPassword' })}

--- a/src/components/ForgotUserName/ForgotUserNameForm.js
+++ b/src/components/ForgotUserName/ForgotUserNameForm.js
@@ -78,7 +78,6 @@ class ForgotUserNameForm extends Component {
                     inputClass={formStyles.input}
                     validationEnabled={false}
                     hasClearIcon={false}
-                    autoComplete="on"
                     autoCapitalize="none"
                     autoFocus
                     placeholder={formatMessage({ id: 'stripes-core.placeholder.forgotUsername' })}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STCOR-742

For a11y purposes, autocomplete is inadequate for describing the intent of this field. The list of acceptable values for this are across the spectrum, but none capture that of something with such a variable type - an email address or a phone number.