### PR TITLE
STCOR-859 list UI apps under apps/modules/interfaces column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Idle-session timeout and "Keep working?" modal. Refs STCOR-776.
 * Use keycloak URLs in place of users-bl for tenant-switch. Refs US1153537.
 * Fix 404 error page when logging in after changing password in Eureka. Refs STCOR-845.
+* List UI apps in "Applications/modules/interfaces" column. STCOR-773
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/components/About/AboutApplicationVersions.js
+++ b/src/components/About/AboutApplicationVersions.js
@@ -21,6 +21,7 @@ const AboutApplicationVersions = ({ message, applications }) => {
       </Headline>
       <Headline>{message}</Headline>
       {Object.values(applications)
+        .sort((a, b) => a.name.localeCompare(b.name))
         .map((app) => {
           return (
             <ul key={app.name}>

--- a/src/components/About/AboutModules.js
+++ b/src/components/About/AboutModules.js
@@ -7,7 +7,7 @@ import {
 import css from './About.css';
 
 
-const AboutInterfaces = ({ list }) => {
+const AboutInterfaces = ({ list = [] }) => {
   list.sort((a, b) => a.name.localeCompare(b.name));
   return (
     <List
@@ -23,7 +23,7 @@ AboutInterfaces.propTypes = {
   list: PropTypes.arrayOf(PropTypes.object),
 };
 
-const AboutModules = ({ list }) => {
+const AboutModules = ({ list = [] }) => {
   list.sort((a, b) => a.name.localeCompare(b.name));
 
   return (

--- a/src/components/About/AboutModules.js
+++ b/src/components/About/AboutModules.js
@@ -8,8 +8,10 @@ import css from './About.css';
 
 
 const AboutInterfaces = ({ list }) => {
+  list.sort((a, b) => a.name.localeCompare(b.name));
   return (
     <List
+      listStyle="bullets"
       listClass={css.paddingLeftOfListItems}
       items={list}
       itemFormatter={(item) => <li key={item.name}>{item.name}</li>}
@@ -22,6 +24,8 @@ AboutInterfaces.propTypes = {
 };
 
 const AboutModules = ({ list }) => {
+  list.sort((a, b) => a.name.localeCompare(b.name));
+
   return (
     <List
       listStyle="bullets"

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -258,9 +258,7 @@ export function discoveryReducer(state = {}, action) {
               ...action.data.uiModules.map((d) => {
                 return {
                   name: d.id,
-                  interfaces: d.provides?.map((i) => {
-                    return { name: i.id + ' ' + i.version };
-                  }) || [],
+                  interfaces: [],
                 };
               })
 

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -46,8 +46,8 @@ function parseApplicationDescriptor(store, descriptor) {
     list.push(...descriptor.moduleDescriptors?.map((i) => dispatchDescriptor(i)));
   }
 
-  if (descriptor['ui-modules']) {
-    list.push(...descriptor['ui-modules']?.map((i) => dispatchDescriptor(i)));
+  if (descriptor.uiModules) {
+    list.push(...descriptor.uiModules?.map((i) => dispatchDescriptor(i)));
   }
 
   list.push(dispatchApplication(descriptor));
@@ -76,7 +76,7 @@ function parseApplicationDescriptor(store, descriptor) {
           { "id": "mod-users-18.2.0", "name": "mod-users", "version": "18.2.0" },
           ...
         ],
-        "ui-modules": [
+        "uiModules": [
           { "name": "folio_stripes-core", "version": "8.1.2" },
           ...
         ],
@@ -246,14 +246,25 @@ export function discoveryReducer(state = {}, action) {
           ...state.applications,
           [action.data.id]: {
             name: action.data.id,
-            modules: action.data.moduleDescriptors.map((d) => {
-              return {
-                name: d.id,
-                interfaces: d.provides?.map((i) => {
-                  return { name: i.id + ' ' + i.version };
-                }) || [],
-              };
-            }),
+            modules: [
+              ...action.data.moduleDescriptors.map((d) => {
+                return {
+                  name: d.id,
+                  interfaces: d.provides?.map((i) => {
+                    return { name: i.id + ' ' + i.version };
+                  }) || [],
+                };
+              }),
+              ...action.data.uiModules.map((d) => {
+                return {
+                  name: d.id,
+                  interfaces: d.provides?.map((i) => {
+                    return { name: i.id + ' ' + i.version };
+                  }) || [],
+                };
+              })
+
+            ],
           },
         },
       };

--- a/src/discoverServices.test.js
+++ b/src/discoverServices.test.js
@@ -98,6 +98,42 @@ describe('discoverServices', () => {
 });
 
 describe('discoveryReducer', () => {
+  it('handles DISCOVERY_APPLICATIONS', () => {
+    let state = {};
+    const moduleDescriptors = [
+      { id: 'mod-a' },
+      { id: 'mod-b' },
+    ];
+    const uiModules = [
+      { id: 'folio_c' },
+      { id: 'folio_d' },
+    ];
+    const action = {
+      type: 'DISCOVERY_APPLICATIONS',
+      data: {
+        id: 'a',
+        moduleDescriptors,
+        uiModules,
+      },
+    };
+
+    const mapped = {
+      applications: {
+        [action.data.id]: {
+          name: action.data.id,
+          modules: [
+            ...moduleDescriptors.map((d) => ({ name: d.id, interfaces: [] })),
+            ...uiModules.map((d) => ({ name: d.id, interfaces: [] })),
+          ],
+        },
+      },
+    };
+
+    state = discoveryReducer(state, action);
+
+    expect(state).toMatchObject(mapped);
+  });
+
   it('handles DISCOVERY_OKAPI', () => {
     let state = {
       okapi: '0.0.0'

--- a/src/discoverServices.test.js
+++ b/src/discoverServices.test.js
@@ -101,7 +101,7 @@ describe('discoveryReducer', () => {
   it('handles DISCOVERY_APPLICATIONS', () => {
     let state = {};
     const moduleDescriptors = [
-      { id: 'mod-a' },
+      { id: 'mod-a', provides: [{ id: 'if-a', version: '1.0' }] },
       { id: 'mod-b' },
     ];
     const uiModules = [
@@ -122,7 +122,13 @@ describe('discoveryReducer', () => {
         [action.data.id]: {
           name: action.data.id,
           modules: [
-            ...moduleDescriptors.map((d) => ({ name: d.id, interfaces: [] })),
+            ...moduleDescriptors.map((d) => (
+              {
+                name: d.id,
+                interfaces: d.provides?.map((i) => {
+                  return { name: i.id + ' ' + i.version };
+                }) || []
+              })),
             ...uiModules.map((d) => ({ name: d.id, interfaces: [] })),
           ],
         },


### PR DESCRIPTION
Follow-up to the original PR (#1385, [STCOR-773](https://folio-org.atlassian.net/browse/STCOR-773)). There were at least two gotchas there:
1. The attribute key in the response changed from `ui-modules` to `uiModules`
2. Since frontend and backend applications are stored under separate keys, the discovery reducer needed to grab values from both keys.

Refs [STCOR-859](https://folio-org.atlassian.net/browse/STCOR-859)