### PR TITLE
STCOR-712 Refactor tagname selectors used in Auth-related forms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 10.1.1 IN PROGRESS
 
 * Utilize the `tenant` procured through the SSO login process. Refs STCOR-769.
+* Remove tag-based selectors from Login, ResetPassword, Forgot UserName/Password form CSS. Refs STCOR-712.
 
 ## 10.1.0 IN PROGRESS
 

--- a/src/components/CreateResetPassword/CreateResetPassword.css
+++ b/src/components/CreateResetPassword/CreateResetPassword.css
@@ -27,6 +27,19 @@ body {
   width: 100%;
   outline: 0;
   text-align: center;
+
+  & .passResetInput {
+    height: 44px;
+    padding: 8px;
+    font-size: var(--font-size-medium);
+  }
+
+  & .passResetSubmitButton {
+    height: 44px;
+    max-height: 100%;
+    margin-top: 1.5rem;
+    font-size: var(--font-size-medium);
+  }
 }
 
 .formGroup {
@@ -41,18 +54,7 @@ body {
   margin-top: 10px;
 }
 
-input.input {
-  height: 44px;
-  padding: 8px;
-  font-size: var(--font-size-medium);
-}
 
-button.submitButton {
-  height: 44px;
-  max-height: 100%;
-  margin-top: 1.5rem;
-  font-size: var(--font-size-medium);
-}
 
 .toggleButtonWrapper {
   display: flex;
@@ -96,15 +98,17 @@ button.submitButton {
     min-height: initial;
   }
 
-  button.submitButton {
-    height: 60px;
-    font-size: var(--font-size-large);
-  }
+  .form {
+    .passResetSubmitButton {
+      height: 60px;
+      font-size: var(--font-size-large);
+    }
 
-  input.input {
-    height: 60px;
-    padding: 15px;
-    font-size: var(--font-size-medium);
+    .passResetInput {
+      height: 60px;
+      padding: 15px;
+      font-size: var(--font-size-medium);
+    }
   }
 
   .passwordStrength {

--- a/src/components/CreateResetPassword/CreateResetPassword.js
+++ b/src/components/CreateResetPassword/CreateResetPassword.js
@@ -199,7 +199,7 @@ class CreateResetPassword extends Component {
                           name="newPassword"
                           autoComplete="new-password"
                           component={PasswordStrength}
-                          inputClass={styles.input}
+                          inputClass={styles.passResetInput}
                           type={passwordType}
                           hasClearIcon={false}
                           autoFocus
@@ -251,7 +251,7 @@ class CreateResetPassword extends Component {
                             type={passwordType}
                             marginBottom0
                             fullWidth
-                            inputClass={styles.input}
+                            inputClass={styles.passResetInput}
                             validationEnabled={false}
                             hasClearIcon={false}
                             autoComplete="new-password"
@@ -291,7 +291,7 @@ class CreateResetPassword extends Component {
                           buttonStyle="primary"
                           id="clickable-login"
                           type="submit"
-                          buttonClass={styles.submitButton}
+                          buttonClass={styles.passResetSubmitButton}
                           disabled={isButtonDisabled(getState)}
                           fullWidth
                           marginBottom0

--- a/src/components/ForgotPassword/ForgotPasswordForm.css
+++ b/src/components/ForgotPassword/ForgotPasswordForm.css
@@ -20,6 +20,18 @@
 .form {
   outline: 0;
   text-align: center;
+
+  & .passForgotInput {
+    height: 60px;
+    font-size: var(--font-size-medium);
+    padding: 15px;
+  }
+
+  & .passForgotSubmitButton {
+    height: 60px;
+    max-height: 100%;
+    font-size: var(--font-size-large);
+  }
 }
 
 .formGroup {
@@ -32,18 +44,6 @@
 
 .authErrorsWrapper {
   margin-top: 10px;
-}
-
-input.input {
-  height: 60px;
-  font-size: var(--font-size-medium);
-  padding: 15px;
-}
-
-button.submitButton {
-  height: 60px;
-  max-height: 100%;
-  font-size: var(--font-size-large);
 }
 
 @media (height <= 440px) {
@@ -62,9 +62,11 @@ button.submitButton {
     font-size: var(--font-size-medium);
   }
 
-  input.input {
-    height: 44px;
-    font-size: var(--font-size-medium);
-    padding: 8px;
+  .form {
+    & .passForgotInput {
+      height: 44px;
+      font-size: var(--font-size-medium);
+      padding: 8px;
+    }
   }
 }

--- a/src/components/ForgotPassword/ForgotPasswordForm.js
+++ b/src/components/ForgotPassword/ForgotPasswordForm.js
@@ -72,7 +72,7 @@ class ForgotPasswordForm extends Component {
                     type="text"
                     marginBottom0
                     fullWidth
-                    inputClass={formStyles.input}
+                    inputClass={formStyles.passForgotInput}
                     validationEnabled={false}
                     hasClearIcon={false}
                     autoCapitalize="none"
@@ -85,7 +85,7 @@ class ForgotPasswordForm extends Component {
                   id="clickable-login"
                   name="continue-button"
                   type="submit"
-                  buttonClass={formStyles.submitButton}
+                  buttonClass={formStyles.passForgotSubmitButton}
                   disabled={pristine}
                   fullWidth
                   marginBottom0

--- a/src/components/ForgotUserName/ForgotUserNameForm.css
+++ b/src/components/ForgotUserName/ForgotUserNameForm.css
@@ -20,6 +20,18 @@
 .form {
   outline: 0;
   text-align: center;
+
+  & .forgotUserInput {
+    height: 60px;
+    font-size: var(--font-size-medium);
+    padding: 15px;
+  }
+
+  & .forgotUserSubmitButton {
+    height: 60px;
+    max-height: 100%;
+    font-size: var(--font-size-large);
+  }
 }
 
 .formGroup {
@@ -34,18 +46,6 @@
   margin-top: 10px;
 }
 
-input.input {
-  height: 60px;
-  font-size: var(--font-size-medium);
-  padding: 15px;
-}
-
-button.submitButton {
-  height: 60px;
-  max-height: 100%;
-  font-size: var(--font-size-large);
-}
-
 @media (height <= 440px) {
   .centered {
     min-height: 330px;
@@ -57,14 +57,16 @@ button.submitButton {
     min-height: 330px;
   }
 
-  button.submitButton {
-    height: 44px;
-    font-size: var(--font-size-medium);
-  }
+  .form {
+    & .forgotUserSubmitButton {
+      height: 44px;
+      font-size: var(--font-size-medium);
+    }
 
-  input.input {
-    height: 44px;
-    font-size: var(--font-size-medium);
-    padding: 8px;
+    & .forgotUserInput {
+      height: 44px;
+      font-size: var(--font-size-medium);
+      padding: 8px;
+    }
   }
 }

--- a/src/components/ForgotUserName/ForgotUserNameForm.js
+++ b/src/components/ForgotUserName/ForgotUserNameForm.js
@@ -75,7 +75,7 @@ class ForgotUserNameForm extends Component {
                     type="text"
                     marginBottom0
                     fullWidth
-                    inputClass={formStyles.input}
+                    inputClass={formStyles.forgotUserInput}
                     validationEnabled={false}
                     hasClearIcon={false}
                     autoCapitalize="none"
@@ -88,7 +88,7 @@ class ForgotUserNameForm extends Component {
                   id="clickable-login"
                   name="continue-button"
                   type="submit"
-                  buttonClass={formStyles.submitButton}
+                  buttonClass={formStyles.forgotUserSubmitButton}
                   disabled={pristine}
                   fullWidth
                   marginBottom0

--- a/src/components/Login/Login.css
+++ b/src/components/Login/Login.css
@@ -17,6 +17,19 @@
   width: 100%;
   outline: 0;
   text-align: center;
+
+  & .loginInput {
+    height: 44px;
+    padding: 8px;
+    font-size: var(--font-size-medium);
+  }
+
+  & .loginSubmitButton {
+    height: 44px;
+    max-height: 100%;
+    margin-top: 1.5rem;
+    font-size: var(--font-size-medium);
+  }
 }
 
 .formGroup {
@@ -32,19 +45,6 @@
   margin-top: 1rem;
 }
 
-input.input {
-  height: 44px;
-  padding: 8px;
-  font-size: var(--font-size-medium);
-}
-
-button.submitButton {
-  height: 44px;
-  max-height: 100%;
-  margin-top: 1.5rem;
-  font-size: var(--font-size-medium);
-}
-
 .link {
   display: block;
   width: 100%;
@@ -58,16 +58,19 @@ button.submitButton {
     min-height: initial;
   }
 
-  button.submitButton {
-    height: 60px;
-    font-size: var(--font-size-large);
+  .form {
+    & .loginSubmitButton {
+      height: 60px;
+      font-size: var(--font-size-large);
+    }
+
+    & .loginInput {
+      height: 60px;
+      padding: 15px;
+      font-size: var(--font-size-medium);
+    }
   }
 
-  input.input {
-    height: 60px;
-    padding: 15px;
-    font-size: var(--font-size-medium);
-  }
 }
 
 @media (--large-up) {

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -119,7 +119,7 @@ class Login extends Component {
                               name="username"
                               type="text"
                               component={TextField}
-                              inputClass={styles.input}
+                              inputClass={styles.loginInput}
                               autoComplete="username"
                               autoCapitalize="none"
                               validationEnabled={false}
@@ -156,7 +156,7 @@ class Login extends Component {
                               value=""
                               marginBottom0
                               fullWidth
-                              inputClass={styles.input}
+                              inputClass={styles.loginInput}
                               validationEnabled={false}
                               hasClearIcon={false}
                               autoComplete="current-password"
@@ -171,7 +171,7 @@ class Login extends Component {
                               buttonStyle="primary"
                               id="clickable-login"
                               type="submit"
-                              buttonClass={styles.submitButton}
+                              buttonClass={styles.loginSubmitButton}
                               disabled={buttonDisabled}
                               fullWidth
                               marginBottom0


### PR DESCRIPTION
Login, Reset Password, Forgot Username workflows all made use of tagname selectors. This may have been implemented this way for sake of specificity at the time, but we'll want to prevent these from running into trouble once global selectors are eliminated. My instincts also really want to consolidate these styles - but they were purposefully separated a long time ago. Shelving that under possible future work.

https://folio-org.atlassian.net/browse/STCOR-712
  

