### PR TITLE
STCOR-949 omit leading slash in useModuleInfo's ky path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Change Help icon aria label to just Help in MainNav component. Refs STCOR-931.
 * *BREAKING* remove token-based authentication code. Refs STCOR-918.
 * *BREAKING* replace useSecureTokens conditionalsRefs STCOR-922.
+* Omit leading slash in paths passed to `ky` in `useModuleInfo`. Refs STCOR-949.
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.2.0)

--- a/src/hooks/useModuleInfo.js
+++ b/src/hooks/useModuleInfo.js
@@ -87,7 +87,7 @@ const useModuleInfo = (path) => {
     [namespace],
     ({ signal }) => {
       return ky.get(
-        `/_/proxy/tenants/${stripes.okapi.tenant}/modules?full=true`,
+        `_/proxy/tenants/${stripes.okapi.tenant}/modules?full=true`,
         { signal },
       ).json();
     }


### PR DESCRIPTION
Whoops, `ky` doesn't want a leading slash when using the `prefixUrl` property and whines about it in the console.

Refs [STCOR-949](https://folio-org.atlassian.net/browse/STCOR-949)