### PR TITLE
STCOR-933 fetch /saml/check when starting a new session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Don't override initial discovery and okapi data in test mocks. Refs STCOR-913.
 * `<Logout>` must consume `QueryClient` in order to supply it to `loginServices::logout()`. Refs STCOR-907.
 * On resuming session, spread session and `_self` together to preserve session values. Refs STCOR-912.
+* Fetch `/saml/check` when starting a new session, i.e. before discovery. Refs STCOR-933, STCOR-816.
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.2.0)

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -851,8 +851,11 @@ export function checkOkapiSession(okapiUrl, store, tenant) {
     .then((sess) => {
       return sess?.user?.id ? validateUser(okapiUrl, store, tenant, sess) : null;
     })
-    .then(() => {
-      if (store.getState().discovery?.interfaces?.['login-saml']) {
+    .then((res) => {
+      // check whether SSO is enabled if either
+      // 1. res is null (when we are starting a new session)
+      // 2. login-saml interface is present (when we are resuming an existing session)
+      if (!res || store.getState().discovery?.interfaces?.['login-saml']) {
         return getSSOEnabled(okapiUrl, store, tenant);
       }
       return Promise.resolve();


### PR DESCRIPTION
This is a follow-up to the botched implementation of [STCOR-816](https://folio-org.atlassian.net/browse/STCOR-816) in PR #1432. The description there is "When restoring an existing session..." but in fact the implementation is "When starting a new session or restoring an existing one...". When starting a new session, however, discovery has not happened yet, so there is no information about what interfaces are present, and the conditional would always return false.

The implementation here corrects the conditional:
1. if we are starting a new session
2. if we are resuming an existing session and the `login-saml` interface is present.

Refs [STCOR-933](https://folio-org.atlassian.net/browse/STCOR-933)