### PR TITLE
[STCOR-787] Always retrieve clientId and tenant values from config.tenantOptions in stripes.config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Idle-session timeout and "Keep working?" modal. Refs STCOR-776.
 * Use keycloak URLs in place of users-bl for tenant-switch. Refs US1153537.
 * Fix 404 error page when logging in after changing password in Eureka. Refs STCOR-845.
+* Omit credentials in requests to `/authn/token` to prevent redirect tailspin. Refs STCOR-853.
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/RootWithIntl.test.js
+++ b/src/RootWithIntl.test.js
@@ -25,7 +25,7 @@ jest.mock('./components/PreLoginLanding', () => () => '<preloginlanding>');
 describe('RootWithIntl', () => {
   describe('AuthnLogin', () => {
     it('handles legacy login', () => {
-      const stripes = { okapi: {}, config: {} };
+      const stripes = { okapi: {}, config: { tenantOptions: {} } };
       render(<AuthnLogin stripes={stripes} />);
 
       expect(screen.getByText(/<login>/)).toBeInTheDocument();
@@ -35,7 +35,12 @@ describe('RootWithIntl', () => {
       it('handles single-tenant', () => {
         const stripes = {
           okapi: { authnUrl: 'https://barbie.com' },
-          config: { isSingleTenant: true }
+          config: {
+            isSingleTenant: true,
+            tenantOptions: {
+              diku: { name: 'diku', clientId: 'diku-application' }
+            }
+          },
         };
         render(<AuthnLogin stripes={stripes} />);
 
@@ -45,7 +50,13 @@ describe('RootWithIntl', () => {
       it('handles multi-tenant', () => {
         const stripes = {
           okapi: { authnUrl: 'https://oppie.com' },
-          config: { },
+          config: {
+            isSingleTenant: false,
+            tenantOptions: {
+              diku: { name: 'diku', clientId: 'diku-application' },
+              diku2: { name: 'diku2', clientId: 'diku2-application' }
+            }
+          },
         };
         render(<AuthnLogin stripes={stripes} />);
 

--- a/src/RootWithIntl.test.js
+++ b/src/RootWithIntl.test.js
@@ -22,10 +22,21 @@ jest.mock('./components/Redirect', () => () => '<redirect>');
 jest.mock('./components/Login', () => () => '<login>');
 jest.mock('./components/PreLoginLanding', () => () => '<preloginlanding>');
 
+const store = {
+  getState: () => ({
+    okapi: {
+      token: '123',
+    },
+  }),
+  dispatch: () => {},
+  subscribe: () => {},
+  replaceReducer: () => {},
+};
+
 describe('RootWithIntl', () => {
   describe('AuthnLogin', () => {
     it('handles legacy login', () => {
-      const stripes = { okapi: {}, config: { tenantOptions: {} } };
+      const stripes = { okapi: {}, config: {}, store };
       render(<AuthnLogin stripes={stripes} />);
 
       expect(screen.getByText(/<login>/)).toBeInTheDocument();
@@ -41,6 +52,7 @@ describe('RootWithIntl', () => {
               diku: { name: 'diku', clientId: 'diku-application' }
             }
           },
+          store
         };
         render(<AuthnLogin stripes={stripes} />);
 
@@ -57,6 +69,7 @@ describe('RootWithIntl', () => {
               diku2: { name: 'diku2', clientId: 'diku2-application' }
             }
           },
+          store
         };
         render(<AuthnLogin stripes={stripes} />);
 

--- a/src/Stripes.js
+++ b/src/Stripes.js
@@ -23,6 +23,7 @@ export const stripesShape = PropTypes.shape({
     logTimestamp: PropTypes.bool,
     showHomeLink: PropTypes.bool,
     showPerms: PropTypes.bool,
+    tenantOptions: PropTypes.object,
   }).isRequired,
   connect: PropTypes.func.isRequired,
   currency: PropTypes.string,

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -9,6 +9,7 @@ import { setUnauthorizedPathToSession } from '../../loginServices';
 
 const AuthnLogin = ({ stripes }) => {
   const { config, okapi } = stripes;
+  const { tenantOptions = {} } = config;
 
   useEffect(() => {
     if (okapi.authnUrl) {
@@ -23,8 +24,9 @@ const AuthnLogin = ({ stripes }) => {
 
   if (okapi.authnUrl) {
     if (config.isSingleTenant) {
+      const defaultTenant = Object.entries(tenantOptions)[0];
       const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;
-      const authnUri = `${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/auth?client_id=${okapi.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
+      const authnUri = `${okapi.authnUrl}/realms/${defaultTenant.name}/protocol/openid-connect/auth?client_id=${defaultTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
       return <Redirect to={authnUri} />;
     }
 

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -37,7 +37,6 @@ const AuthnLogin = ({ stripes }) => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (okapi.authnUrl) {
-
     // If only 1 tenant is defined in config, skip the tenant selection screen.
     if (tenants.length === 1) {
       const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -9,8 +9,14 @@ import { setUnauthorizedPathToSession } from '../../loginServices';
 
 const AuthnLogin = ({ stripes }) => {
   const { config, okapi } = stripes;
-  const { tenantOptions = {} } = config;
+  // If config.tenantOptions is not defined, default to classic okapi.tenant and okapi.clientId
+  const { tenantOptions = [{ name: okapi.tenant, clientId: okapi.clientId }] } = config;
   const tenants = Object.values(tenantOptions);
+
+  const setTenant = (tenant, clientId) => {
+    localStorage.setItem('tenant', JSON.stringify({ tenantName: tenant, clientId }));
+    stripes.store.dispatch(setOkapiTenant({ tenant, clientId }));
+  };
 
   useEffect(() => {
     if (okapi.authnUrl) {
@@ -19,25 +25,27 @@ const AuthnLogin = ({ stripes }) => {
     */
       setUnauthorizedPathToSession(window.location.pathname);
     }
+
+    // If only 1 tenant is defined in config (in either okapi or config.tenantOptions) set to okapi to be accessed there
+    // in the rest of the application for compatibity across existing modules.
+    if (tenants.length === 1) {
+      const loginTenant = tenants[0];
+      setTenant(loginTenant.name, loginTenant.clientId);
+    }
     // we only want to run this effect once, on load.
-    // okapi.authnUrl are defined in stripes.config.js
+    // okapi.authnUrl tenant values are defined in stripes.config.js
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (okapi.authnUrl) {
+
     // If only 1 tenant is defined in config, skip the tenant selection screen.
     if (tenants.length === 1) {
-      const loginTenant = tenants[0];
       const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;
-      const authnUri = `${okapi.authnUrl}/realms/${loginTenant.name}/protocol/openid-connect/auth?client_id=${loginTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
+      const authnUri = `${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/auth?client_id=${okapi.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
       return <Redirect to={authnUri} />;
     }
 
-    const handleSelectTenant = (tenant, clientId) => {
-      localStorage.setItem('tenant', JSON.stringify({ tenantName: tenant, clientId }));
-      stripes.store.dispatch(setOkapiTenant({ tenant, clientId }));
-    };
-
-    return <PreLoginLanding onSelectTenant={handleSelectTenant} />;
+    return <PreLoginLanding onSelectTenant={setTenant} />;
   }
 
   return <Login

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -10,6 +10,7 @@ import { setUnauthorizedPathToSession } from '../../loginServices';
 const AuthnLogin = ({ stripes }) => {
   const { config, okapi } = stripes;
   const { tenantOptions = {} } = config;
+  const tenants = Object.values(tenantOptions);
 
   useEffect(() => {
     if (okapi.authnUrl) {
@@ -23,10 +24,11 @@ const AuthnLogin = ({ stripes }) => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (okapi.authnUrl) {
-    if (config.isSingleTenant) {
-      const defaultTenant = Object.values(tenantOptions)[0];
+    // If only 1 tenant is defined in config, skip the tenant selection screen.
+    if (tenants.length === 1) {
+      const loginTenant = tenants[0];
       const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;
-      const authnUri = `${okapi.authnUrl}/realms/${defaultTenant.name}/protocol/openid-connect/auth?client_id=${defaultTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
+      const authnUri = `${okapi.authnUrl}/realms/${loginTenant.name}/protocol/openid-connect/auth?client_id=${loginTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
       return <Redirect to={authnUri} />;
     }
 

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -24,7 +24,7 @@ const AuthnLogin = ({ stripes }) => {
 
   if (okapi.authnUrl) {
     if (config.isSingleTenant) {
-      const defaultTenant = Object.entries(tenantOptions)[0];
+      const defaultTenant = Object.values(tenantOptions)[0];
       const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;
       const authnUri = `${okapi.authnUrl}/realms/${defaultTenant.name}/protocol/openid-connect/auth?client_id=${defaultTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
       return <Redirect to={authnUri} />;

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -58,12 +58,12 @@ const OIDCLanding = () => {
     const otp = getOtp();
 
     if (otp) {
-      const defaultTenant = Object.values(tenantOptions)[0];
+      const loginTenant = Object.values(tenantOptions)[0];
 
       setPotp(otp);
       fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${window.location.protocol}//${window.location.host}/oidc-landing`, {
         credentials: 'omit',
-        headers: { 'X-Okapi-tenant': defaultTenant.name, 'Content-Type': 'application/json' },
+        headers: { 'X-Okapi-tenant': loginTenant.name, 'Content-Type': 'application/json' },
         mode: 'cors',
       })
         .then((resp) => {
@@ -76,7 +76,7 @@ const OIDCLanding = () => {
                 });
               })
               .then(() => {
-                return requestUserWithPerms(okapi.url, store, defaultTenant.name);
+                return requestUserWithPerms(okapi.url, store, loginTenant.name);
               });
           } else {
             return resp.json().then((error) => {

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -59,7 +59,7 @@ const OIDCLanding = () => {
     if (otp) {
       setPotp(otp);
       fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${window.location.protocol}//${window.location.host}/oidc-landing`, {
-        credentials: 'include',
+        credentials: 'omit',
         headers: { 'X-Okapi-tenant': okapi.tenant, 'Content-Type': 'application/json' },
         mode: 'cors',
       })

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -25,7 +25,8 @@ const OIDCLanding = () => {
   const location = useLocation();
   const store = useStore();
   // const samlError = useRef();
-  const { okapi } = useStripes();
+  const { okapi, config } = useStripes();
+  const { tenantOptions = {} } = config;
 
   const [potp, setPotp] = useState();
   const [samlError, setSamlError] = useState();
@@ -57,10 +58,12 @@ const OIDCLanding = () => {
     const otp = getOtp();
 
     if (otp) {
+      const defaultTenant = Object.entries(tenantOptions)[0];
+
       setPotp(otp);
       fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${window.location.protocol}//${window.location.host}/oidc-landing`, {
         credentials: 'omit',
-        headers: { 'X-Okapi-tenant': okapi.tenant, 'Content-Type': 'application/json' },
+        headers: { 'X-Okapi-tenant': defaultTenant.name, 'Content-Type': 'application/json' },
         mode: 'cors',
       })
         .then((resp) => {
@@ -73,7 +76,7 @@ const OIDCLanding = () => {
                 });
               })
               .then(() => {
-                return requestUserWithPerms(okapi.url, store, okapi.tenant);
+                return requestUserWithPerms(okapi.url, store, defaultTenant.name);
               });
           } else {
             return resp.json().then((error) => {
@@ -90,7 +93,7 @@ const OIDCLanding = () => {
     // we only want to run this effect once, on load.
     // keycloak authentication will redirect here and the other deps will be constant:
     // location.search: the query string; this will never change
-    // okapi.tenant, okapi.url: these are defined in stripes.config.js
+    // config.tenantOptions, okapi.url: these are defined in stripes.config.js
     // store: the redux store
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -25,9 +25,7 @@ const OIDCLanding = () => {
   const location = useLocation();
   const store = useStore();
   // const samlError = useRef();
-  const { okapi, config } = useStripes();
-  const { tenantOptions = {} } = config;
-
+  const { okapi } = useStripes();
   const [potp, setPotp] = useState();
   const [samlError, setSamlError] = useState();
 
@@ -58,12 +56,10 @@ const OIDCLanding = () => {
     const otp = getOtp();
 
     if (otp) {
-      const loginTenant = Object.values(tenantOptions)[0];
-
       setPotp(otp);
       fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${window.location.protocol}//${window.location.host}/oidc-landing`, {
         credentials: 'include',
-        headers: { 'X-Okapi-tenant': loginTenant.name, 'Content-Type': 'application/json' },
+        headers: { 'X-Okapi-tenant': okapi.tenant, 'Content-Type': 'application/json' },
         mode: 'cors',
       })
         .then((resp) => {
@@ -76,7 +72,7 @@ const OIDCLanding = () => {
                 });
               })
               .then(() => {
-                return requestUserWithPerms(okapi.url, store, loginTenant.name);
+                return requestUserWithPerms(okapi.url, store, okapi.tenant);
               });
           } else {
             return resp.json().then((error) => {
@@ -93,7 +89,7 @@ const OIDCLanding = () => {
     // we only want to run this effect once, on load.
     // keycloak authentication will redirect here and the other deps will be constant:
     // location.search: the query string; this will never change
-    // config.tenantOptions, okapi.url: these are defined in stripes.config.js
+    // okapi.tenant, okapi.url: these are defined in stripes.config.js
     // store: the redux store
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -58,7 +58,7 @@ const OIDCLanding = () => {
     const otp = getOtp();
 
     if (otp) {
-      const defaultTenant = Object.entries(tenantOptions)[0];
+      const defaultTenant = Object.values(tenantOptions)[0];
 
       setPotp(otp);
       fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${window.location.protocol}//${window.location.host}/oidc-landing`, {

--- a/src/components/OIDCLanding.test.js
+++ b/src/components/OIDCLanding.test.js
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+
+import { requestUserWithPerms, setTokenExpiry } from '../loginServices';
+import OIDCLanding from './OIDCLanding';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    search: 'session_state=dead-beef&code=c0ffee'
+  }),
+  Redirect: () => <>Redirect</>,
+}));
+
+jest.mock('react-redux', () => ({
+  useStore: () => { },
+}));
+
+jest.mock('../StripesContext', () => ({
+  useStripes: () => ({
+    okapi: { url: 'https://whaterver' },
+  }),
+}));
+
+// jest.mock('../loginServices');
+
+
+const mockSetTokenExpiry = jest.fn();
+const mockRequestUserWithPerms = jest.fn();
+const mockFoo = jest.fn();
+jest.mock('../loginServices', () => ({
+  setTokenExpiry: () => mockSetTokenExpiry(),
+  requestUserWithPerms: () => mockRequestUserWithPerms(),
+  foo: () => mockFoo(),
+}));
+
+
+// fetch success: resolve promise with ok == true and $data in json()
+const mockFetchSuccess = (data) => {
+  global.fetch = jest.fn().mockImplementation(() => (
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(data),
+      headers: new Map(),
+    })
+  ));
+};
+
+// fetch failure: resolve promise with ok == false and $error in json()
+const mockFetchError = (error) => {
+  global.fetch = jest.fn().mockImplementation(() => (
+    Promise.resolve({
+      ok: false,
+      json: () => Promise.resolve(error),
+      headers: new Map(),
+    })
+  ));
+};
+
+// restore default fetch impl
+const mockFetchCleanUp = () => {
+  global.fetch.mockClear();
+  delete global.fetch;
+};
+
+describe('OIDCLanding', () => {
+  it('calls requestUserWithPerms, setTokenExpiry on success', async () => {
+    mockFetchSuccess({
+      accessTokenExpiration: '2024-05-23T09:47:17.000-04:00',
+      refreshTokenExpiration: '2024-05-23T10:07:17.000-04:00',
+    });
+
+    await render(<OIDCLanding />);
+    screen.getByText('Loading');
+    await waitFor(() => expect(mockSetTokenExpiry).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockRequestUserWithPerms).toHaveBeenCalledTimes(1));
+    mockFetchCleanUp();
+  });
+
+  it('displays an error on failure', async () => {
+    mockFetchError('barf');
+
+    await render(<OIDCLanding />);
+    await screen.findByText('errors.saml.missingToken');
+    mockFetchCleanUp();
+  });
+});

--- a/src/components/OIDCLanding.test.js
+++ b/src/components/OIDCLanding.test.js
@@ -1,6 +1,5 @@
 import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 
-import { requestUserWithPerms, setTokenExpiry } from '../loginServices';
 import OIDCLanding from './OIDCLanding';
 
 jest.mock('react-router-dom', () => ({
@@ -17,6 +16,7 @@ jest.mock('react-redux', () => ({
 jest.mock('../StripesContext', () => ({
   useStripes: () => ({
     okapi: { url: 'https://whaterver' },
+    config: { tenantOptions: { diku: { name: 'diku', clientId: 'diku-application' } } },
   }),
 }));
 

--- a/src/components/OIDCRedirect.test.js
+++ b/src/components/OIDCRedirect.test.js
@@ -25,14 +25,14 @@ describe('OIDCRedirect', () => {
   afterAll(() => sessionStorage.removeItem('unauthorized_path'));
 
   it('redirects to value from session storage under unauthorized_path key', () => {
-    useStripes.mockReturnValue({ okapi: { authnUrl: 'http://example.com/authn' }, config: {} });
+    useStripes.mockReturnValue({ okapi: { authnUrl: 'http://example.com/authn' } });
     render(<OIDCRedirect />);
 
     expect(screen.getByText(/internalredirect/)).toBeInTheDocument();
   });
 
   it('redirects fwd if no authn provided to stripes okapi config', () => {
-    useStripes.mockReturnValue({ okapi: { }, config: {} });
+    useStripes.mockReturnValue({ okapi: { } });
     render(<OIDCRedirect />);
 
     expect(screen.getByText(/internalredirect/)).toBeInTheDocument();

--- a/src/components/OIDCRedirect.test.js
+++ b/src/components/OIDCRedirect.test.js
@@ -25,14 +25,14 @@ describe('OIDCRedirect', () => {
   afterAll(() => sessionStorage.removeItem('unauthorized_path'));
 
   it('redirects to value from session storage under unauthorized_path key', () => {
-    useStripes.mockReturnValue({ okapi:{ authnUrl: 'http://example.com/authn' } });
+    useStripes.mockReturnValue({ okapi: { authnUrl: 'http://example.com/authn' }, config: {} });
     render(<OIDCRedirect />);
 
     expect(screen.getByText(/internalredirect/)).toBeInTheDocument();
   });
 
   it('redirects fwd if no authn provided to stripes okapi config', () => {
-    useStripes.mockReturnValue({ okapi: { } });
+    useStripes.mockReturnValue({ okapi: { }, config: {} });
     render(<OIDCRedirect />);
 
     expect(screen.getByText(/internalredirect/)).toBeInTheDocument();

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -15,7 +15,6 @@ function PreLoginLanding({ onSelectTenant }) {
 
   const getLoginUrl = () => {
     if (!okapi.tenant) return '';
-
     if (okapi.authnUrl) {
       return `${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/auth?client_id=${okapi.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid&isConsortium=true`;
     }

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -14,9 +14,12 @@ function PreLoginLanding({ onSelectTenant }) {
   const options = Object.keys(tenantOptions).map(tenantName => ({ value: tenantName, label: tenantName }));
 
   const getLoginUrl = () => {
-    if (!okapi.tenant) return '';
+    if (options.length < 1) return '';
+
+    const defaultTenant = Object.entries(tenantOptions)[0];
+
     if (okapi.authnUrl) {
-      return `${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/auth?client_id=${okapi.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid&isConsortium=true`;
+      return `${okapi.authnUrl}/realms/${defaultTenant.name}/protocol/openid-connect/auth?client_id=${defaultTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid&isConsortium=true`;
     }
     return '';
   };

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -14,12 +14,10 @@ function PreLoginLanding({ onSelectTenant }) {
   const options = Object.keys(tenantOptions).map(tenantName => ({ value: tenantName, label: tenantName }));
 
   const getLoginUrl = () => {
-    if (options.length < 1) return '';
-
-    const defaultTenant = Object.values(tenantOptions)[0];
+    if (!okapi.tenant) return '';
 
     if (okapi.authnUrl) {
-      return `${okapi.authnUrl}/realms/${defaultTenant.name}/protocol/openid-connect/auth?client_id=${defaultTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid&isConsortium=true`;
+      return `${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/auth?client_id=${okapi.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid&isConsortium=true`;
     }
     return '';
   };

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -16,7 +16,7 @@ function PreLoginLanding({ onSelectTenant }) {
   const getLoginUrl = () => {
     if (options.length < 1) return '';
 
-    const defaultTenant = Object.entries(tenantOptions)[0];
+    const defaultTenant = Object.values(tenantOptions)[0];
 
     if (okapi.authnUrl) {
       return `${okapi.authnUrl}/realms/${defaultTenant.name}/protocol/openid-connect/auth?client_id=${defaultTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid&isConsortium=true`;

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -778,7 +778,7 @@ export function validateUser(okapiUrl, store, tenant, session) {
           token,
           tokenExpiration,
         }));
-        return loadResources(store, sessionTenant, user.id);
+        return loadResources(store, sessionTenant, user?.id ?? data.user?.id);
       });
     } else {
       store.dispatch(clearCurrentUser());


### PR DESCRIPTION
- Fulfills [STCOR-787](https://folio-org.atlassian.net/browse/STCOR-787).
- Removed dependence on `okapi.tenant` and `okapi.clientId` since those same values are now defined in `config.tenantOptions`.
- Removed dependence on `config.isSingleTenant` since a single tenant in `config.tenantOptions` should always caused the tenant selection screen to be skipped.
- Unrelated: add a fallback in `loginServices.js`if user object not returned from local storage, then default to user from `/_self` response. I ran into this issue causing login to crash occasionally on localhost and it was annoying, so adding a graceful fallback here.