### PR TITLE
STCOR-776 optionally schedule RTR based on session data

### DIFF
--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -47,6 +47,7 @@ import {
   setRtrTimeout
 } from '../../okapiActions';
 
+import { getTokenExpiry } from '../../loginServices';
 import {
   getPromise,
   isAuthenticationRequest,
@@ -107,19 +108,42 @@ export class FFetch {
   rotateCallback = (res) => {
     this.logger.log('rtr', 'rotation callback setup');
 
-    // set a short rotation interval by default, then inspect the response for
-    // token-expiration data to use instead if available. not all responses
-    // (e.g. those from _self) contain token-expiration values, so it is
-    // necessary to provide a default.
-    let rotationInterval = 10 * 1000;
-    if (res?.accessTokenExpiration) {
-      rotationInterval = (new Date(res.accessTokenExpiration).getTime() - Date.now()) * RTR_AT_TTL_FRACTION;
-    }
+    const scheduleRotation = (rotationP) => {
+      rotationP.then((rotationInterval) => {
+        this.logger.log('rtr', `rotation fired from rotateCallback; next callback in ${ms(rotationInterval)}`);
+        this.store.dispatch(setRtrTimeout(setTimeout(() => {
+          rtr(this.nativeFetch, this.logger, this.rotateCallback);
+        }, rotationInterval)));
+      });
+    };
 
-    this.logger.log('rtr', `rotation fired from rotateCallback; next callback in ${ms(rotationInterval)}`);
-    this.store.dispatch(setRtrTimeout(setTimeout(() => {
-      rtr(this.nativeFetch, this.logger, this.rotateCallback);
-    }, rotationInterval)));
+    // When starting a new session, the response from /bl-users/login-with-expiry
+    // will contain AT expiration info, but when restarting an existing session,
+    // the response from /bl-users/_self will NOT, although that information will
+    // have been cached in local-storage.
+    //
+    // This means there are many places we have to check to figure out when the
+    // AT is likely to expire, and thus when we want to rotate. First inspect
+    // the response, otherwise the session. Default to 10 seconds.
+    if (res?.accessTokenExpiration) {
+      this.logger.log('rtr', 'rotation scheduled with login response data');
+      const rotationPromise = Promise.resolve((new Date(res.accessTokenExpiration).getTime() - Date.now()) * RTR_AT_TTL_FRACTION);
+
+      scheduleRotation(rotationPromise);
+    } else {
+      const rotationPromise = getTokenExpiry().then((expiry) => {
+        if (expiry.atExpires) {
+          this.logger.log('rtr', 'rotation scheduled with cached session data');
+          return (new Date(expiry.atExpires).getTime() - Date.now()) * RTR_AT_TTL_FRACTION;
+        }
+
+        // default: 10 seconds
+        this.logger.log('rtr', 'rotation scheduled with default value');
+        return 10 * 1000;
+      });
+
+      scheduleRotation(rotationPromise);
+    }
   }
 
   /**

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -158,13 +158,16 @@ export class FFetch {
         this.logger.log('rtr', 'authn request');
         return this.nativeFetch.apply(global, [resource, options && { ...options, ...OKAPI_FETCH_OPTIONS }])
           .then(res => {
-            this.logger.log('rtr', 'authn success!');
             // a response can only be read once, so we clone it to grab the
             // tokenExpiration in order to kick of the rtr cycle, then return
             // the original
-            res.clone().json().then(json => {
-              this.rotateCallback(json.tokenExpiration);
-            });
+            const clone = res.clone();
+            if (clone.ok) {
+              this.logger.log('rtr', 'authn success!');
+              clone.json().then(json => {
+                this.rotateCallback(json.tokenExpiration);
+              });
+            }
 
             return res;
           });

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -59,10 +59,10 @@ import {
   RTRError,
 } from './Errors';
 import {
+  RTR_AT_EXPIRY_IF_UNKNOWN,
   RTR_AT_TTL_FRACTION,
   RTR_ERROR_EVENT,
 } from './constants';
-
 import FXHR from './FXHR';
 
 const OKAPI_FETCH_OPTIONS = {
@@ -139,7 +139,7 @@ export class FFetch {
 
         // default: 10 seconds
         this.logger.log('rtr', 'rotation scheduled with default value');
-        return 10 * 1000;
+        return ms(RTR_AT_EXPIRY_IF_UNKNOWN);
       });
 
       scheduleRotation(rotationPromise);

--- a/src/components/Root/constants.js
+++ b/src/components/Root/constants.js
@@ -47,3 +47,17 @@ export const RTR_IDLE_SESSION_TTL = '60m';
  * value must be a string parsable by ms()
  */
 export const RTR_IDLE_MODAL_TTL = '1m';
+
+/**
+ * When resuming an existing session but there is no token-expiration
+ * data in the session, we can't properly schedule RTR.
+ * 1. the real expiration data is in the cookie, but it's HTTPOnly
+ * 2. the resume-session API endpoint, _self, doesn't include
+ *    token-expiration data in its response
+ * 3. the session _should_ contain a value, but maybe the session
+ *    was corrupt.
+ * Given the resume-session API call succeeded, we know the AT must have been
+ * valid at the time, so we punt and schedule rotation in the future by this
+ * (relatively short) interval.
+ */
+export const RTR_AT_EXPIRY_IF_UNKNOWN = '10s';

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -693,7 +693,6 @@ export function processOkapiSession(okapiUrl, store, tenant, resp, ssoToken) {
  */
 export function validateUser(okapiUrl, store, tenant, session) {
   const { token, tenant: sessionTenant = tenant } = session;
-  console.log({ session })
   return fetch(`${okapiUrl}/bl-users/_self?expandPermissions=true`, {
     headers: getHeaders(sessionTenant, token),
     credentials: 'include',

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -693,6 +693,7 @@ export function processOkapiSession(okapiUrl, store, tenant, resp, ssoToken) {
  */
 export function validateUser(okapiUrl, store, tenant, session) {
   const { token, tenant: sessionTenant = tenant } = session;
+  console.log({ session })
   return fetch(`${okapiUrl}/bl-users/_self?expandPermissions=true`, {
     headers: getHeaders(sessionTenant, token),
     credentials: 'include',
@@ -742,7 +743,9 @@ export function validateUser(okapiUrl, store, tenant, session) {
 
 /**
  * checkOkapiSession
- * 1. Pull the session from local storage; if non-empty validate it, dispatching load-resources actions.
+ * 1. Pull the session from local storage; if it contains a user id,
+ *    validate it by fetching /_self to verify that it is still active,
+ *    dispatching load-resources actions.
  * 2. Check if SSO (SAML) is enabled, dispatching check-sso actions
  * 3. dispatch set-okapi-ready.
  *
@@ -753,7 +756,7 @@ export function validateUser(okapiUrl, store, tenant, session) {
 export function checkOkapiSession(okapiUrl, store, tenant) {
   getOkapiSession()
     .then((sess) => {
-      return sess !== null ? validateUser(okapiUrl, store, tenant, sess) : null;
+      return sess?.user?.id ? validateUser(okapiUrl, store, tenant, sess) : null;
     })
     .then(() => {
       return getSSOEnabled(okapiUrl, store, tenant);


### PR DESCRIPTION
Not all authentication-related responses are created equal. If the response contains AT expiration data, i.e. it is a response from `/bl-users/login-with-expiry`, use that data to configure RTR. If the response does not contain such data, i.e. it is a response from `/bl-users/_self`, pull AT expiration data from the session and use that. If we still don't have any AT expiration data, cross your fingers and try rotating in 10 seconds.

Previously, we did not ever check the session, so RTR always fired 10 seconds into a resumed, which is exactly the situation faced in e2e tests.

This doesn't precisely handle the issue faced by e2e tests that stall when the RTR request fires, but leveraging the session data should push the RTR request far enough into the future that most e2e tests will now complete before RTR fires. We should still try to understand that problem and solve it, but in the mean time this may enable us to work around it.

Refs [STCOR-776](https://folio-org.atlassian.net/browse/STCOR-776), [FAT-13789](https://folio-org.atlassian.net/browse/FAT-13789)