### PR TITLE
STCOR-832 invalidate react-query cache on login and logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Utilize the `tenant` procured through the SSO login process. Refs STCOR-769.
 * Remove tag-based selectors from Login, ResetPassword, Forgot UserName/Password form CSS. Refs STCOR-712.
 * Provide `useUserTenantPermissions` hook. Refs STCOR-830.
+* Invalidate `QueryClient` cache on login/logout. Refs STCOR-832.
 
 ## 10.1.0 IN PROGRESS
 

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -50,6 +50,7 @@ class RootWithIntl extends React.Component {
     isAuthenticated: PropTypes.bool,
     disableAuth: PropTypes.bool.isRequired,
     history: PropTypes.shape({}),
+    queryClient: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -72,6 +73,7 @@ class RootWithIntl extends React.Component {
       isAuthenticated,
       disableAuth,
       history,
+      queryClient,
     } = this.props;
 
     const connect = connectFor('@folio/core', this.props.stripes.epics, this.props.stripes.logger);
@@ -92,7 +94,7 @@ class RootWithIntl extends React.Component {
                       <>
                         <MainContainer>
                           <AppCtxMenuProvider>
-                            <MainNav stripes={stripes} />
+                            <MainNav stripes={stripes} queryClient={queryClient} />
                             {typeof stripes?.config?.staleBundleWarning === 'object' && <StaleBundleWarning />}
                             <HandlerManager
                               event={events.LOGIN}

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -96,7 +96,7 @@ class MainNav extends Component {
       }
     });
 
-    // invalidate QueryProvider cache to be 100% sure we're starting from a clean slate.
+    // remove QueryProvider cache to be 100% sure we're starting from a clean slate.
     this.props.queryClient.removeQueries();
   }
 

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -4,7 +4,6 @@ import { isEqual, find } from 'lodash';
 import { compose } from 'redux';
 import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router';
-
 import { branding, config } from 'stripes-config';
 
 import { Icon } from '@folio/stripes-components';
@@ -56,7 +55,8 @@ class MainNav extends Component {
     }).isRequired,
     modules: PropTypes.shape({
       app: PropTypes.arrayOf(PropTypes.object),
-    })
+    }),
+    queryClient: PropTypes.object.isRequired
   };
 
   constructor(props) {
@@ -95,6 +95,9 @@ class MainNav extends Component {
         }
       }
     });
+
+    // invalidate QueryProvider cache to be 100% sure we're starting from a clean slate.
+    this.props.queryClient.invalidateQueries();
   }
 
   componentDidUpdate(prevProps) {
@@ -121,7 +124,7 @@ class MainNav extends Component {
     const { okapi } = this.store.getState();
 
     return getLocale(okapi.url, this.store, okapi.tenant)
-      .then(sessionLogout(okapi.url, this.store));
+      .then(sessionLogout(okapi.url, this.store, this.props.queryClient));
   }
 
   // return the user to the login screen, but after logging in they will be brought to the default screen.
@@ -237,6 +240,7 @@ class MainNav extends Component {
 }
 
 export default compose(
+
   injectIntl,
   withRouter,
   withModules,

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -97,7 +97,7 @@ class MainNav extends Component {
     });
 
     // invalidate QueryProvider cache to be 100% sure we're starting from a clean slate.
-    this.props.queryClient.invalidateQueries();
+    this.props.queryClient.removeQueries();
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -71,7 +71,7 @@ class Root extends Component {
     // * configure document-level event listeners to listen for RTR events
     if (this.props.config.useSecureTokens) {
       this.ffetch = new FFetch({ logger: this.props.logger });
-      addRtrEventListeners(okapi, store);
+      addRtrEventListeners(okapi, store, this.reactQueryClient);
     }
   }
 
@@ -180,6 +180,7 @@ class Root extends Component {
                   isAuthenticated={isAuthenticated}
                   disableAuth={disableAuth}
                   history={history}
+                  queryClient={this.reactQueryClient}
                 />
               </IntlProvider>
             </QueryClientProvider>

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -434,7 +434,7 @@ export async function logout(okapiUrl, store, queryClient) {
   store.dispatch(resetStore());
 
   // reset QueryClient cache to remove any cached requests.
-  queryClient.invalidateQueries();
+  queryClient.removeQueries();
 
   return fetch(`${okapiUrl}/authn/logout`, {
     method: 'POST',
@@ -522,7 +522,7 @@ export const handleRtrError = (event, store, queryClient) => {
   store.dispatch(resetStore());
 
   // reset QueryClient cache to remove any cached requests.
-  queryClient.invalidateQueries();
+  queryClient.removeQueries();
 
   localforage.removeItem(SESSION_NAME)
     .then(localforage.removeItem('loginResponse'));

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -433,7 +433,7 @@ export async function logout(okapiUrl, store, queryClient) {
   store.dispatch(clearOkapiToken());
   store.dispatch(resetStore());
 
-  // reset QueryClient cache to remove any cached requests.
+  // remove QueryClient cache for all queries.
   queryClient.removeQueries();
 
   return fetch(`${okapiUrl}/authn/logout`, {
@@ -521,7 +521,7 @@ export const handleRtrError = (event, store, queryClient) => {
   store.dispatch(clearCurrentUser());
   store.dispatch(resetStore());
 
-  // reset QueryClient cache to remove any cached requests.
+  // remove QueryClient cache for all queries.
   queryClient.removeQueries();
 
   localforage.removeItem(SESSION_NAME)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -427,11 +427,15 @@ export function spreadUserWithPerms(userWithPerms) {
  *
  * @returns {Promise}
  */
-export async function logout(okapiUrl, store) {
+export async function logout(okapiUrl, store, queryClient) {
   store.dispatch(setIsAuthenticated(false));
   store.dispatch(clearCurrentUser());
   store.dispatch(clearOkapiToken());
   store.dispatch(resetStore());
+
+  // reset QueryClient cache to remove any cached requests.
+  queryClient.invalidateQueries();
+
   return fetch(`${okapiUrl}/authn/logout`, {
     method: 'POST',
     mode: 'cors',
@@ -511,11 +515,15 @@ export function createOkapiSession(okapiUrl, store, tenant, token, data) {
  * @param {*} store
  * @returns void
  */
-export const handleRtrError = (event, store) => {
+export const handleRtrError = (event, store, queryClient) => {
   logger.log('rtr', 'rtr error; logging out', event.detail);
   store.dispatch(setIsAuthenticated(false));
   store.dispatch(clearCurrentUser());
   store.dispatch(resetStore());
+
+  // reset QueryClient cache to remove any cached requests.
+  queryClient.invalidateQueries();
+
   localforage.removeItem(SESSION_NAME)
     .then(localforage.removeItem('loginResponse'));
 };
@@ -528,9 +536,9 @@ export const handleRtrError = (event, store) => {
  * @param {*} okapiConfig
  * @param {*} store
  */
-export function addRtrEventListeners(okapiConfig, store) {
+export function addRtrEventListeners(okapiConfig, store, queryClient) {
   document.addEventListener(RTR_ERROR_EVENT, (e) => {
-    handleRtrError(e, store);
+    handleRtrError(e, store, queryClient);
   });
 
   // document.addEventListener(RTR_ROTATION_EVENT, (e) => {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STCOR-832

When a ui-module is using `react-query` it's possible that failing requests due to expired token can be cached and not be called when the user logs back in as a result. This PR invalidates the cache, so the calls that failed previously are made again.

### Approach

Pass QueryClient down appropriately from its creation through components where it can be passed through to the utility functions found within `loginServices` for logout via RTR error or via manual logout. `login` invalidation occurs within `MainNavigation` in the component's `cDM`. The locations of this logic are probably the most debatable aspect of this PR. 