### PR TITLE
STCOR-930 correctly dispatch rtrFlsWarningTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Do not store /logout as a "return-to" URL. Refs STCOR-869.
 * Add small margin to ensure /authn/logout is called before cookie expires. Refs STCOR-869.
 * Wait longer before declaring a rotation request to be stale. Refs STCOR-895.
+* Correctly send `rtrFlsWarningTimeout` when dispatching `setRtrFlsWarningTimeout()`. Refs STCOR-930.
 
 ## [10.1.1](https://github.com/folio-org/stripes-core/tree/v10.1.1) (2024-03-25)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.0...v10.1.1)

--- a/src/okapiActions.js
+++ b/src/okapiActions.js
@@ -164,10 +164,10 @@ function clearRtrTimeout() {
   };
 }
 
-function setRtrFlsWarningTimeout(rtrFlsTimeout) {
+function setRtrFlsWarningTimeout(rtrFlsWarningTimeout) {
   return {
     type: OKAPI_REDUCER_ACTIONS.SET_RTR_FLS_WARNING_TIMEOUT,
-    rtrFlsTimeout,
+    rtrFlsWarningTimeout,
   };
 }
 


### PR DESCRIPTION
`setRtrFlsWarningTimeout()` now sends `rtrFlsWarningTimeout` rather than `rtrFlsTimeout`. This bug was introduced in PR #1511 (onto `keycloak-quesnelia`), which looks like a bad copy-pasta from PR #1510 (onto `keycloak-ramsons`). 

When RTR is correctly configured such that sessions end at a fixed (static) datestamp, this change will have no effect: the original timer will not be canceled when the tokens rotate, but it won't matter because the end-point isn't moving, meaning the original timer will remain accurate.

When RTR is incorrectly configured, however, and a session's end-point is extended on rotation as in a sliding window, this change resolves a bug that would cause the session-timeout banner to display a "Time remaining: 00:00" message without actually ending the session. This occurred because the original timer would not be canceled when the tokens rotated even though a new, later end-point had been established.

Refs [STCOR-930](https://folio-org.atlassian.net/browse/STCOR-930)