### PR TITLE
STCOR-913 Don't override initial discovery and okapi data in test mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * Send the stored central tenant name in the header on logout. Refs STCOR-900.
 * Provide `<IfAnyPermission>` and `stripes.hasAnyPermission()`. Refs STCOR-910.
 * Use the `users-keycloak/_self` endpoint conditionally when the `users-keycloak` interface is present; otherwise, use `bl-users/_self` within `useUserTenantPermissions`. Refs STCOR-905.
-* Don't override initial discovery and okapi data in test mocks. Disable StrictMode in tests. Refs TBD.
-
+* Don't override initial discovery and okapi data in test mocks. Refs STCOR-913.
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Send the stored central tenant name in the header on logout. Refs STCOR-900.
 * Provide `<IfAnyPermission>` and `stripes.hasAnyPermission()`. Refs STCOR-910.
 * Use the `users-keycloak/_self` endpoint conditionally when the `users-keycloak` interface is present; otherwise, use `bl-users/_self` within `useUserTenantPermissions`. Refs STCOR-905.
+* Don't override initial discovery and okapi data in test mocks. Disable StrictMode in tests. Refs TBD.
 
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)

--- a/src/App.js
+++ b/src/App.js
@@ -16,12 +16,6 @@ import { eventsPortal } from './constants';
 import { getStoredTenant } from './loginServices';
 
 const StrictWrapper = ({ children }) => {
-  /*
-    WIP. THIS IS JUST HARDCODED FOR INVESTIGATION PURPOSES
-    Need to be able to pass `disableStrictMode` flag to karma tests
-  */
-  return children;
-
   if (config.disableStrictMode) {
     return children;
   }

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,12 @@ import { eventsPortal } from './constants';
 import { getStoredTenant } from './loginServices';
 
 const StrictWrapper = ({ children }) => {
+  /*
+    WIP. THIS IS JUST HARDCODED FOR INVESTIGATION PURPOSES
+    Need to be able to pass `disableStrictMode` flag to karma tests
+  */
+  return children;
+
   if (config.disableStrictMode) {
     return children;
   }

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -42,6 +42,7 @@ export default function setupApplication({
     // when auth is disabled, add a fake user to the store
     if (disableAuth) {
       initialState.okapi = {
+        ...initialState.okapi,
         currentUser: assign({
           id: 'test',
           username: 'testuser',
@@ -55,10 +56,12 @@ export default function setupApplication({
         isAuthenticated: true,
       };
       initialState.discovery = {
+        ...initialState.discovery,
         isFinished: true,
       };
     } else {
       initialState.okapi = {
+        ...initialState.okapi,
         ssoEnabled: true,
       };
     }


### PR DESCRIPTION
## Description
Updating `stripes-core` in SSC causes 30+ tests to fail. https://github.com/folio-org/stripes-smart-components/pull/1538
This PR addresses some issues which cause these failures.

1. StrictMode. Using StrictMode makes components render twice to check for mutation, which makes some components receive test data twice, render twice etc. **For now the fix is only hardcoded. Need to be able to pass `disableStrictMode` flag to karma tests**
2. Overwriting of initial okapi and discovery data in `setupApplication` helper. Some tests require custom okapi data, but `setupApplication` in some cases can overwrite that data which makes those tests fail.
3. ? Still investigating a few failing tests so maybe there's something else that needs to be fixed.

