### PR TITLE
STCOR-872: Return query keys from useChunkedCQLFetch 

### DIFF
--- a/src/queries/useChunkedCQLFetch.js
+++ b/src/queries/useChunkedCQLFetch.js
@@ -96,7 +96,9 @@ const useChunkedCQLFetch = ({
     STEP_SIZE
   ]);
 
-  const itemQueries = useQueries(getQueryArray());
+  const queryArray = getQueryArray();
+
+  const itemQueries = useQueries(queryArray);
 
   // Once chunk has finished fetching, fetch next chunk
   useEffect(() => {
@@ -133,7 +135,8 @@ const useChunkedCQLFetch = ({
     itemQueries,
     isLoading,
     // Offer all fetched orderLines in flattened array once ready
-    items: isLoading ? [] : reduceFunction(itemQueries)
+    items: isLoading ? [] : reduceFunction(itemQueries),
+    queryKeys: queryArray.map(q => q.queryKey)
   };
 };
 

--- a/src/queries/useChunkedCQLFetch.test.js
+++ b/src/queries/useChunkedCQLFetch.test.js
@@ -193,5 +193,25 @@ describe('Given useChunkedCQLFetch', () => {
 
       expect(result.current.itemQueries?.length).toEqual(2);
     });
+
+    it('expose queryKeys based on given ids and endpoint', async () => {
+      const { result } = renderHook(() => useChunkedCQLFetch({
+        ...baseOptions,
+        STEP_SIZE: 2
+      }), { wrapper });
+
+      await waitFor(() => {
+        const loadingQueries = result.current.itemQueries?.filter(iq => iq.isLoading);
+
+        return loadingQueries.length === 0;
+      });
+
+      expect(result.current.queryKeys).toHaveLength(3);
+      expect(result.current.queryKeys).toStrictEqual([
+        ['stripes-core', 'users', ['1234-5678-a', '1234-5678-b']],
+        ['stripes-core', 'users', ['1234-5678-c', '1234-5678-d']],
+        ['stripes-core', 'users', ['1234-5678-e']]
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Sometimes we need to invalidate queries, to be able to do so queryKeys generated in useChunkedCQLFetch should be available. 
**Purpose**
[STCOR-872](https://folio-org.atlassian.net/browse/STCOR-872) - expose query keys from useChunkedCQLFetch. 

