### PR TITLE
STCOR-912 spread session, _self data when resuming session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Provide `<IfAnyPermission>` and `stripes.hasAnyPermission()`. Refs STCOR-910.
 * Use the `users-keycloak/_self` endpoint conditionally when the `users-keycloak` interface is present; otherwise, use `bl-users/_self` within `useUserTenantPermissions`. Refs STCOR-905.
 * Don't override initial discovery and okapi data in test mocks. Refs STCOR-913.
+* On resuming session, spread session and `_self` together to preserve session values. Refs STCOR-912.
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.2.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -807,7 +807,10 @@ export function validateUser(okapiUrl, store, tenant, session) {
         // data isn't provided by _self.
         store.dispatch(setSessionData({
           isAuthenticated: true,
-          user,
+          // spread data from the previous session (which may include session-specific
+          // values such as the current service point), and the restructured user object
+          // (which includes permissions in a lookup-friendly way)
+          user: { ...session.user, ...user },
           perms,
           tenant: sessionTenant,
           token,

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -350,7 +350,11 @@ describe('validateUser', () => {
     };
 
     const session = {
-      user: { id: 'id', username: 'username' },
+      user: {
+        id: 'id',
+        username: 'username',
+        storageOnlyValue: 'is still persisted',
+      },
       perms: { foo: true },
       tenant: sessionTenant,
       token: 'token',
@@ -361,7 +365,7 @@ describe('validateUser', () => {
     await validateUser('url', store, tenant, session);
 
     const updatedSession = {
-      user: data.user,
+      user: { ...session.user, ...data.user },
       isAuthenticated: true,
       perms: { ask: true, tell: true },
       tenant: session.tenant,


### PR DESCRIPTION
Spread together existing session data with the response data from the `_self` endpoint. The latter may contain updated information such as new permissions, but it may also be sparsely populated, e.g. if the user has not selected a default service point but the active service point has been saved to the session.

We take the union of the data, with the `_self` data overwriting matching values. Think of it like a bitwise-or.

Refs [STCOR-912](https://folio-org.atlassian.net/browse/STCOR-912)