### PR TITLE
STCOR-890 useUserTenantPermissions hook - provide `isFetched` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * When re-authenticating after logout timeout, return to previous location. Refs STCOR-849.
 * Add `nl` (Dutch, Flemish) to the supported locales. Refs STCOR-878.
 * Include optional okapi interfaces, `consortia`, `roles`, `users-keycloak`. Refs STCOR-889.
+* useUserTenantPermissions hook - provide `isFetched` property. Refs STCOR-890.
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/hooks/useUserSelfTenantPermissions.js
+++ b/src/hooks/useUserSelfTenantPermissions.js
@@ -23,6 +23,7 @@ const useUserSelfTenantPermissions = (
 
   const {
     isFetching,
+    isFetched,
     isLoading,
     data,
   } = useQuery(
@@ -42,6 +43,7 @@ const useUserSelfTenantPermissions = (
 
   return ({
     isFetching,
+    isFetched,
     isLoading,
     userPermissions: data?.permissions.permissions || INITIAL_DATA,
     totalRecords: data?.permissions.permissions.length || 0,

--- a/src/hooks/useUserTenantPermissionNames.js
+++ b/src/hooks/useUserTenantPermissionNames.js
@@ -28,6 +28,7 @@ const useUserTenantPermissionNames = (
 
   const {
     isFetching,
+    isFetched,
     isLoading,
     data = {},
   } = useQuery(
@@ -50,6 +51,7 @@ const useUserTenantPermissionNames = (
 
   return ({
     isFetching,
+    isFetched,
     isLoading,
     userPermissions: data.permissionNames || INITIAL_DATA,
     totalRecords: data.totalRecords,

--- a/src/hooks/useUserTenantPermissions.js
+++ b/src/hooks/useUserTenantPermissions.js
@@ -10,6 +10,7 @@ const useUserTenantPermissions = (
 
   const {
     isFetching: isPermissionsFetching,
+    isFetched: isPermissionsFetched,
     isLoading: isPermissionsLoading,
     userPermissions: permissionsData = {},
     totalRecords: permissionsTotalRecords
@@ -17,18 +18,21 @@ const useUserTenantPermissions = (
 
   const {
     isFetching: isSelfPermissionsFetching,
+    isFetched: isSelfPermissionsFetched,
     isLoading: isSelfPermissionsLoading,
     userPermissions:selfPermissionsData = {},
     totalRecords: selfPermissionsTotalRecords
   } = useUserSelfTenantPermissions({ tenantId }, options);
 
   const isFetching = stripes.hasInterface('roles') ? isSelfPermissionsFetching : isPermissionsFetching;
+  const isFetched = stripes.hasInterface('roles') ? isSelfPermissionsFetched : isPermissionsFetched;
   const isLoading = stripes.hasInterface('roles') ? isSelfPermissionsLoading : isPermissionsLoading;
   const userPermissions = stripes.hasInterface('roles') ? selfPermissionsData : permissionsData;
   const totalRecords = stripes.hasInterface('roles') ? selfPermissionsTotalRecords : permissionsTotalRecords;
 
   return ({
     isFetching,
+    isFetched,
     isLoading,
     userPermissions,
     totalRecords

--- a/src/hooks/useUserTenantPermissions.test.js
+++ b/src/hooks/useUserTenantPermissions.test.js
@@ -23,6 +23,7 @@ describe('useUserTenantPermissions', () => {
 
     useUserSelfTenantPermissions.mockReturnValue({
       isFetching: true,
+      isFetched: true,
       isLoading: true,
       userPermissions: ['self'],
       totalRecords: 1
@@ -30,6 +31,7 @@ describe('useUserTenantPermissions', () => {
 
     useUserTenantPermissionNames.mockReturnValue({
       isFetching: false,
+      isFetched: false,
       isLoading: false,
       userPermissions: ['permission name'],
       totalRecords: 1
@@ -39,6 +41,7 @@ describe('useUserTenantPermissions', () => {
 
     expect(result.current).toStrictEqual({
       isFetching: true,
+      isFetched: true,
       isLoading: true,
       userPermissions: ['self'],
       totalRecords: 1
@@ -50,6 +53,7 @@ describe('useUserTenantPermissions', () => {
 
     useUserSelfTenantPermissions.mockReturnValue({
       isFetching: true,
+      isFetched: true,
       isLoading: true,
       userPermissions: ['self'],
       totalRecords: 1
@@ -57,6 +61,7 @@ describe('useUserTenantPermissions', () => {
 
     useUserTenantPermissionNames.mockReturnValue({
       isFetching: false,
+      isFetched: false,
       isLoading: false,
       userPermissions: ['permission name'],
       totalRecords: 1
@@ -66,6 +71,7 @@ describe('useUserTenantPermissions', () => {
 
     expect(result.current).toStrictEqual({
       isFetching: false,
+      isFetched: false,
       isLoading: false,
       userPermissions: ['permission name'],
       totalRecords: 1


### PR DESCRIPTION
## Description
Is some cases it could be useful to provide isFetched in addition to isFetching, for example to differentiate if permissions had been loaded in the past, regardless if they are loading now or not

## Issues
[STCOR-890](https://folio-org.atlassian.net/browse/STCOR-890)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2600