### PR TITLE
STCOR-821 Add `idName` and `limit` as passable props to `useChunkedCQLFetch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Make `<Settings>` a functional component. Update connected modules when `stripes` object changes. Fixes STCOR-797.
 * `useOkapiKy` uses || instead of ?? to apply current tenant id when override was not provided. Refs STCOR-814.
 * Correctly parse `.../_self` permissions object. Refs STCOR-813.
-* Add `idName` and `limit` as passable parameters to `useChunkedCQLFetch`. Refs STCOR-821.
+* Add `idName` and `limit` as passable props to `useChunkedCQLFetch`. Refs STCOR-821.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Make `<Settings>` a functional component. Update connected modules when `stripes` object changes. Fixes STCOR-797.
 * `useOkapiKy` uses || instead of ?? to apply current tenant id when override was not provided. Refs STCOR-814.
 * Correctly parse `.../_self` permissions object. Refs STCOR-813.
+* Add `idName` and `limit` as passable parameters to `useChunkedCQLFetch`. Refs STCOR-821.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/queries/useChunkedCQLFetch.js
+++ b/src/queries/useChunkedCQLFetch.js
@@ -33,10 +33,12 @@ const useChunkedCQLFetch = ({
   CONCURRENT_REQUESTS = CONCURRENT_REQUESTS_DEFAULT, // Number of requests to make concurrently
   endpoint, // endpoint to hit to fetch items
   generateQueryKey, // Passed function to allow customised query keys
-  ids: passedIds, // List of ids to fetch
+  ids: passedIds, // List of IDs to fetch
+  idName = 'id', // Named ID field to use in the CQL query (i.e. id or userId)
+  limit = 1000, // Item limit to fetch on each request
   queryOptions: passedQueryOptions = {}, // Options to pass to each query
   reduceFunction, // Function to reduce fetched objects at the end into single array
-  STEP_SIZE = STEP_SIZE_DEFAULT // Number of ids fetch per request
+  STEP_SIZE = STEP_SIZE_DEFAULT // Number of IDs fetch per request
 }) => {
   const ky = useOkapiKy();
 
@@ -58,7 +60,7 @@ const useChunkedCQLFetch = ({
   const getQueryArray = useCallback(() => {
     const queryArray = [];
     chunkedItems.forEach((chunkedItem, chunkedItemIndex) => {
-      const query = `id==(${chunkedItem.join(' or ')})`;
+      const query = `${idName}==(${chunkedItem.join(' or ')})`;
       const queryKey = generateQueryKey ?
         generateQueryKey({
           CONCURRENT_REQUESTS,
@@ -72,7 +74,7 @@ const useChunkedCQLFetch = ({
         ['stripes-core', endpoint, chunkedItem];
       queryArray.push({
         queryKey,
-        queryFn: () => ky.get(`${endpoint}?limit=1000&query=${query}`).json(),
+        queryFn: () => ky.get(`${endpoint}?limit=${limit}&query=${query}`).json(),
         // Only enable once the previous slice has all been fetched
         enabled: queryEnabled && chunkedItemIndex < CONCURRENT_REQUESTS,
         ...queryOptions
@@ -85,7 +87,9 @@ const useChunkedCQLFetch = ({
     CONCURRENT_REQUESTS,
     endpoint,
     generateQueryKey,
+    idName,
     ids,
+    limit,
     ky,
     queryEnabled,
     queryOptions,

--- a/src/queries/useChunkedCQLFetch.test.js
+++ b/src/queries/useChunkedCQLFetch.test.js
@@ -157,4 +157,41 @@ describe('Given useChunkedCQLFetch', () => {
       expect(result.current.itemQueries?.length).toEqual(6);
     });
   });
+
+  describe('allows parameter overrides', () => {
+    it('sets up 1 fetch using alternate ID name', async () => {
+      const { result } = renderHook(() => useChunkedCQLFetch({
+        ...baseOptions,
+        idName: 'userId'
+      }), { wrapper });
+
+      await waitFor(() => {
+        const loadingQueries = result.current.itemQueries?.filter(iq => iq.isLoading);
+
+        return loadingQueries.length === 0;
+      });
+
+      expect(result.current.itemQueries?.length).toEqual(1);
+    });
+
+    it('sets up 2 fetches with custom limit', async () => {
+      const largeIdSet = [];
+      for (let i = 0; i < 100; i++) {
+        largeIdSet.push(makeid(5));
+      }
+
+      const { result } = renderHook(() => useChunkedCQLFetch({
+        ...baseOptions,
+        ids: largeIdSet,
+        limit: 100
+      }), { wrapper });
+
+      await waitFor(() => {
+        const loadingQueries = result.current.itemQueries?.filter(iq => iq.isLoading);
+        return loadingQueries.length === 0;
+      });
+
+      expect(result.current.itemQueries?.length).toEqual(2);
+    });
+  });
 });


### PR DESCRIPTION
- Fulfills [STCOR-821](https://folio-org.atlassian.net/browse/STCOR-821)
- Allow for parameter idName to be overridden to allow for using other IDs when id alone is too ambiguous (such as a case where userId, roleId, etc is needed).
- Allow for parameter limit to be overridden if a different response limit is needed.