### PR TITLE
STCOR-902 show error message on OIDC fetch failure

### DIFF
--- a/src/components/OIDCLanding.test.js
+++ b/src/components/OIDCLanding.test.js
@@ -20,8 +20,7 @@ jest.mock('../StripesContext', () => ({
   }),
 }));
 
-// jest.mock('../loginServices');
-
+jest.mock('./OrganizationLogo', () => (() => <div>OrganizationLogo</div>));
 
 const mockSetTokenExpiry = jest.fn();
 const mockRequestUserWithPerms = jest.fn();
@@ -79,7 +78,7 @@ describe('OIDCLanding', () => {
     mockFetchError('barf');
 
     await render(<OIDCLanding />);
-    await screen.findByText('errors.saml.missingToken');
+    await screen.findByText('stripes-core.errors.oidc');
     mockFetchCleanUp();
   });
 });

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -147,6 +147,7 @@
   "errors.password.consecutiveWhitespaces.invalid": "The password must not contain consecutive white space characters.",
   "errors.password.compromised.invalid": "The password must not be commonly-used, expected or compromised",
   "errors.saml.missingToken": "No <code>code</code> query parameter.",
+  "errors.oidc": "Error: server is forbidden, unreachable, or unavailable.",
 
   "createResetPassword.header": "Choose a password",
   "createResetPassword.newPassword": "New Password",

--- a/translations/stripes-core/en_US.json
+++ b/translations/stripes-core/en_US.json
@@ -159,5 +159,7 @@
     "tenantLibrary": "Tenant/Library",
     "errors.saml.missingToken": "No <code>code</code> query parameter.",
     "rtr.fixedLengthSession.timeRemaining": "Your session will end soon! Time remaining:",
-    "logoutComplete": "You have logged out."
+    "logoutComplete": "You have logged out.",
+    "errors.oidc": "Error: server is forbidden, unreachable, or unavailable."
+
 }


### PR DESCRIPTION
When returning from a SAML/OIDC request, stripes makes an API request to exchange the token for cookies. If that API request fails, show an error and a button prompting the user to try authenticating again.

Previously, instead of showing a button, stripes would automatically redirect to `/`, which (because there were no cookies) would redirect to the authentication URL, which (because there _were_ still valid authentication cookies) would redirect to stripes, starting an endless circle.

Refs [STCOR-902](https://folio-org.atlassian.net/browse/STCOR-902)