### PR TITLE
STCOR-834: refactor useUserTenantPermissions to use _self endpoint permissions instead of okapi permissions if roles interface is presented

### DIFF
--- a/src/hooks/useUserSelfTenantPermissions.js
+++ b/src/hooks/useUserSelfTenantPermissions.js
@@ -1,0 +1,51 @@
+import { useQuery } from 'react-query';
+
+import { useStripes } from '../StripesContext';
+import { useNamespace } from '../components';
+import useOkapiKy from '../useOkapiKy';
+
+const INITIAL_DATA = [];
+
+const useUserSelfTenantPermissions = (
+  { tenantId },
+  options = {},
+) => {
+  const stripes = useStripes();
+  const ky = useOkapiKy();
+  const api = ky.extend({
+    hooks: {
+      beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', tenantId)]
+    }
+  });
+  const [namespace] = useNamespace({ key: 'user-self-permissions' });
+
+  const user = stripes.user.user;
+
+  const {
+    isFetching,
+    isLoading,
+    data,
+  } = useQuery(
+    [namespace, user?.id, tenantId],
+    ({ signal }) => {
+      return api.get(
+        'users-keycloak/_self',
+        { signal },
+      ).json();
+    },
+    {
+      enabled: Boolean(user?.id && tenantId) && stripes.hasInterface('users-keycloak'),
+      keepPreviousData: true,
+      ...options,
+    },
+  );
+
+  return ({
+    isFetching,
+    isLoading,
+    userPermissions: data?.permissions.permissions || INITIAL_DATA,
+    totalRecords: data?.permissions.permissions.length || 0,
+  });
+};
+
+export default useUserSelfTenantPermissions;

--- a/src/hooks/useUserSelfTenantPermissions.test.js
+++ b/src/hooks/useUserSelfTenantPermissions.test.js
@@ -5,7 +5,7 @@ import {
 } from 'react-query';
 
 import permissions from 'fixtures/permissions';
-import useUserTenantPermissionNames from './useUserTenantPermissionNames';
+import useUserSelfTenantPermissions from './useUserSelfTenantPermissions';
 import useOkapiKy from '../useOkapiKy';
 
 jest.mock('../useOkapiKy');
@@ -19,7 +19,7 @@ jest.mock('../StripesContext', () => ({
         id: 'userId'
       }
     },
-    hasInterface: () => false
+    hasInterface: () => true
   }),
 }));
 
@@ -33,11 +33,10 @@ const wrapper = ({ children }) => (
 );
 
 const response = {
-  permissionNames: permissions,
-  totalRecords: permissions.length,
+  permissions: { permissions },
 };
 
-describe('useUserTenantPermissionNames', () => {
+describe('useUserSelfTenantPermissions', () => {
   const getMock = jest.fn(() => ({
     json: () => Promise.resolve(response),
   }));
@@ -62,11 +61,11 @@ describe('useUserTenantPermissionNames', () => {
       userId: 'userId',
       tenantId: 'tenantId',
     };
-    const { result } = renderHook(() => useUserTenantPermissionNames(options), { wrapper });
+    const { result } = renderHook(() => useUserSelfTenantPermissions(options), { wrapper });
 
     await waitFor(() => !result.current.isLoading);
 
     expect(setHeaderMock).toHaveBeenCalledWith('X-Okapi-Tenant', options.tenantId);
-    expect(getMock).toHaveBeenCalledWith(`perms/users/${options.userId}/permissions`, expect.objectContaining({}));
+    expect(getMock).toHaveBeenCalledWith('users-keycloak/_self', expect.objectContaining({}));
   });
 });

--- a/src/hooks/useUserTenantPermissionNames.js
+++ b/src/hooks/useUserTenantPermissionNames.js
@@ -1,0 +1,59 @@
+import { useQuery } from 'react-query';
+
+import { useStripes } from '../StripesContext';
+import { useNamespace } from '../components';
+import useOkapiKy from '../useOkapiKy';
+
+const INITIAL_DATA = [];
+
+const useUserTenantPermissionNames = (
+  { tenantId },
+  options = {},
+) => {
+  const stripes = useStripes();
+  const ky = useOkapiKy();
+  const api = ky.extend({
+    hooks: {
+      beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', tenantId)]
+    }
+  });
+  const [namespace] = useNamespace({ key: 'user-affiliation-permissions' });
+
+  const user = stripes.user.user;
+
+  const searchParams = {
+    full: 'true',
+    indexField: 'userId',
+  };
+
+  const {
+    isFetching,
+    isLoading,
+    data = {},
+  } = useQuery(
+    [namespace, user?.id, tenantId],
+    ({ signal }) => {
+      return api.get(
+        `perms/users/${user.id}/permissions`,
+        {
+          searchParams,
+          signal,
+        },
+      ).json();
+    },
+    {
+      enabled: Boolean(user?.id && tenantId),
+      keepPreviousData: true,
+      ...options,
+    },
+  );
+
+  return ({
+    isFetching,
+    isLoading,
+    userPermissions: data.permissionNames || INITIAL_DATA,
+    totalRecords: data.totalRecords,
+  });
+};
+
+export default useUserTenantPermissionNames;

--- a/src/hooks/useUserTenantPermissionNames.js
+++ b/src/hooks/useUserTenantPermissionNames.js
@@ -42,7 +42,7 @@ const useUserTenantPermissionNames = (
       ).json();
     },
     {
-      enabled: Boolean(user?.id && tenantId),
+      enabled: Boolean(user?.id && tenantId) && !stripes.hasInterface('roles'),
       keepPreviousData: true,
       ...options,
     },

--- a/src/hooks/useUserTenantPermissionNames.test.js
+++ b/src/hooks/useUserTenantPermissionNames.test.js
@@ -5,7 +5,7 @@ import {
 } from 'react-query';
 
 import permissions from 'fixtures/permissions';
-import useUserTenantPermissions from './useUserTenantPermissions';
+import useUserTenantPermissionNames from './useUserTenantPermissionNames';
 import useOkapiKy from '../useOkapiKy';
 
 jest.mock('../useOkapiKy');
@@ -61,7 +61,7 @@ describe('useUserTenantPermissions', () => {
       userId: 'userId',
       tenantId: 'tenantId',
     };
-    const { result } = renderHook(() => useUserTenantPermissions(options), { wrapper });
+    const { result } = renderHook(() => useUserTenantPermissionNames(options), { wrapper });
 
     await waitFor(() => !result.current.isLoading);
 

--- a/src/hooks/useUserTenantPermissions.js
+++ b/src/hooks/useUserTenantPermissions.js
@@ -1,58 +1,37 @@
-import { useQuery } from 'react-query';
-
 import { useStripes } from '../StripesContext';
-import { useNamespace } from '../components';
-import useOkapiKy from '../useOkapiKy';
-
-const INITIAL_DATA = [];
+import useUserSelfTenantPermissions from './useUserSelfTenantPermissions';
+import useUserTenantPermissionNames from './useUserTenantPermissionNames';
 
 const useUserTenantPermissions = (
   { tenantId },
   options = {},
 ) => {
   const stripes = useStripes();
-  const ky = useOkapiKy();
-  const api = ky.extend({
-    hooks: {
-      beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', tenantId)]
-    }
-  });
-  const [namespace] = useNamespace({ key: 'user-affiliation-permissions' });
-
-  const user = stripes.user.user;
-
-  const searchParams = {
-    full: 'true',
-    indexField: 'userId',
-  };
 
   const {
-    isFetching,
-    isLoading,
-    data = {},
-  } = useQuery(
-    [namespace, user?.id, tenantId],
-    ({ signal }) => {
-      return api.get(
-        `perms/users/${user.id}/permissions`,
-        {
-          searchParams,
-          signal,
-        },
-      ).json();
-    },
-    {
-      enabled: Boolean(user?.id && tenantId),
-      keepPreviousData: true,
-      ...options,
-    },
-  );
+    isFetching: isPermissionsFetching,
+    isLoading: isPermissionsLoading,
+    userPermissions: permissionsData = {},
+    totalRecords: permissionsTotalRecords
+  } = useUserTenantPermissionNames({ tenantId }, options);
+
+  const {
+    isFetching: isSelfPermissionsFetching,
+    isLoading: isSelfPermissionsLoading,
+    userPermissions:selfPermissionsData = {},
+    totalRecords: selfPermissionsTotalRecords
+  } = useUserSelfTenantPermissions({ tenantId }, options);
+
+  const isFetching = stripes.hasInterface('roles') ? isSelfPermissionsFetching : isPermissionsFetching;
+  const isLoading = stripes.hasInterface('roles') ? isSelfPermissionsLoading : isPermissionsLoading;
+  const userPermissions = stripes.hasInterface('roles') ? selfPermissionsData : permissionsData;
+  const totalRecords = stripes.hasInterface('roles') ? selfPermissionsTotalRecords : permissionsTotalRecords;
 
   return ({
     isFetching,
     isLoading,
-    userPermissions: data.permissionNames || INITIAL_DATA,
-    totalRecords: data.totalRecords,
+    userPermissions,
+    totalRecords
   });
 };
 

--- a/src/hooks/useUserTenantPermissions.test.js
+++ b/src/hooks/useUserTenantPermissions.test.js
@@ -1,0 +1,74 @@
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+import { useStripes } from '../StripesContext';
+import useUserSelfTenantPermissions from './useUserSelfTenantPermissions';
+import useUserTenantPermissionNames from './useUserTenantPermissionNames';
+import useUserTenantPermissions from './useUserTenantPermissions';
+
+jest.mock('../StripesContext');
+jest.mock('./useUserSelfTenantPermissions');
+jest.mock('./useUserTenantPermissionNames');
+
+describe('useUserTenantPermissions', () => {
+  const tenantId = 'tenant-id';
+  const options = {};
+
+  beforeEach(() => {
+    useStripes.mockReturnValue({
+      hasInterface: jest.fn()
+    });
+  });
+
+  it('should return _self permissions data when "roles" interface is present', () => {
+    useStripes().hasInterface.mockReturnValue(true);
+
+    useUserSelfTenantPermissions.mockReturnValue({
+      isFetching: true,
+      isLoading: true,
+      userPermissions: ['self'],
+      totalRecords: 1
+    });
+
+    useUserTenantPermissionNames.mockReturnValue({
+      isFetching: false,
+      isLoading: false,
+      userPermissions: ['permission name'],
+      totalRecords: 1
+    });
+
+    const { result } = renderHook(() => useUserTenantPermissions({ tenantId }, options));
+
+    expect(result.current).toStrictEqual({
+      isFetching: true,
+      isLoading: true,
+      userPermissions: ['self'],
+      totalRecords: 1
+    });
+  });
+
+  it('should return tenant permissions data when "roles" interface is NOT present', () => {
+    useStripes().hasInterface.mockReturnValue(false);
+
+    useUserSelfTenantPermissions.mockReturnValue({
+      isFetching: true,
+      isLoading: true,
+      userPermissions: ['self'],
+      totalRecords: 1
+    });
+
+    useUserTenantPermissionNames.mockReturnValue({
+      isFetching: false,
+      isLoading: false,
+      userPermissions: ['permission name'],
+      totalRecords: 1
+    });
+
+    const { result } = renderHook(() => useUserTenantPermissions({ tenantId }, options));
+
+    expect(result.current).toStrictEqual({
+      isFetching: false,
+      isLoading: false,
+      userPermissions: ['permission name'],
+      totalRecords: 1
+    });
+  });
+});


### PR DESCRIPTION
Refs [STCOR-834](https://folio-org.atlassian.net/browse/STCOR-834). 
Create separate hooks to retrieve permissions, one for getting okapi permissions, and second getting permissions from users-keycloak/_self endpoint. And depending on if roles interface presented use okapi permissions or users-keycloak permissions. 



