### PR TITLE
STCOR-830 provide useUserTenantPermissions hook

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,8 @@
 {
-  "extends": "@folio/eslint-config-stripes",
-  "parser": "@babel/eslint-parser",
-  "rules": {
-    "global-require": "off",
-    "import/no-cycle": [ 2, { "maxDepth": 1 } ],
-    "import/no-dynamic-require": "off",
-    "import/no-extraneous-dependencies": "off",
-    "prefer-object-spread": "off"
+  "env": {
+    "jest": true
   },
+  "extends": "@folio/eslint-config-stripes",
   "overrides": [
     {
       "files": [ "src/**/tests/*", "test/**/*", "*test.js" ],
@@ -21,7 +16,24 @@
       }
     }
   ],
-  "env": {
-    "jest": true
+  "parser": "@babel/eslint-parser",
+  "rules": {
+    "global-require": "off",
+    "import/no-cycle": [ 2, { "maxDepth": 1 } ],
+    "import/no-dynamic-require": "off",
+    "import/no-extraneous-dependencies": "off",
+    "prefer-object-spread": "off"
+  },
+  "settings": {
+    "import/resolver": {
+      "alias": {
+        "map": [
+          ["__mock__", "./test/jest/__mock__"],
+          ["fixtures", "./test/jest/fixtures"],
+          ["helpers", "./test/jest/helpers"]
+        ]
+      }
+    }
   }
 }
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Utilize the `tenant` procured through the SSO login process. Refs STCOR-769.
 * Remove tag-based selectors from Login, ResetPassword, Forgot UserName/Password form CSS. Refs STCOR-712.
+* Provide `useUserTenantPermissions` hook. Refs STCOR-830.
 
 ## 10.1.0 IN PROGRESS
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ export {
 /* Queries */
 export { useChunkedCQLFetch } from './src/queries';
 
+/* Hooks */
+export { useUserTenantPermissions } from './src/hooks';
+
 /* misc */
 export { supportedLocales } from './src/loginServices';
 export { supportedNumberingSystems } from './src/loginServices';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,2 @@
+export { default as useUserTenantPermissions } from './useUserTenantPermissions';
+

--- a/src/hooks/useUserTenantPermissions.js
+++ b/src/hooks/useUserTenantPermissions.js
@@ -1,0 +1,59 @@
+import { useQuery } from 'react-query';
+
+import { useStripes } from '../StripesContext';
+import { useNamespace } from '../components';
+import useOkapiKy from '../useOkapiKy';
+
+const INITIAL_DATA = [];
+
+const useUserTenantPermissions = (
+  { tenantId },
+  options = {},
+) => {
+  const stripes = useStripes();
+  const ky = useOkapiKy();
+  const api = ky.extend({
+    hooks: {
+      beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', tenantId)]
+    }
+  });
+  const [namespace] = useNamespace({ key: 'user-affiliation-permissions' });
+
+  const user = stripes.user.user;
+
+  const searchParams = {
+    full: 'true',
+    indexField: 'userId',
+  };
+
+  const {
+    isFetching,
+    isLoading,
+    data = {},
+  } = useQuery(
+    [namespace, user?.id, tenantId],
+    ({ signal }) => {
+      return api.get(
+        `perms/users/${user.id}/permissions`,
+        {
+          searchParams,
+          signal,
+        },
+      ).json();
+    },
+    {
+      enabled: Boolean(user?.id && tenantId),
+      keepPreviousData: true,
+      ...options,
+    },
+  );
+
+  return ({
+    isFetching,
+    isLoading,
+    userPermissions: data.permissionNames || INITIAL_DATA,
+    totalRecords: data.totalRecords,
+  });
+};
+
+export default useUserTenantPermissions;

--- a/src/hooks/useUserTenantPermissions.test.js
+++ b/src/hooks/useUserTenantPermissions.test.js
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import permissions from 'fixtures/permissions';
+import useUserTenantPermissions from './useUserTenantPermissions';
+import useOkapiKy from '../useOkapiKy';
+import { useNamespace } from '../components';
+import { useStripes } from '../StripesContext';
+
+jest.mock('../useOkapiKy');
+jest.mock('../components', () => ({
+  useNamespace: () => ([]),
+}));
+jest.mock('../StripesContext', () => ({
+  useStripes: () => ({
+    user: {
+      user: {
+        id: 'userId'
+      }
+    }
+  }),
+}));
+
+const queryClient = new QueryClient();
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+const response = {
+  permissionNames: permissions,
+  totalRecords: permissions.length,
+};
+
+describe('useUserTenantPermissions', () => {
+  const getMock = jest.fn(() => ({
+    json: () => Promise.resolve(response),
+  }));
+  const setHeaderMock = jest.fn();
+  const kyMock = {
+    extend: jest.fn(({ hooks: { beforeRequest } }) => {
+      beforeRequest.forEach(handler => handler({ headers: { set: setHeaderMock } }));
+
+      return {
+        get: getMock,
+      };
+    }),
+  };
+
+  beforeEach(() => {
+    getMock.mockClear();
+    useOkapiKy.mockClear().mockReturnValue(kyMock);
+  });
+
+  it('should fetch user permissions for specified tenant', async () => {
+    const options = {
+      userId: 'userId',
+      tenantId: 'tenantId',
+    };
+    const { result } = renderHook(() => useUserTenantPermissions(options), { wrapper });
+
+    await waitFor(() => !result.current.isLoading);
+
+    expect(setHeaderMock).toHaveBeenCalledWith('X-Okapi-Tenant', options.tenantId);
+    expect(getMock).toHaveBeenCalledWith(`perms/users/${options.userId}/permissions`, expect.objectContaining({}));
+  });
+});

--- a/test/jest/fixtures/permissions.json
+++ b/test/jest/fixtures/permissions.json
@@ -1,0 +1,30 @@
+[
+  {
+    "deprecated": false,
+    "description": "Grants all permissions included in Agreements: Search & view agreements plus the ability to delete agreements. This does not include the ability to edit agreements, only to delete them",
+    "displayName": "Agreements: Delete agreements",
+    "grantedTo": ["8fafcfdb-419c-483e-a698-d7f8f46ea694"],
+    "id": "026bc082-add6-4cdd-a4fd-a588439a57b6",
+    "moduleName": "folio_agreements",
+    "moduleVersion": "8.1.1000825",
+    "mutable": false,
+    "permissionName": "ui-agreements.agreements.delete",
+    "subPermissions": ["ui-agreements.agreements.view", "erm.agreements.item.delete"],
+    "tags": [],
+    "visible": true
+  },
+  {
+    "deprecated": false,
+    "description": "Grants all permissions included in Agreements: Search & view agreements plus the ability to delete agreements. This does not include the ability to edit agreements, only to delete them",
+    "displayName": "Agreements: Edit agreements",
+    "grantedTo": ["8fafcfdb-419c-483e-a698-d7f8f46ea694"],
+    "id": "b52da718-7770-407a-af6d-668d258b2309",
+    "moduleName": "folio_agreements",
+    "moduleVersion": "8.1.1000825",
+    "mutable": false,
+    "permissionName": "ui-agreements.agreements.edit",
+    "subPermissions": ["ui-agreements.agreements.view", "erm.agreements.item.delete"],
+    "tags": [],
+    "visible": true
+  }
+]


### PR DESCRIPTION
Provide a `useUserTenantPermissions` hook that retrieves permissions for the currently-authenticated user in the given tenant.

Refs [STCOR-830](https://folio-org.atlassian.net/browse/STCOR-830)