### PR TITLE
STCOR-913 do not overwrite initialState in BTOG setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Send the stored central tenant name in the header on logout. Refs STCOR-900.
 * Provide `<IfAnyPermission>` and `stripes.hasAnyPermission()`. Refs STCOR-910.
 * Use the `users-keycloak/_self` endpoint conditionally when the `users-keycloak` interface is present; otherwise, use `bl-users/_self` within `useUserTenantPermissions`. Refs STCOR-905.
-
+* Do not overwrite `initialData` in BTOG setup. Refs STCOR-913.
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.2.0)

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -42,6 +42,7 @@ export default function setupApplication({
     // when auth is disabled, add a fake user to the store
     if (disableAuth) {
       initialState.okapi = {
+        ...initialState.okapi,
         currentUser: assign({
           id: 'test',
           username: 'testuser',
@@ -55,10 +56,12 @@ export default function setupApplication({
         isAuthenticated: true,
       };
       initialState.discovery = {
+        ...initialState.discovery,
         isFinished: true,
       };
     } else {
       initialState.okapi = {
+        ...initialState.okapi,
         ssoEnabled: true,
       };
     }


### PR DESCRIPTION
Test setup must honor the values it accepts in the `initialState` argument. It can augment them, but must not ignore them.

Refs [STCOR-913](https://folio-org.atlassian.net/browse/STCOR-913)