### PR TITLE
STCOR-866 include `/users-keycloak/_self` in auth-n requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Always retrieve `clientId` and `tenant` values from `config.tenantOptions` in stripes.config.js. Retires `okapi.tenant`, `okapi.clientId`, and `config.isSingleTenant`. Refs STCOR-787.
 * List UI apps in "Applications/modules/interfaces" column. STCOR-773
 * Correctly evaluate `stripes.okapi` before rendering `<RootWithIntl>`. Refs STCOR-864.
+* `/users-keycloak/_self` is an authentication request. Refs STCOR-866.
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -5,7 +5,6 @@ import { RTRError, UnexpectedResourceError } from './Errors';
 import {
   RTR_ACTIVITY_EVENTS,
   RTR_ERROR_EVENT,
-  RTR_FLS_WARNING_TTL,
   RTR_IDLE_MODAL_TTL,
   RTR_IDLE_SESSION_TTL,
   RTR_SUCCESS_EVENT,
@@ -325,12 +324,6 @@ export const configureRtr = (config = {}) => {
   // what events constitute activity?
   if (isEmpty(conf.activityEvents)) {
     conf.activityEvents = RTR_ACTIVITY_EVENTS;
-  }
-
-  // how long is the "your session is gonna die!" warning shown
-  // before the session is, in fact, killed?
-  if (!conf.fixedSessionWarningTTL) {
-    conf.fixedSessionWarningTTL = RTR_FLS_WARNING_TTL;
   }
 
   return conf;

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -5,6 +5,7 @@ import { RTRError, UnexpectedResourceError } from './Errors';
 import {
   RTR_ACTIVITY_EVENTS,
   RTR_ERROR_EVENT,
+  RTR_FLS_WARNING_TTL,
   RTR_IDLE_MODAL_TTL,
   RTR_IDLE_SESSION_TTL,
   RTR_SUCCESS_EVENT,
@@ -74,6 +75,7 @@ export const isAuthenticationRequest = (resource, oUrl) => {
       '/authn/token',
       '/bl-users/login-with-expiry',
       '/bl-users/_self',
+      '/users-keycloak/_self',
     ];
 
     return !!permissible.find(i => string.startsWith(`${oUrl}${i}`));
@@ -323,6 +325,12 @@ export const configureRtr = (config = {}) => {
   // what events constitute activity?
   if (isEmpty(conf.activityEvents)) {
     conf.activityEvents = RTR_ACTIVITY_EVENTS;
+  }
+
+  // how long is the "your session is gonna die!" warning shown
+  // before the session is, in fact, killed?
+  if (!conf.fixedSessionWarningTTL) {
+    conf.fixedSessionWarningTTL = RTR_FLS_WARNING_TTL;
   }
 
   return conf;


### PR DESCRIPTION
The RTR cycle is kicked off when processing the reponse from an authentication-related request. `/users-keycloak/_self` was missing from the list, which meant that RTR would never kick off when a new tab was opened for an existing session.

Refs [STCOR-866](https://folio-org.atlassian.net/browse/STCOR-866)