### PR TITLE
STCOR-907 cautiously evaluate localforage data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 10.1.3 IN PROGRESS
+
+* Cautiously evaluate localforage data when restoring a session. Refs STCOR-907.
+
 ## [10.1.2](https://github.com/folio-org/stripes-core/tree/v10.1.2) (2024-10-21)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.1.2)
 

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -81,7 +81,11 @@ class Root extends Component {
 
   componentDidMount() {
     const { okapi, store, locale, defaultTranslations } = this.props;
-    if (this.withOkapi) checkOkapiSession(okapi.url, store, okapi.tenant);
+    if (this.withOkapi) {
+      // checkOkapiSession is async and will cause a re-render after a delay
+      // when an API call's .then() handler updates the store.
+      checkOkapiSession(okapi.url, store, okapi.tenant);
+    }
     // TODO: remove this after we load locale and translations at start from a public endpoint
     loadTranslations(store, locale, defaultTranslations);
   }

--- a/src/components/Root/token-util.test.js
+++ b/src/components/Root/token-util.test.js
@@ -1,3 +1,5 @@
+import localforage from 'localforage';
+
 import { RTRError, UnexpectedResourceError } from './Errors';
 import {
   isFolioApiRequest,
@@ -11,6 +13,16 @@ import {
   RTR_MAX_AGE,
 } from './token-util';
 import { RTR_SUCCESS_EVENT } from './Events';
+
+jest.mock('localforage', () => ({
+  getItem: jest.fn(() => Promise.resolve({
+    user: { id: 'robert' },
+    tenant: 'manhattan',
+    isAuthenticated: 'i am',
+  })),
+  setItem: jest.fn((k, v) => Promise.resolve(v)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
 
 describe('isFolioApiRequest', () => {
   it('accepts requests whose origin matches okapi\'s', () => {


### PR DESCRIPTION
Be thorough when evaluating data from localforage to determine whether a session exists by checking for `user.id`, `tenant`, and `isAuthenticated` values rather than accepting the existence of a (possibly empty, or mostly empty) object as proof of life. Without these more thorough checks, a sparsely-populated value may be passed to `validateUser()`, causing it to throw when evaluating `user.id`, and misleadingly dispatching a server-down message.

It is likely that a rogue RTR process is responsible for writing this garbled/sparse session data. We need to research that and resolve that problem too, but at least we have a handle on this from the other end.

Refs [STCOR-907](https://folio-org.atlassian.net/browse/STCOR-907)