### PR TITLE
STCOR-776 always populate stripes.config.rtr.activityEvents

### DIFF
--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -1,8 +1,15 @@
+import { isEmpty } from 'lodash';
 import { okapi } from 'stripes-config';
 
 import { getTokenExpiry, setTokenExpiry } from '../../loginServices';
 import { RTRError, UnexpectedResourceError } from './Errors';
-import { RTR_ERROR_EVENT, RTR_SUCCESS_EVENT } from './constants';
+import {
+  RTR_ACTIVITY_EVENTS,
+  RTR_ERROR_EVENT,
+  RTR_IDLE_MODAL_TTL,
+  RTR_IDLE_SESSION_TTL,
+  RTR_SUCCESS_EVENT,
+} from './constants';
 
 /** localstorage flag indicating whether an RTR request is already under way. */
 export const RTR_IS_ROTATING = '@folio/stripes/core::rtrIsRotating';
@@ -294,7 +301,7 @@ export const getPromise = async (logger) => {
 /**
  * configureRtr
  * Provide default values necessary for RTR. They may be overriden by setting
- * config.rtr in stripes.config.js.
+ * config.rtr... in stripes.config.js.
  *
  * @param {object} config
  */
@@ -303,15 +310,19 @@ export const configureRtr = (config = {}) => {
 
   // how long does an idle session last before being killed?
   if (!conf.idleSessionTTL) {
-    conf.idleSessionTTL = '60m';
+    conf.idleSessionTTL = RTR_IDLE_SESSION_TTL;
   }
 
   // how long is the "warning, session is idle!" modal shown
   // before the session is killed?
   if (!conf.idleModalTTL) {
-    conf.idleModalTTL = '1m';
+    conf.idleModalTTL = RTR_IDLE_MODAL_TTL;
+  }
+
+  // what events constitute activity?
+  if (isEmpty(conf.activityEvents)) {
+    conf.activityEvents = RTR_ACTIVITY_EVENTS;
   }
 
   return conf;
 };
-

--- a/src/components/SessionEventContainer/SessionEventContainer.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.js
@@ -8,7 +8,6 @@ import KeepWorkingModal from './KeepWorkingModal';
 import { useStripes } from '../../StripesContext';
 import {
   RTR_ACTIVITY_CHANNEL,
-  RTR_ACTIVITY_EVENTS,
   RTR_ERROR_EVENT,
   RTR_TIMEOUT_EVENT
 } from '../Root/constants';
@@ -21,7 +20,7 @@ import { toggleRtrModal } from '../../okapiActions';
 
 // RTR error in this window: logout
 export const thisWindowRtrError = (_e, stripes, history) => {
-  console.warn('rtr error; logging out', history); // eslint-disable-line no-console
+  console.warn('rtr error; logging out'); // eslint-disable-line no-console
   return logout(stripes.okapi.url, stripes.store)
     .then(() => {
       history.push('/logout-timeout');
@@ -177,7 +176,7 @@ const SessionEventContainer = ({ history }) => {
     const channelListeners = { window, bc };
 
     if (stripes.config.useSecureTokens) {
-      const { idleModalTTL, idleSessionTTL } = stripes.config.rtr;
+      const { idleModalTTL, idleSessionTTL, activityEvents } = stripes.config.rtr;
 
       // inactive timer: show the "keep working?" modal
       const showModalIT = createInactivityTimer(ms(idleSessionTTL) - ms(idleModalTTL), () => {
@@ -213,7 +212,6 @@ const SessionEventContainer = ({ history }) => {
       channels.bc.message = (message) => otherWindowActivity(message, stripes, timers, setIsVisible);
 
       // activity in this window: ping idle-timers and BroadcastChannel
-      const activityEvents = stripes.config.rtr?.activityEvents ?? RTR_ACTIVITY_EVENTS;
       activityEvents.forEach(eventName => {
         channels.window[eventName] = (e) => thisWindowActivity(e, stripes, timers, bc);
       });

--- a/src/components/SessionEventContainer/SessionEventContainer.test.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.test.js
@@ -23,6 +23,7 @@ const stripes = {
     rtr: {
       idleModalTTL: '3s',
       idleSessionTTL: '3s',
+      activityEvents: ['right thing', 'hustle', 'hand jive']
     }
   },
   okapi: {
@@ -34,12 +35,12 @@ const stripes = {
 
 describe('SessionEventContainer', () => {
   it('Renders nothing if useSecureTokens is false', async () => {
-    const inSecureStripes = {
+    const insecureStripes = {
       config: {
         useSecureTokens: false,
       },
     };
-    render(<Harness stripes={inSecureStripes}><SessionEventContainer /></Harness>);
+    render(<Harness stripes={insecureStripes}><SessionEventContainer /></Harness>);
 
     expect(screen.queryByText('KeepWorkingModal')).toBe(null);
   });

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -19,8 +19,6 @@ import {
   SESSION_NAME
 } from './loginServices';
 
-
-
 import {
   clearCurrentUser,
   clearOkapiToken,
@@ -43,23 +41,6 @@ import {
 } from './okapiActions';
 
 import { defaultErrors } from './constants';
-
-// reassign console.log to keep things quiet
-const consoleInterruptor = {};
-beforeAll(() => {
-  consoleInterruptor.log = global.console.log;
-  consoleInterruptor.error = global.console.error;
-  consoleInterruptor.warn = global.console.warn;
-  console.log = () => { };
-  console.error = () => { };
-  console.warn = () => { };
-});
-
-afterAll(() => {
-  global.console.log = consoleInterruptor.log;
-  global.console.error = consoleInterruptor.error;
-  global.console.warn = consoleInterruptor.warn;
-});
 
 jest.mock('localforage', () => ({
   getItem: jest.fn(() => Promise.resolve({ user: {} })),


### PR DESCRIPTION
* Always populate `stripes.config.rtr.activityEvents`; if it isn't defined at build-time via `stripes.config.js`, populate it with values from `RTR_ACTIVITY_EVENTS`. Previously, it was omitted if not defined in `stripes.config.js`, causing the KeepWorkingModal callback to dispatch an empty event, dismissing the modal but failing to actually prolong the session since no "activity" event was fired. Whoops. Related, this means we must supply `activityEvents` on `stripes` in tests of `<SessionEventContainer>` where it is rendered directly, without `<Root>` as a parent to call `configureRtr()`.
* Populate `stripes.config.rtr.idleSessionTTL` and `stripes.config.rtr.idleModalTTL` from their corresponding constants instead of hard-coding magic strings in multiple places like an idiot.
* Minor test clean up. We don't need to reassign `console` methods when we can just run jest with `--silent`.

Refs [STCOR-776](https://folio-org.atlassian.net/browse/STCOR-776)