### PR TITLE
STCOR-845 Redirect correctly after changing password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Utilize the `tenant` procured through the SSO login process. Refs STCOR-769.
 * Use keycloak URLs in place of users-bl for tenant-switch. Refs US1153537.
 * Provide `useUserTenantPermissions` hook. Refs STCOR-830.
+* Fix 404 error page when logging in after changing password in Eureka. Refs STCOR-845.
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/components/CreateResetPassword/CreateResetPasswordControl.js
+++ b/src/components/CreateResetPassword/CreateResetPasswordControl.js
@@ -162,7 +162,7 @@ class CreateResetPasswordControl extends Component {
     } = this.state;
 
     if (isSuccessfulPasswordChange) {
-      return <PasswordSuccessfullyChanged />;
+      return <PasswordSuccessfullyChanged stripes={this.props.stripes} />;
     }
 
     if (isLoading) {

--- a/src/components/CreateResetPassword/components/PasswordSuccessfullyChanged/PasswordSuccessfullyChanged.js
+++ b/src/components/CreateResetPassword/components/PasswordSuccessfullyChanged/PasswordSuccessfullyChanged.js
@@ -69,9 +69,7 @@ PasswordSuccessfullyChanged.propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,
-  stripes: PropTypes.shape({
-    isEureka: PropTypes.bool,
-  }),
+  stripes: PropTypes.object,
 };
 
 export default withRouter(PasswordSuccessfullyChanged);

--- a/src/components/CreateResetPassword/components/PasswordSuccessfullyChanged/PasswordSuccessfullyChanged.js
+++ b/src/components/CreateResetPassword/components/PasswordSuccessfullyChanged/PasswordSuccessfullyChanged.js
@@ -12,12 +12,17 @@ import OrganizationLogo from '../../../OrganizationLogo';
 
 import styles from './PasswordSuccessfullyChanged.css';
 
-const PasswordSuccessfullyChanged = ({ history }) => {
+const PasswordSuccessfullyChanged = ({ history, stripes }) => {
   const labelNamespace = 'stripes-core.label';
   const buttonNamespace = 'stripes-core.button';
 
   const handleRedirectClick = () => {
-    history.push('/login');
+    // If using Eureka, go to base URL. Otherwise, if using Okapi then go to /login
+    if (stripes.config.isEureka) {
+      history.push('/');
+    } else {
+      history.push('/login');
+    }
   };
 
   return (
@@ -64,6 +69,9 @@ PasswordSuccessfullyChanged.propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,
+  stripes: PropTypes.shape({
+    isEureka: PropTypes.bool,
+  }),
 };
 
 export default withRouter(PasswordSuccessfullyChanged);


### PR DESCRIPTION
- Fixes [STCOR-845](https://folio-org.atlassian.net/browse/STCOR-845).
- Eureka back-end doesn't recognize `/login` route, so base URL `/` should be used instead. 