### PR TITLE
STCOR-820 For the /reset-password route, allow token to be specified in the path or query arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Simplify logout workflow to bypass keycloak confirmation page. Refs STCOR-803.
 * After login, only check SSO endpoints when `login-saml` interface is present. Refs STCOR-816.
 * Add `idName` and `limit` as passable props to `useChunkedCQLFetch`. Refs STCOR-821.
+* For the `/reset-password` route, allow token to be specified in the path or query arguments. Refs STCOR-820.
 
 ## [10.0.0](https://github.com/folio-org/stripes-core/tree/v10.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v9.0.0...v10.0.0)

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -173,7 +173,7 @@ class RootWithIntl extends React.Component {
                       <Switch>
                         <TitledRoute
                           name="CreateResetPassword"
-                          path="/reset-password/:token"
+                          path="/reset-password/:token?"
                           component={<CreateResetPassword stripes={stripes} />}
                         />
                         <TitledRoute

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -8,6 +8,7 @@ import { stripesShape } from '../../Stripes';
 import { setAuthError } from '../../okapiActions';
 import { defaultErrors } from '../../constants';
 import OrganizationLogo from '../OrganizationLogo';
+import { getLocationQuery } from '../../locationService';
 
 import CreateResetPassword from './CreateResetPassword';
 import PasswordHasNotChanged from './components/PasswordHasNotChanged';
@@ -18,13 +19,14 @@ class CreateResetPasswordControl extends Component {
   static propTypes = {
     authFailure: PropTypes.arrayOf(PropTypes.object),
     location: PropTypes.shape({
+      query: PropTypes.string,
       search: PropTypes.string.isRequired,
     }),
     match: PropTypes.shape({
       params: PropTypes.shape({
-        token: PropTypes.string.isRequired,
-      }).isRequired,
-    }).isRequired,
+        token: PropTypes.string,
+      }),
+    }),
     stripes: stripesShape.isRequired,
     handleBadResponse: PropTypes.func.isRequired,
     clearAuthErrors: PropTypes.func.isRequired,
@@ -107,6 +109,7 @@ class CreateResetPasswordControl extends Component {
       },
     } = stripes;
 
+    const resetToken = token ?? getLocationQuery(location)?.resetToken;
     const interfacePath = stripes.hasInterface('users-keycloak') ? 'users-keycloak' : 'bl-users';
     const path = `${url}/${interfacePath}/password-reset/${isValidToken ? 'reset' : 'validate'}`;
 
@@ -114,7 +117,7 @@ class CreateResetPasswordControl extends Component {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-okapi-token': token,
+        'x-okapi-token': resetToken,
         'x-okapi-tenant': getTenant(stripes, location),
       },
       ...(body && { body: JSON.stringify(body) }),
@@ -145,11 +148,6 @@ class CreateResetPasswordControl extends Component {
   render() {
     const {
       authFailure,
-      match: {
-        params: {
-          token,
-        },
-      },
       clearAuthErrors,
     } = this.props;
 
@@ -178,7 +176,6 @@ class CreateResetPasswordControl extends Component {
 
     return (
       <CreateResetPassword
-        token={token}
         errors={authFailure}
         stripes={this.props.stripes}
         onSubmit={this.handleSubmit}

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.test.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.test.js
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { Provider } from 'react-redux';
+
+import { getLocationQuery } from '../../locationService';
+import CreateResetPasswordControl from './CreateResetPasswordControl';
+
+jest.mock('../OrganizationLogo');
+
+jest.mock('../../locationService', () => ({
+  getLocationQuery: jest.fn()
+}));
+
+describe('CreateResetPasswordControl', () => {
+  const mockFetch = jest.fn(() => Promise.resolve({
+    json: () => Promise.resolve({ test: 100 }),
+  }));
+
+  const stripes = {
+    clone: jest.fn(),
+    config: {},
+    okapi: {
+      url: 'http://test'
+    },
+    hasInterface: jest.fn().mockReturnValue(true),
+    store: {
+      getState: () => ({
+        okapi: {
+          token: '123',
+        },
+      }),
+      dispatch: () => {},
+      subscribe: () => {},
+      replaceReducer: () => {},
+    }
+  };
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('uses reset token in URL param', async () => {
+    getLocationQuery.mockReturnValue({ resetToken: '123' });
+
+    const history = createMemoryHistory();
+
+    render(
+      <Provider store={stripes.store}>
+        <Router history={history}>
+          <CreateResetPasswordControl stripes={stripes} />
+        </Router>
+      </Provider>
+    );
+
+    console.log(mockFetch.mock.lastCall[1].headers);
+
+    expect(mockFetch.mock.lastCall[1].headers['x-okapi-token'] === '123').toBeTruthy();
+  });
+});

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.test.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.test.js
@@ -57,8 +57,6 @@ describe('CreateResetPasswordControl', () => {
       </Provider>
     );
 
-    console.log(mockFetch.mock.lastCall[1].headers);
-
     expect(mockFetch.mock.lastCall[1].headers['x-okapi-token'] === '123').toBeTruthy();
   });
 });


### PR DESCRIPTION
- Fulfills [STCOR-820](https://folio-org.atlassian.net/browse/STCOR-820)
- Add support for optional URL parameter `resetToken` which allows us to use longer keys since path has a much smaller allowable length than URL params
- Removed token param passed into `<CreateResetPassword>` component since it's not used there.