### PR TITLE
STCOR-853 do not include credential in /authn/token request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Idle-session timeout and "Keep working?" modal. Refs STCOR-776.
 * Use keycloak URLs in place of users-bl for tenant-switch. Refs US1153537.
 * Fix 404 error page when logging in after changing password in Eureka. Refs STCOR-845.
+* Omit credentials in requests to `/authn/token` to prevent redirect tailspin. Refs STCOR-853.
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -59,7 +59,7 @@ const OIDCLanding = () => {
     if (otp) {
       setPotp(otp);
       fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${window.location.protocol}//${window.location.host}/oidc-landing`, {
-        credentials: 'include',
+        credentials: 'omit',
         headers: { 'X-Okapi-tenant': okapi.tenant, 'Content-Type': 'application/json' },
         mode: 'cors',
       })

--- a/src/components/OIDCLanding.test.js
+++ b/src/components/OIDCLanding.test.js
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+
+import { requestUserWithPerms, setTokenExpiry } from '../loginServices';
+import OIDCLanding from './OIDCLanding';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    search: 'session_state=dead-beef&code=c0ffee'
+  }),
+  Redirect: () => <>Redirect</>,
+}));
+
+jest.mock('react-redux', () => ({
+  useStore: () => { },
+}));
+
+jest.mock('../StripesContext', () => ({
+  useStripes: () => ({
+    okapi: { url: 'https://whaterver' },
+  }),
+}));
+
+// jest.mock('../loginServices');
+
+
+const mockSetTokenExpiry = jest.fn();
+const mockRequestUserWithPerms = jest.fn();
+const mockFoo = jest.fn();
+jest.mock('../loginServices', () => ({
+  setTokenExpiry: () => mockSetTokenExpiry(),
+  requestUserWithPerms: () => mockRequestUserWithPerms(),
+  foo: () => mockFoo(),
+}));
+
+
+// fetch success: resolve promise with ok == true and $data in json()
+const mockFetchSuccess = (data) => {
+  global.fetch = jest.fn().mockImplementation(() => (
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(data),
+      headers: new Map(),
+    })
+  ));
+};
+
+// fetch failure: resolve promise with ok == false and $error in json()
+const mockFetchError = (error) => {
+  global.fetch = jest.fn().mockImplementation(() => (
+    Promise.resolve({
+      ok: false,
+      json: () => Promise.resolve(error),
+      headers: new Map(),
+    })
+  ));
+};
+
+// restore default fetch impl
+const mockFetchCleanUp = () => {
+  global.fetch.mockClear();
+  delete global.fetch;
+};
+
+describe('OIDCLanding', () => {
+  it('calls requestUserWithPerms, setTokenExpiry on success', async () => {
+    mockFetchSuccess({
+      accessTokenExpiration: '2024-05-23T09:47:17.000-04:00',
+      refreshTokenExpiration: '2024-05-23T10:07:17.000-04:00',
+    });
+
+    await render(<OIDCLanding />);
+    screen.getByText('Loading');
+    await waitFor(() => expect(mockSetTokenExpiry).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockRequestUserWithPerms).toHaveBeenCalledTimes(1));
+    mockFetchCleanUp();
+  });
+
+  it('displays an error on failure', async () => {
+    mockFetchError('barf');
+
+    await render(<OIDCLanding />);
+    await screen.findByText('errors.saml.missingToken');
+    mockFetchCleanUp();
+  });
+});


### PR DESCRIPTION
The request to `/authn/token` pulls an OTP from the query string and exchanges it for AT/RT cookies. If, somehow, the browser already has cookies and sends them along on this request, it causes a negative feedback look because the OTP and the cookies are out of sync. The old AT/RT cookies will cause the endpoint to return 4xx, which will result in a redirect back to keycloak, which will find its (still perfectly valid) authentication cookies, which will cause it redirect back to stripes with a new OTP ... and the cycle repeats.

Thus, when we are exchanging an OTP, we don't want to send any cookies. We want the to send the OTP and have new cookies from the response overwrite anything that was previously stored.

Refs [STCOR-853](https://folio-org.atlassian.net/browse/STCOR-853)

Replaces #1477 