### PR TITLE
STCOR-950 Added `location` to a hook in `<MainNav>` to fix comparing old `location` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Change Help icon aria label to just Help in MainNav component. Refs STCOR-931.
 * *BREAKING* remove token-based authentication code. Refs STCOR-918.
 * *BREAKING* replace useSecureTokens conditionalsRefs STCOR-922.
+* Added `location` to a hook in `<MainNav>` to fix comparing old `location` value. Fixes STCOR-950.
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.2.0)

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -69,7 +69,7 @@ const MainNav = () => {
     return () => {
       _unsubscribe();
     };
-  }, []); // eslint-disable-line
+  }, [location]); // eslint-disable-line
 
   // if the location changes, we need to update the current module/query resource.
   // This logic changes the visible current app at the starting side of the Main Navigation.


### PR DESCRIPTION
## Description
After the switch to hooks, in [stripes-core/src/components/MainNav/MainNav.js at 3570eea0bca50bb0abb0cc0e52db3ae4bc3a792e · folio-org/stripes-core](https://github.com/folio-org/stripes-core/blob/3570eea0bca50bb0abb0cc0e52db3ae4bc3a792e/src/components/MainNav/MainNav.js#L46)  `location` object is not updated, and so `store.subscribe` callback always uses an old value.

When `updateLocation` compares `cleanStateQuery` and `cleanLocationQuery` objects, they are always different because we’re comparing to an old `location`

This caused a bug in Inventory, where when a user opens a shared record - the page reloads and user is taken back to search results. This happens because when a user opens a shared record we append `shared=true` to the url. And because `<MainNav>` doesn't compare to a current url the flow gets interrupted.

If we add location to the hook’s deps it works as expected.

## Screenshots

https://github.com/user-attachments/assets/0973c2ab-c915-4d99-b062-b62c07eb9308


## Issues
[STCOR-950](https://folio-org.atlassian.net/browse/STCOR-950)