### PR TITLE
STCOR-860 correctly populate stripes.user.user on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Update session data with values from `_self` request on reload. Refs STCOR-846.
 * Avoid deprecated `getChildContext`. Refs STCOR-842.
 * Read locale from stripes-config before defaulting to `en-US`. Refs STCOR-851.
+* Correctly populate `stripes.user.user` on reload. Refs STCOR-860.
 
 ## [10.1.0](https://github.com/folio-org/stripes-core/tree/v10.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.0.0...v10.1.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -719,7 +719,7 @@ export function validateUser(okapiUrl, store, tenant, session) {
         // data isn't provided by _self.
         store.dispatch(setSessionData({
           isAuthenticated: true,
-          user: data.user,
+          user,
           perms,
           tenant: sessionTenant,
           token,


### PR DESCRIPTION
When resuming an existing session, populate `stripes.user.user` exactly the same way as when creating a new session. Principally, this means leveraging the return value from `spreadUserWithPerms` over `user`, instead of using the raw `user` value from the response, which spreads the `user.personal` attributes.

Refs [STCOR-860](https://folio-org.atlassian.net/browse/STCOR-860)