### PR TITLE
STCOR-874 provide "key" prop to SessionEventContainer elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Correctly evaluate `stripes.okapi` before rendering `<RootWithIntl>`. Refs STCOR-864.
 * `/users-keycloak/_self` is an authentication request. Refs STCOR-866.
 * Terminate the session when the fixed-length session expires. Refs STCOR-862.
+* Provide `key` to elements in `<SessionEventContainer>`. Refs STCOR-874.
 
 ## [10.1.0](https://github.com/folio-org/stripes-core/tree/v10.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.0.0...v10.1.0)

--- a/src/components/SessionEventContainer/SessionEventContainer.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.js
@@ -270,12 +270,12 @@ const SessionEventContainer = ({ history }) => {
 
   // show the idle-session warning modal?
   if (isVisible) {
-    renderList.push(<KeepWorkingModal callback={keepWorkingCallback} />);
+    renderList.push(<KeepWorkingModal callback={keepWorkingCallback} key="KeepWorkingModal" />);
   }
 
   // show the fixed-length session warning?
   if (isFlsVisible) {
-    renderList.push(<FixedLengthSessionWarning />);
+    renderList.push(<FixedLengthSessionWarning key="FixedLengthSessionWarning" />);
   }
 
   return renderList.length ? renderList : null;


### PR DESCRIPTION
Without a `key` prop to distinguish the elements rendered by `<SessionEventContainer>`, they could interact badly. In particular, if both elements (`<KeepWorkingModal>`, `<FixedLengthSessionWarning>`) were displayed, dismissing the former would cause the latter to remount, thus restarting the timer and putting it out of sync with when the session will actually end.

When React warns you about missing keys, it ain't foolin'!

Refs [STCOR-874](https://folio-org.atlassian.net/browse/STCOR-874)