### PR TITLE
STCOR-867 Add permission display names lookup table to Redux

### DIFF
--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -25,6 +25,7 @@ function parseApplicationDescriptor(store, descriptor) {
   const dispatchDescriptor = (d) => {
     return Promise.all([
       store.dispatch({ type: 'DISCOVERY_INTERFACES', data: d }),
+      store.dispatch({ type: 'DISCOVERY_PERMISSION_DISPLAY_NAMES', data: d }),
       store.dispatch({ type: 'DISCOVERY_PROVIDERS', data: d }),
     ]);
   };
@@ -42,8 +43,13 @@ function parseApplicationDescriptor(store, descriptor) {
       data: descriptor.moduleDescriptors,
     })
   );
+
   if (descriptor.moduleDescriptors) {
     list.push(...descriptor.moduleDescriptors?.map((i) => dispatchDescriptor(i)));
+  }
+
+  if (descriptor.uiModuleDescriptors) {
+    list.push(...descriptor.uiModuleDescriptors?.map((i) => dispatchDescriptor(i)));
   }
 
   if (descriptor.uiModules) {
@@ -284,6 +290,16 @@ export function discoveryReducer(state = {}, action) {
       }
       return Object.assign({}, state, {
         interfaces: Object.assign(state.interfaces || {}, interfaces),
+      });
+    }
+    case 'DISCOVERY_PERMISSION_DISPLAY_NAMES': {
+      const permissions = {};
+      for (const entry of action.data.permissionSets || []) {
+        permissions[entry.permissionName] = entry.displayName;
+      }
+      return Object.assign({}, state, {
+        permissionDisplayNames: state.permissionDisplayNames ?
+          Object.assign({}, state.permissionDisplayNames, permissions) : permissions,
       });
     }
     case 'DISCOVERY_PROVIDERS': {

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -45,15 +45,15 @@ function parseApplicationDescriptor(store, descriptor) {
   );
 
   if (descriptor.moduleDescriptors) {
-    list.push(...descriptor.moduleDescriptors?.map((i) => dispatchDescriptor(i)));
+    list.push(...descriptor.moduleDescriptors.map((i) => dispatchDescriptor(i)));
   }
 
   if (descriptor.uiModuleDescriptors) {
-    list.push(...descriptor.uiModuleDescriptors?.map((i) => dispatchDescriptor(i)));
+    list.push(...descriptor.uiModuleDescriptors.map((i) => dispatchDescriptor(i)));
   }
 
   if (descriptor.uiModules) {
-    list.push(...descriptor.uiModules?.map((i) => dispatchDescriptor(i)));
+    list.push(...descriptor.uiModules.map((i) => dispatchDescriptor(i)));
   }
 
   list.push(dispatchApplication(descriptor));
@@ -297,10 +297,7 @@ export function discoveryReducer(state = {}, action) {
       for (const entry of action.data.permissionSets || []) {
         permissions[entry.permissionName] = entry.displayName;
       }
-      return Object.assign({}, state, {
-        permissionDisplayNames: state.permissionDisplayNames ?
-          Object.assign({}, state.permissionDisplayNames, permissions) : permissions,
-      });
+      return { permissionDisplayNames: { ...state.permissionDisplayNames, ...permissions } };
     }
     case 'DISCOVERY_PROVIDERS': {
       if (action.data.provides?.length > 0) {

--- a/src/discoverServices.test.js
+++ b/src/discoverServices.test.js
@@ -140,6 +140,26 @@ describe('discoveryReducer', () => {
     expect(state).toMatchObject(mapped);
   });
 
+  it('handles DISCOVERY_PERMISSION_DISPLAY_NAMES', () => {
+    let state = {
+      permissionDisplayNames: {}
+    };
+    const action = {
+      type: 'DISCOVERY_PERMISSION_DISPLAY_NAMES',
+      data: {
+        permissionSets: [
+          { 'permissionName': 'perm1', 'displayName': 'Admin Permission' },
+          { 'permissionName': 'perm2', 'displayName': 'Read-only Permission' }
+        ]
+      },
+    };
+
+    state = discoveryReducer(state, action);
+
+    expect(state.permissionDisplayNames.perm1).toBe(action.data.permissionSets[0].displayName);
+    expect(state.permissionDisplayNames.perm2).toBe(action.data.permissionSets[1].displayName);
+  });
+
   it('handles DISCOVERY_OKAPI', () => {
     let state = {
       okapi: '0.0.0'


### PR DESCRIPTION
- Fulfills [STCOR-867](https://folio-org.atlassian.net/browse/STCOR-867) which is needed to complete [UID-156](https://folio-org.atlassian.net/browse/UID-156).
- Created lookup table for `permissionDisplayName` which is keyed by `permissionName`.
- Also including `uiModuleDescriptors` since those permissions are relevant.
- Note there is a separate Redux section called `okapi.currentPerms` that I considered building on, but that cannot be reused here since we need all permission names, not just the enabled ones.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/039a9dcd-79df-4741-b3dd-2ea07220fdba">
