### PR TITLE
STCOR-893: Misleading "server is down"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Add `nl` (Dutch, Flemish) to the supported locales. Refs STCOR-878.
 * Include optional okapi interfaces, `consortia`, `roles`, `users-keycloak`. Refs STCOR-889.
 * useUserTenantPermissions hook - provide `isFetched` property. Refs STCOR-890.
+* Reword error message "Error: server is forbidden, unreachable or down. VPN issue?". Refs STCOR-893.
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -120,7 +120,7 @@ class Root extends Component {
     const { logger, store, epics, config, okapi, actionNames, token, isAuthenticated, disableAuth, currentUser, currentPerms, locale, defaultTranslations, timezone, currency, plugins, bindings, discovery, translations, history, serverDown } = this.props;
     if (serverDown) {
       // note: this isn't i18n'ed because we haven't rendered an IntlProvider yet.
-      return <div>Error: server is down.</div>;
+      return <div>Error: server is forbidden, unreachable or down. VPN issue?</div>;
     }
 
     if (!translations) {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STCOR-893

Reword misleading error message.