### PR TITLE
STCOR-882 return to previous location on logout-timeout

### DIFF
--- a/src/components/Logout/Logout.js
+++ b/src/components/Logout/Logout.js
@@ -13,7 +13,11 @@ import {
 
 import OrganizationLogo from '../OrganizationLogo';
 import { useStripes } from '../../StripesContext';
-import { logout } from '../../loginServices';
+import {
+  getUnauthorizedPathFromSession,
+  logout,
+  removeUnauthorizedPathFromSession,
+} from '../../loginServices';
 
 import styles from './Logout.css';
 
@@ -51,6 +55,12 @@ const Logout = () => {
     []
   );
 
+  const handleClick = (_e) => {
+    removeUnauthorizedPathFromSession();
+  };
+
+  const redirectTo = getUnauthorizedPathFromSession() || '/';
+
   if (!didLogout) {
     return <LoadingView />;
   }
@@ -71,7 +81,7 @@ const Logout = () => {
           </Row>
           <Row center="xs">
             <Col xs={12}>
-              <Button to="/"><FormattedMessage id="stripes-core.rtr.idleSession.logInAgain" /></Button>
+              <Button to={redirectTo} onClick={handleClick}><FormattedMessage id="stripes-core.rtr.idleSession.logInAgain" /></Button>
             </Col>
           </Row>
         </div>

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -14,13 +14,24 @@ jest.mock('@folio/stripes-components', () => ({
       <span>{props.children}</span>
     </span>
   )),
-  Button: jest.fn(({ children, onClick = jest.fn() }) => (
-    <button data-test-button type="button" onClick={onClick}>
-      <span>
-        {children}
-      </span>
-    </button>
-  )),
+  Button: jest.fn(({ children, to, onClick = jest.fn() }) => {
+    if (to) {
+      return (
+        <a href={to} role="button" data-test-button onClick={onClick}>
+          <span>
+            {children}
+          </span>
+        </a>
+      );
+    }
+    return (
+      <button data-test-button type="button" onClick={onClick}>
+        <span>
+          {children}
+        </span>
+      </button>
+    );
+  }),
   Callout: jest.fn(({ children, ...rest }) => (
     <span {...rest}>{children}</span>
   )),


### PR DESCRIPTION
PR #1551 introduced a regression to the functionality added in STCOR-849/PR #1523. The correct behavior is for the logout button on the timeout page to point to the previous location, but after #1551 the button always pointed to `/`.

Refs [STCOR-882](https://folio-org.atlassian.net/browse/STCOR-882), [STCOR-849](https://folio-org.atlassian.net/browse/STCOR-849)