### PR TITLE
STCOR-787 Fix tenant and clientId references

### DIFF
--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -39,8 +39,9 @@ const AuthnLogin = ({ stripes }) => {
   if (okapi.authnUrl) {
     // If only 1 tenant is defined in config, skip the tenant selection screen.
     if (tenants.length === 1) {
+      const loginTenant = tenants[0];
       const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;
-      const authnUri = `${okapi.authnUrl}/realms/${okapi.tenant}/protocol/openid-connect/auth?client_id=${okapi.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
+      const authnUri = `${okapi.authnUrl}/realms/${loginTenant.name}/protocol/openid-connect/auth?client_id=${loginTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
       return <Redirect to={authnUri} />;
     }
 

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -112,7 +112,8 @@ export class FFetch {
       rotationP.then((rotationInterval) => {
         this.logger.log('rtr', `rotation fired from rotateCallback; next callback in ${ms(rotationInterval)}`);
         this.store.dispatch(setRtrTimeout(setTimeout(() => {
-          rtr(this.nativeFetch, this.logger, this.rotateCallback);
+          const { okapi } = this.store.getState();
+          rtr(this.nativeFetch, this.logger, this.rotateCallback, okapi);
         }, rotationInterval)));
       });
     };

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -112,8 +112,8 @@ export class FFetch {
       rotationP.then((rotationInterval) => {
         this.logger.log('rtr', `rotation fired from rotateCallback; next callback in ${ms(rotationInterval)}`);
         this.store.dispatch(setRtrTimeout(setTimeout(() => {
-          const { okapi } = this.store.getState();
-          rtr(this.nativeFetch, this.logger, this.rotateCallback, okapi);
+          const okapiStore = this.store.getState().okapi;
+          rtr(this.nativeFetch, this.logger, this.rotateCallback, okapiStore);
         }, rotationInterval)));
       });
     };

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -42,7 +42,7 @@
  */
 
 import ms from 'ms';
-import { okapi } from 'stripes-config';
+import { okapi as okapiConfig } from 'stripes-config';
 import {
   setRtrTimeout
 } from '../../okapiActions';
@@ -112,8 +112,8 @@ export class FFetch {
       rotationP.then((rotationInterval) => {
         this.logger.log('rtr', `rotation fired from rotateCallback; next callback in ${ms(rotationInterval)}`);
         this.store.dispatch(setRtrTimeout(setTimeout(() => {
-          const okapiStore = this.store.getState().okapi;
-          rtr(this.nativeFetch, this.logger, this.rotateCallback, okapiStore);
+          const { okapi } = this.store.getState();
+          rtr(this.nativeFetch, this.logger, this.rotateCallback, okapi);
         }, rotationInterval)));
       });
     };
@@ -174,12 +174,12 @@ export class FFetch {
    */
   ffetch = async (resource, options = {}) => {
     // FOLIO API requests are subject to RTR
-    if (isFolioApiRequest(resource, okapi.url)) {
+    if (isFolioApiRequest(resource, okapiConfig.url)) {
       this.logger.log('rtrv', 'will fetch', resource);
 
       // on authentication, grab the response to kick of the rotation cycle,
       // then return the response
-      if (isAuthenticationRequest(resource, okapi.url)) {
+      if (isAuthenticationRequest(resource, okapiConfig.url)) {
         this.logger.log('rtr', 'authn request');
         return this.nativeFetch.apply(global, [resource, options && { ...options, ...OKAPI_FETCH_OPTIONS }])
           .then(res => {
@@ -208,7 +208,7 @@ export class FFetch {
       // tries to logout, the logout request will fail. And that's fine, just
       // fine. We will let them fail, capturing the response and swallowing it
       // to avoid getting stuck in an error loop.
-      if (isLogoutRequest(resource, okapi.url)) {
+      if (isLogoutRequest(resource, okapiConfig.url)) {
         this.logger.log('rtr', 'logout request');
 
         return this.nativeFetch.apply(global, [resource, options && { ...options, ...OKAPI_FETCH_OPTIONS }])

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -1,6 +1,3 @@
-import { isEmpty } from 'lodash';
-import { okapi } from 'stripes-config';
-
 import { getTokenExpiry, setTokenExpiry } from '../../loginServices';
 import { RTRError, UnexpectedResourceError } from './Errors';
 import {
@@ -192,9 +189,10 @@ export const isRotating = () => {
  * @param {function} fetchfx native fetch function
  * @param {@folio/stripes/logger} logger
  * @param {function} callback
+ * @param {object} store
  * @returns void
  */
-export const rtr = (fetchfx, logger, callback) => {
+export const rtr = (fetchfx, logger, callback, okapi) => {
   logger.log('rtr', '** RTR ...');
 
   // rotation is already in progress, maybe in this window,

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -1,3 +1,5 @@
+import { isEmpty } from 'lodash';
+
 import { getTokenExpiry, setTokenExpiry } from '../../loginServices';
 import { RTRError, UnexpectedResourceError } from './Errors';
 import {

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -191,7 +191,7 @@ export const isRotating = () => {
  * @param {function} fetchfx native fetch function
  * @param {@folio/stripes/logger} logger
  * @param {function} callback
- * @param {object} store
+ * @param {object} okapi
  * @returns void
  */
 export const rtr = (fetchfx, logger, callback, okapi) => {

--- a/src/components/Root/token-util.test.js
+++ b/src/components/Root/token-util.test.js
@@ -13,6 +13,11 @@ import {
 } from './token-util';
 import { RTR_SUCCESS_EVENT } from './constants';
 
+const okapi = {
+  tenant: 'diku',
+  url: 'http://test'
+};
+
 describe('isFolioApiRequest', () => {
   it('accepts requests whose origin matches okapi\'s', () => {
     const oUrl = 'https://millicent-sounds-kinda-like-malificent.edu';
@@ -126,7 +131,7 @@ describe('rtr', () => {
     let ex = null;
     // const callback = () => { console.log('HOLA!!!')}; // jest.fn();
     try {
-      await rtr(fetchfx, logger, callback);
+      await rtr(fetchfx, logger, callback, okapi);
       expect(callback).toHaveBeenCalled();
     } catch (e) {
       ex = e;
@@ -168,7 +173,7 @@ describe('rtr', () => {
 
       let ex = null;
       try {
-        await rtr(nativeFetch, logger, jest.fn());
+        await rtr(nativeFetch, logger, jest.fn(), okapi);
       } catch (e) {
         ex = e;
       }
@@ -202,7 +207,7 @@ describe('rtr', () => {
 
       let ex = null;
       try {
-        await rtr(nativeFetch, logger, jest.fn());
+        await rtr(nativeFetch, logger, jest.fn(), okapi);
       } catch (e) {
         ex = e;
       }
@@ -232,7 +237,7 @@ describe('rtr', () => {
 
     let ex = null;
     try {
-      await rtr(nativeFetch, logger, jest.fn());
+      await rtr(nativeFetch, logger, jest.fn(), okapi);
     } catch (e) {
       ex = e;
     }
@@ -262,7 +267,7 @@ describe('rtr', () => {
 
     let ex = null;
     try {
-      await rtr(nativeFetch, logger, jest.fn());
+      await rtr(nativeFetch, logger, jest.fn(), okapi);
     } catch (e) {
       ex = e;
     }

--- a/src/components/SSOLanding/useSSOSession.js
+++ b/src/components/SSOLanding/useSSOSession.js
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { useCookies } from 'react-cookie';
 import queryString from 'query-string';
 
-import { config, okapi } from 'stripes-config';
+import { config } from 'stripes-config';
 
 import { defaultErrors } from '../../constants';
 import { setAuthError } from '../../okapiActions';
@@ -24,11 +24,12 @@ const getToken = (cookies, params) => {
 };
 
 const getTenant = (params, token) => {
+  const store = useStore();
   const tenant = config.useSecureTokens
     ? params?.tenantId
     : parseJWT(token)?.tenant;
 
-  return tenant || okapi.tenant;
+  return tenant || store.getState()?.okapi?.tenant;
 };
 
 const useSSOSession = () => {

--- a/src/components/SSOLanding/useSSOSession.js
+++ b/src/components/SSOLanding/useSSOSession.js
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { useCookies } from 'react-cookie';
 import queryString from 'query-string';
 
-import { config } from 'stripes-config';
+import { config, okapi } from 'stripes-config';
 
 import { defaultErrors } from '../../constants';
 import { setAuthError } from '../../okapiActions';
@@ -23,8 +23,7 @@ const getToken = (cookies, params) => {
   return cookies?.ssoToken || params?.ssoToken;
 };
 
-const getTenant = (params, token) => {
-  const store = useStore();
+const getTenant = (params, token, store) => {
   const tenant = config.useSecureTokens
     ? params?.tenantId
     : parseJWT(token)?.tenant;
@@ -43,7 +42,7 @@ const useSSOSession = () => {
   const params = getParams(location);
 
   const token = getToken(cookies, params);
-  const tenant = getTenant(params, token);
+  const tenant = getTenant(params, token, store);
 
   useEffect(() => {
     requestUserWithPerms(okapi.url, store, tenant, token)

--- a/src/components/SSOLanding/useSSOSession.test.js
+++ b/src/components/SSOLanding/useSSOSession.test.js
@@ -56,7 +56,7 @@ describe('SSOLanding', () => {
         okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } 
+        }
       })
     });
 

--- a/src/components/SSOLanding/useSSOSession.test.js
+++ b/src/components/SSOLanding/useSSOSession.test.js
@@ -51,7 +51,14 @@ describe('SSOLanding', () => {
     useLocation.mockReturnValue({ search: '' });
     useCookies.mockReturnValue([]);
 
-    useStore.mockReturnValue({ getState: jest.fn() });
+    useStore.mockReturnValue({
+      getState: jest.fn().mockReturnValue({
+        okapi: {
+          url: 'okapiUrl',
+          tenant: 'okapiTenant'
+        } 
+      })
+    });
 
     requestUserWithPerms.mockReturnValue(Promise.resolve());
   });

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -96,7 +96,7 @@ function parseApplicationDescriptor(store, descriptor) {
 const APP_MAX_COUNT = 500;
 
 function fetchApplicationDetails(store) {
-  const okapi = store.getState().okapi;
+  const { okapi } = store.getState();
 
   return fetch(`${okapi.url}/entitlements/${okapi.tenant}/applications?limit=${APP_MAX_COUNT}`, {
     credentials: 'include',
@@ -146,7 +146,7 @@ function fetchApplicationDetails(store) {
  */
 
 function fetchGatewayVersion(store) {
-  const okapi = store.getState().okapi;
+  const { okapi } = store.getState();
 
   return fetch(`${okapi.url}/version`, {
     credentials: 'include',
@@ -167,7 +167,7 @@ function fetchGatewayVersion(store) {
 }
 
 function fetchOkapiVersion(store) {
-  const okapi = store.getState().okapi;
+  const { okapi } = store.getState();
 
   return fetch(`${okapi.url}/_/version`, {
     credentials: 'include',
@@ -188,7 +188,7 @@ function fetchOkapiVersion(store) {
 }
 
 function fetchModules(store) {
-  const okapi = store.getState().okapi;
+  const { okapi } = store.getState();
 
   return fetch(`${okapi.url}/_/proxy/tenants/${okapi.tenant}/modules?full=true`, {
     credentials: 'include',


### PR DESCRIPTION
- Fixes issues introduced in https://github.com/folio-org/stripes-core/pull/1487.
- Fulfills [STCOR-787](https://folio-org.atlassian.net/browse/STCOR-787).
- This ensures that stripes.config.js is only read once on application load. 
  - If there is only 1 tenant, it is saved to `okapi.tenant`.
  - If there is > 1 tenant, user selects the tenant and then it is saved to `okapi.tenant`.