### PR TITLE
STCOR-895 wait a loooong time for a "stale" rotation request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 10.1.2 IN PROGRESS
+
+* Wait longer before declaring a rotation request to be stale. Refs STCOR-895.
+
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)
 

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -50,7 +50,7 @@ export const RTR_IS_ROTATING = '@folio/stripes/core::rtrIsRotating';
  *
  * Time in milliseconds
  */
-export const RTR_MAX_AGE = 2000;
+export const RTR_MAX_AGE = 20000;
 
 /**
  * resourceMapper

--- a/src/components/Root/token-util.test.js
+++ b/src/components/Root/token-util.test.js
@@ -188,7 +188,7 @@ describe('rtr', () => {
 
       expect(ex).toBe(null);
       // expect(window.removeEventListener).toHaveBeenCalled();
-    });
+    }, 25000);
 
     it('multiple window (storage event)', async () => {
       const context = {
@@ -224,7 +224,7 @@ describe('rtr', () => {
 
       expect(ex).toBe(null);
       // expect(window.removeEventListener).toHaveBeenCalledWith('monkey')
-    });
+    }, 25000);
   });
 
 


### PR DESCRIPTION
As part of the RTR lifecycle, we write a rotation timestamp to local storage when the process starts and then remove it when it ends. This is a cheap way of making the rotation request visible across tabs, because all tabs read the same shared storage.

To avoid the problem of a cancelled request leaving cruft in storage, we inspect that timestamp and consider a request "stale" if it's too old. That was the problem here: our "too old" timeout was too short; on a busy server, or on a slow connection, or on a client far from its host (say, in New Zealand), two seconds was not long enough. The rotation request would still be active when stripes considered it "stale", allowing a second request to go through. But since the first request was just slow, not dead, the second one is treated as a token-replay attack by the backend, causing all active sessions for that user account to be immediately terminated.

Thus, waiting longer is a quick fix. A more detailed approach to tracking the request is detailed in the code-comments attached to #1547.

Refs [STCOR-895](https://folio-org.atlassian.net/browse/STCOR-895)