### PR TITLE
[STCOR-876] Remember requested URL path on Login (Regression bug) 

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -163,6 +163,7 @@ const RootWithIntl = ({ stripes, token = '', isAuthenticated = false, disableAut
                       />
                       <TitledRoute
                         name="login"
+                        path="*"
                         component={<AuthnLogin stripes={connectedStripes} />}
                       />
                     </Switch>

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -36,7 +36,7 @@ const AuthnLogin = ({ stripes }) => {
      * @see OIDCRedirect
      */
     if (okapi.authnUrl && window.location.pathname !== '/') {
-      setUnauthorizedPathToSession(window.location.pathname);
+      setUnauthorizedPathToSession(window.location.pathname + window.location.search);
     }
 
     // If only 1 tenant is defined in config (in either okapi or config.tenantOptions) set to okapi to be accessed there

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import Redirect from '../Redirect';
 import PreLoginLanding from '../PreLoginLanding';
@@ -18,7 +18,7 @@ const AuthnLogin = ({ stripes }) => {
     stripes.store.dispatch(setOkapiTenant({ tenant, clientId }));
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     /**
      * Cache the current path so we can return to it after authenticating.
      * In RootWithIntl, unauthenticated visits to protected paths will be


### PR DESCRIPTION
- Refs [STCOR-876](https://folio-org.atlassian.net/browse/STCOR-876).
- Ensure `setUnauthorizedPathToSession` is called in `AuthnLogin` to remember requested path on login. I added a more explicit default path handler when user is unauthorized. I also switched from `useEffect` to `useLayoutEffect` in `AuthnLogin` so that logic is called before anything on the UI is drawn.
- Also adding `window.location.search` to session storage so URL params are remembered.