### PR TITLE
STCOR-880 (STCOR-869 backport) add margin to prevent cookie expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change history for stripes-core
 
-## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
-[Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)
+## IN PROGRESS
 
 * Use keycloak URLs in place of users-bl for tenant-switch. Refs US1153537.
 * Idle-session timeout and "Keep working?" modal. Refs STCOR-776.
@@ -10,6 +9,13 @@
 * `/users-keycloak/_self` is an authentication request. Refs STCOR-866.
 * Terminate the session when the fixed-length session expires. Refs STCOR-862.
 * Provide `key` to elements in `<SessionEventContainer>`. Refs STCOR-874.
+* Do not store /logout as a "return-to" URL. Refs STCOR-869.
+* Add small margin to ensure /authn/logout is called before cookie expires. Refs STCOR-869.
+
+## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
+[Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)
+
+* Utilize the `tenant` procured through the SSO login process. Refs STCOR-769.
 
 ## [10.1.0](https://github.com/folio-org/stripes-core/tree/v10.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.0.0...v10.1.0)

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -65,6 +65,7 @@ import {
   RTR_AT_TTL_FRACTION,
   RTR_ERROR_EVENT,
   RTR_FLS_TIMEOUT_EVENT,
+  RTR_TIME_MARGIN_IN_MS,
   RTR_FLS_WARNING_EVENT,
   RTR_RT_EXPIRY_IF_UNKNOWN,
 } from './constants';
@@ -142,7 +143,7 @@ export class FFetch {
       this.store.dispatch(setRtrFlsTimeout(setTimeout(() => {
         this.logger.log('rtr-fls', 'emitting RTR_FLS_TIMEOUT_EVENT');
         window.dispatchEvent(new Event(RTR_FLS_TIMEOUT_EVENT));
-      }, rtTimeoutInterval)));
+      }, rtTimeoutInterval - RTR_TIME_MARGIN_IN_MS))); // Calling /logout a small margin before cookie is deleted to ensure it is included in the request
     });
   };
 

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -11,6 +11,7 @@ import {
   RTR_AT_EXPIRY_IF_UNKNOWN,
   RTR_AT_TTL_FRACTION,
   RTR_FLS_WARNING_TTL,
+  RTR_TIME_MARGIN_IN_MS,
 } from './constants';
 
 jest.mock('../../loginServices', () => ({
@@ -206,7 +207,7 @@ describe('FFetch class', () => {
       expect(st).toHaveBeenCalledWith(expect.any(Function), (refreshTokenExpiration - whatTimeIsItMrFox) - ms(RTR_FLS_WARNING_TTL));
 
       // FLS timeout
-      expect(st).toHaveBeenCalledWith(expect.any(Function), (refreshTokenExpiration - whatTimeIsItMrFox));
+      expect(st).toHaveBeenCalledWith(expect.any(Function), (refreshTokenExpiration - whatTimeIsItMrFox - RTR_TIME_MARGIN_IN_MS));
     });
 
     it('handles RTR data in the session', async () => {
@@ -379,7 +380,7 @@ describe('FFetch class', () => {
       expect(st).toHaveBeenCalledWith(expect.any(Function), (refreshTokenExpiration - whatTimeIsItMrFox) - ms(RTR_FLS_WARNING_TTL));
 
       // FLS timeout
-      expect(st).toHaveBeenCalledWith(expect.any(Function), (refreshTokenExpiration - whatTimeIsItMrFox));
+      expect(st).toHaveBeenCalledWith(expect.any(Function), (refreshTokenExpiration - whatTimeIsItMrFox - RTR_TIME_MARGIN_IN_MS));
     });
   });
 

--- a/src/components/Root/constants.js
+++ b/src/components/Root/constants.js
@@ -87,3 +87,9 @@ export const RTR_IDLE_MODAL_TTL = '1m';
  */
 export const RTR_AT_EXPIRY_IF_UNKNOWN = '10s';
 export const RTR_RT_EXPIRY_IF_UNKNOWN = '10m';
+
+/**
+ * To account for minor delays between events (such as cookie expiration and API calls),
+ * this is a small amount of time to wait so the proper order can be ensured if they happen simultaneously.
+ */
+export const RTR_TIME_MARGIN_IN_MS = 200;


### PR DESCRIPTION
Add a small margin to the `/authn/logout` call to ensure it is called before the cookie expires.
    
See PR #1513
    
Refs [STCOR-880](https://folio-org.atlassian.net/browse/STCOR-880), [STCOR-869](https://folio-org.atlassian.net/browse/STCOR-869)