### PR TITLE
STCOR-789-follow-up: Include /authn/token on the list of always-permissible API

### DIFF
--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Redirect from '../Redirect';
 import PreLoginLanding from '../PreLoginLanding';
@@ -10,7 +10,7 @@ import { setUnauthorizedPathToSession } from '../../loginServices';
 const AuthnLogin = ({ stripes }) => {
   const { config, okapi } = stripes;
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (okapi.authnUrl) {
     /** Store unauthorized pathname to session storage. Refs STCOR-789
     * @see OIDCRedirect

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import Redirect from '../Redirect';
 import PreLoginLanding from '../PreLoginLanding';
@@ -10,7 +10,7 @@ import { setUnauthorizedPathToSession } from '../../loginServices';
 const AuthnLogin = ({ stripes }) => {
   const { config, okapi } = stripes;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (okapi.authnUrl) {
     /** Store unauthorized pathname to session storage. Refs STCOR-789
     * @see OIDCRedirect

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -95,6 +95,7 @@ export class FFetch {
 
     const isPermissibleResource = (string) => {
       const permissible = [
+        '/authn/token',
         '/bl-users/forgotten/password',
         '/bl-users/forgotten/username',
         '/bl-users/login-with-expiry',

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -458,7 +458,6 @@ export async function logout(okapiUrl, store) {
     .then(localStorage.removeItem('tenant'))
     .then(localforage.removeItem(SESSION_NAME))
     .then(localforage.removeItem('loginResponse'))
-    .then(removeUnauthorizedPathFromSession)
     .catch((error) => {
       // eslint-disable-next-line no-console
       console.log(`Error logging out: ${JSON.stringify(error)}`);
@@ -804,7 +803,7 @@ export function requestLogin(okapiUrl, store, tenant, data) {
       method: 'POST',
       mode: 'cors',
     })
-    .then(resp => processOkapiSession(store, tenant, resp));
+      .then(resp => processOkapiSession(store, tenant, resp));
   }
 }
 


### PR DESCRIPTION
Include `/authn/token` on the list of always-permissible API in order to
allow OTP-for-cookie exchange on return from authentication. Without
this allowance in place, stripes will get stuck in a loop bouncing
between the authn-server (which believes, correctly, that the user has
authenticated) and stripes (which believes, wrongly, that the user has
not authenticated because its "valid AT?" check fails). The AT won't be
valid until after we get to exchange the OTP for an AT by visiting
`/authn/token`.