### PR TITLE
STCOR-931: Change Help icon aria label to just Help in MainNav component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove remaining references to stripes.isEureka. Refs STCOR-938.
 * *BREAKING* Upgrade `@folio/stripes-*` dependencies.
 * *BREAKING* Upgrade `react-intl` to `^v7`. Refs STCOR-945.
+* Change Help icon aria label to just Help in MainNav component. Refs STCOR-931.
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.2.0)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -196,7 +196,7 @@ class MainNav extends Component {
                 />
                 <NavDivider md="hide" />
                 <NavButton
-                  aria-label="Help"
+                  aria-label={intl.formatMessage({ id: 'stripes-core.help' })}
                   data-test-item-help-button
                   href={helpUrl}
                   icon={<Icon

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -196,7 +196,7 @@ class MainNav extends Component {
                 />
                 <NavDivider md="hide" />
                 <NavButton
-                  aria-label="Help button"
+                  aria-label="Help"
                   data-test-item-help-button
                   href={helpUrl}
                   icon={<Icon

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -105,6 +105,7 @@
   "settingChoose": "Choose settings",
   "tenantChoose": "Select your tenant/library",
   "tenantLibrary": "Tenant/Library",
+  "help": "Help",
 
   "mainnav.showAllApplicationsButtonLabel": "Apps",
   "mainnav.showAllApplicationsButtonAriaLabel": "All applications",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STCOR-931

Here we changed the `aria-label` in `MainNav` component from "Help button" to "Help" regarding screen-reader recommendations.