### PR TITLE
[STCOR-867] Add back missing reference to state

### DIFF
--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -297,7 +297,7 @@ export function discoveryReducer(state = {}, action) {
       for (const entry of action.data.permissionSets || []) {
         permissions[entry.permissionName] = entry.displayName;
       }
-      return { permissionDisplayNames: { ...state.permissionDisplayNames, ...permissions } };
+      return { ...state, permissionDisplayNames: { ...state.permissionDisplayNames, ...permissions } };
     }
     case 'DISCOVERY_PROVIDERS': {
       if (action.data.provides?.length > 0) {


### PR DESCRIPTION
This is so state is not dropped when adding permission display names. The previous code was improper Redux behavior because it overwrote existing state.