### PR TITLE
STCOR-841 enable StrictMode by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Remove tag-based selectors from Login, ResetPassword, Forgot UserName/Password form CSS. Refs STCOR-712.
 * Provide `useUserTenantPermissions` hook. Refs STCOR-830.
 * Load DayJS locale data as part of `loginServices`. STCOR-771.
+* Turn on `<StrictMode>`; ignore it with `stripes.config.js` `ignoreStrictMode: true`. Refs STCOR-841.
 
 ## 10.1.0 IN PROGRESS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Remove tag-based selectors from Login, ResetPassword, Forgot UserName/Password form CSS. Refs STCOR-712.
 * Provide `useUserTenantPermissions` hook. Refs STCOR-830.
 * Load DayJS locale data as part of `loginServices`. STCOR-771.
-* Turn on `<StrictMode>`; ignore it with `stripes.config.js` `ignoreStrictMode: true`. Refs STCOR-841.
+* Turn on `<StrictMode>`; ignore it with `stripes.config.js` `disableStrictMode: true`. Refs STCOR-841.
 
 ## 10.1.0 IN PROGRESS
 

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,14 @@ import { destroyStore } from './mainActions';
 
 import Root from './components/Root';
 
+const StrictWrapper = ({ children }) => {
+  if (config.ignoreUseStrict) {
+    return <>{children}</>
+  }
+
+  return <StrictMode>{children}</StrictMode>;
+};
+
 export default class StripesCore extends Component {
   static propTypes = {
     history: PropTypes.object,
@@ -42,15 +50,17 @@ export default class StripesCore extends Component {
     const { initialState, ...props } = this.props;
 
     return (
-      <Root
-        store={this.store}
-        epics={this.epics}
-        logger={this.logger}
-        config={config}
-        actionNames={this.actionNames}
-        disableAuth={(config && config.disableAuth) || false}
-        {...props}
-      />
+      <StrictWrapper>
+        <Root
+          store={this.store}
+          epics={this.epics}
+          logger={this.logger}
+          config={config}
+          actionNames={this.actionNames}
+          disableAuth={(config && config.disableAuth) || false}
+          {...props}
+        />
+      </StrictWrapper>
     );
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, StrictMode } from 'react';
 import PropTypes from 'prop-types';
 import { okapi as okapiConfig, config } from 'stripes-config';
 import merge from 'lodash/merge';
@@ -14,10 +14,13 @@ import Root from './components/Root';
 
 const StrictWrapper = ({ children }) => {
   if (config.ignoreUseStrict) {
-    return <>{children}</>
+    return <>{children}</>;
   }
 
   return <StrictMode>{children}</StrictMode>;
+};
+StrictWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 export default class StripesCore extends Component {

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import Root from './components/Root';
 
 const StrictWrapper = ({ children }) => {
   if (config.disableStrictMode) {
-    return <>{children}</>;
+    return children;
   }
 
   return <StrictMode>{children}</StrictMode>;

--- a/src/App.js
+++ b/src/App.js
@@ -13,12 +13,13 @@ import { destroyStore } from './mainActions';
 import Root from './components/Root';
 
 const StrictWrapper = ({ children }) => {
-  if (config.ignoreUseStrict) {
+  if (config.disableStrictMode) {
     return <>{children}</>;
   }
 
   return <StrictMode>{children}</StrictMode>;
 };
+
 StrictWrapper.propTypes = {
   children: PropTypes.node.isRequired,
 };

--- a/src/components/Namespace/useNamespace.js
+++ b/src/components/Namespace/useNamespace.js
@@ -27,11 +27,11 @@ import { delimiters } from '../../constants';
 
 const useNamespace = (options = {}) => {
   const moduleHierarchy = useModuleHierarchy();
-  const getNamespace = (opts) => {
+  const getNamespace = (opts = {}) => {
     const { ignoreParents, key } = opts;
     const { NAMESPACE_DELIMITER } = delimiters;
 
-    let namespace = ignoreParents ? moduleHierarchy.pop() : moduleHierarchy.join(NAMESPACE_DELIMITER);
+    let namespace = ignoreParents ? moduleHierarchy[moduleHierarchy.length - 1] : moduleHierarchy.join(NAMESPACE_DELIMITER);
 
     if (key) {
       namespace += `${NAMESPACE_DELIMITER}${key}`;


### PR DESCRIPTION
Enable [`<StrictMode>`](https://react.dev/reference/react/StrictMode) by default, allowing it to be turned off via the `stripes.config.js` prop `config.ignoreStrictMode: true`.

Refs [STCOR-841](https://folio-org.atlassian.net/browse/STCOR-841)