### PR TITLE
[STCOR-885] Clear saved entry path so that subsequent logins will use default base URL.

### DIFF
--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -36,7 +36,7 @@ const AuthnLogin = ({ stripes }) => {
      * @see OIDCRedirect
      */
     if (okapi.authnUrl && window.location.pathname !== '/') {
-      setUnauthorizedPathToSession(window.location.pathname + window.location.search);
+      setUnauthorizedPathToSession();
     }
 
     // If only 1 tenant is defined in config (in either okapi or config.tenantOptions) set to okapi to be accessed there

--- a/src/components/OIDCRedirect.js
+++ b/src/components/OIDCRedirect.js
@@ -1,7 +1,9 @@
 import { withRouter, Redirect, useLocation } from 'react-router';
 import queryString from 'query-string';
 import { useStripes } from '../StripesContext';
-import { getUnauthorizedPathFromSession } from '../loginServices';
+import { getUnauthorizedPathFromSession, removeUnauthorizedPathFromSession } from '../loginServices';
+
+const unauthorizedPath = getUnauthorizedPathFromSession();
 
 /**
  * OIDCRedirect authenticated route handler for /oidc-landing.
@@ -29,8 +31,10 @@ const OIDCRedirect = () => {
 
   const getUrl = () => {
     if (stripes.okapi.authnUrl) {
-      const unauthorizedPath = getUnauthorizedPathFromSession();
-      if (unauthorizedPath) return unauthorizedPath;
+      if (unauthorizedPath) {
+        removeUnauthorizedPathFromSession();
+        return unauthorizedPath;
+      }
     }
 
     const params = getParams();

--- a/src/components/OIDCRedirect.js
+++ b/src/components/OIDCRedirect.js
@@ -3,6 +3,8 @@ import queryString from 'query-string';
 import { useStripes } from '../StripesContext';
 import { getUnauthorizedPathFromSession, removeUnauthorizedPathFromSession } from '../loginServices';
 
+// Setting at top of component since value should be retained during re-renders
+// but will be correctly re-fetched when redirected from Keycloak login page.
 const unauthorizedPath = getUnauthorizedPathFromSession();
 
 /**

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -514,9 +514,6 @@ export async function logout(okapiUrl, store) {
       localStorage.removeItem(SESSION_NAME);
       localStorage.removeItem(RTR_TIMEOUT_EVENT);
 
-      // Clear saved entry path so that subsequent logins will use default base URL.
-      removeUnauthorizedPathFromSession();
-
       store.dispatch(setIsAuthenticated(false));
       store.dispatch(clearCurrentUser());
       store.dispatch(clearOkapiToken());

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -125,7 +125,7 @@ export const removeUnauthorizedPathFromSession = () => sessionStorage.removeItem
 export const setUnauthorizedPathToSession = (pathname) => {
   const path = pathname ?? `${window.location.pathname}${window.location.search}`;
   if (!path.startsWith('/logout')) {
-    sessionStorage.setItem(UNAUTHORIZED_PATH, pathname ?? `${window.location.pathname}${window.location.search}`);
+    sessionStorage.setItem(UNAUTHORIZED_PATH, path);
   }
 };
 export const getUnauthorizedPathFromSession = () => sessionStorage.getItem(UNAUTHORIZED_PATH);
@@ -513,6 +513,9 @@ export async function logout(okapiUrl, store) {
       // BroadcastChannel to communicate with all tabs/windows
       localStorage.removeItem(SESSION_NAME);
       localStorage.removeItem(RTR_TIMEOUT_EVENT);
+
+      // Clear saved entry path so that subsequent logins will use default base URL.
+      removeUnauthorizedPathFromSession();
 
       store.dispatch(setIsAuthenticated(false));
       store.dispatch(clearCurrentUser());


### PR DESCRIPTION
- Fixes [STCOR-885](https://folio-org.atlassian.net/browse/STCOR-885). 
- The issue was that if a user initially navigated to a routed URL such as `/users?search=test` after redirect on login, that route is opened on all consecutive logins. By clearing session storage on logout, subsequent logins go to the default `/` route as expected.
- Cleaned up some redundant code. `setUnauthorizedPathToSession()` was being called with same params as it defaults to. Also cleaned up duplicate code within `setUnauthorizedPathToSession()`