### PR TITLE
rebase-cleanup: restore logout AND ITS TESTS

### DIFF
--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -475,6 +475,7 @@ describe('logout', () => {
       global.fetch = jest.fn().mockImplementation(() => Promise.resolve());
       const store = {
         dispatch: jest.fn(),
+        getState: jest.fn(),
       };
       window.sessionStorage.clear();
 
@@ -496,6 +497,7 @@ describe('logout', () => {
       localStorage.setItem(SESSION_NAME, 'true');
       const store = {
         dispatch: jest.fn(),
+        getState: jest.fn(),
       };
       window.sessionStorage.clear();
 


### PR DESCRIPTION
The previous commit re-enabled logout by correctly passing the `x-okapi-tenant` header in the `/authn/logout` request. It turns out that if you want read the tenant from the store in a test, you have to mock the store in your test. WHO KNEW???

Replaces #1478 