### PR TITLE
STCOR-900: (ECS) Automatically logged into Central tenant after logging out from Member tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Move session timeout banner to the bottom of the page. Refs STCOR-883.
 * Conditionally use `/users-keycloak/_self` endpoint when `users-keycloak` interface is present. Refs STCOR-835.
 * Wait longer before declaring a rotation request to be stale. Refs STCOR-895.
+* Send the stored central tenant name in the header on logout. Refs STCOR-900.
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import css from './components/SessionEventContainer/style.css';
 
 import Root from './components/Root';
 import { eventsPortal } from './constants';
+import { getStoredTenant } from './loginServices';
 
 const StrictWrapper = ({ children }) => {
   if (config.disableStrictMode) {
@@ -35,8 +36,7 @@ export default class StripesCore extends Component {
   constructor(props) {
     super(props);
 
-    const storedTenant = localStorage.getItem('tenant');
-    const parsedTenant = storedTenant ? JSON.parse(storedTenant) : undefined;
+    const parsedTenant = getStoredTenant();
 
     const okapi = (typeof okapiConfig === 'object' && Object.keys(okapiConfig).length > 0)
       ? { ...okapiConfig, tenant: parsedTenant?.tenantName || okapiConfig.tenant, clientId: parsedTenant?.clientId || okapiConfig.clientId } : { withoutOkapi: true };

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -131,6 +131,12 @@ export const setUnauthorizedPathToSession = (pathname) => {
 };
 export const getUnauthorizedPathFromSession = () => sessionStorage.getItem(UNAUTHORIZED_PATH);
 
+const TENANT_LOCAL_STORAGE_KEY = 'tenant';
+export const getStoredTenant = () => {
+  const storedTenant = localStorage.getItem(TENANT_LOCAL_STORAGE_KEY);
+  return storedTenant ? JSON.parse(storedTenant) : undefined;
+};
+
 // export config values for storing user locale
 export const userLocaleConfig = {
   'configName': 'localeSettings',
@@ -500,7 +506,7 @@ export async function logout(okapiUrl, store, queryClient) {
       method: 'POST',
       mode: 'cors',
       credentials: 'include',
-      headers: getHeaders(store.getState()?.okapi?.tenant),
+      headers: getHeaders(getStoredTenant()?.tenantName || store.getState()?.okapi?.tenant),
     })
     :
     Promise.resolve();

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -506,6 +506,10 @@ export async function logout(okapiUrl, store, queryClient) {
       method: 'POST',
       mode: 'cors',
       credentials: 'include',
+      /* Since the tenant in the x-okapi-token and the x-okapi-tenant header on logout should match,
+      switching affiliations updates store.okapi.tenant, leading to mismatched tenant names from the token.
+      Use the tenant name stored during login to ensure they match.
+        */
       headers: getHeaders(getStoredTenant()?.tenantName || store.getState()?.okapi?.tenant),
     })
     :

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -23,7 +23,7 @@ import {
   updateUser,
   validateUser,
   IS_LOGGING_OUT,
-  SESSION_NAME
+  SESSION_NAME, getStoredTenant
 } from './loginServices';
 
 import {
@@ -683,6 +683,19 @@ describe('unauthorizedPath functions', () => {
       const value = 'monkey';
       setUnauthorizedPathToSession(value);
       expect(getUnauthorizedPathFromSession()).toBe(value);
+    });
+  });
+
+  describe('getStoredTenant', () => {
+    afterEach(() => {
+      localStorage.clear();
+    });
+    it('retrieves the value from localstorage', () => {
+      const value = { tenantName: 'diku', clientId: 'diku-id' };
+      localStorage.setItem('tenant', JSON.stringify(value));
+      const parsedTenant = getStoredTenant();
+
+      expect(parsedTenant).toStrictEqual(value);
     });
   });
 });


### PR DESCRIPTION
## Purpose
[STCOR-900](https://folio-org.atlassian.net/browse/STCOR-900)  - (ECS) Automatically logged into Central tenant after logging out from Member tenant.

## Approach 
On login, we store tenant data in localStorage and use it as the initial state of the Redux store for okapi.tenant. When the affiliation changes, okapi.tenant updates, but the tenant in localStorage does not. As a result, the updated okapi.tenant is sent on logout. Since the tenant in the x-okapi-token and the x-okapi-tenant header on logout should match, use the tenant data stored in localStorage for the x-okapi-tenant header.

## Refs
https://folio-org.atlassian.net/browse/STCOR-900