### PR TITLE
STCOR-942: get okapi url from the store, not directly from config in LoginCtrl.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Set tenant context based on authentication response with overrideUser parameter on login (Eureka, ECS - Single tenant UX) STCOR-946.
 * Omit leading slash in paths passed to `ky` in `useModuleInfo`. Refs STCOR-949.
 * Added `location` to a hook in `<MainNav>` to fix comparing old `location` value. Fixes STCOR-950.
+* Use `okapiUrl` from the store in `<LoginCtrl>` instead of reading it from `stripes-config` file. Refs STCOR-942.
 
 ## [10.2.0](https://github.com/folio-org/stripes-core/tree/v10.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.1.1...v10.2.0)

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -18,6 +18,7 @@ class LoginCtrl extends Component {
   static propTypes = {
     authFailure: PropTypes.arrayOf(PropTypes.object),
     ssoEnabled: PropTypes.bool,
+    okapiUrl: PropTypes.string.isRequired,
     autoLogin: PropTypes.shape({
       username: PropTypes.string.isRequired,
       password: PropTypes.string.isRequired,
@@ -36,7 +37,6 @@ class LoginCtrl extends Component {
   constructor(props) {
     super(props);
     this.sys = require('stripes-config'); // eslint-disable-line global-require
-    this.okapiUrl = this.sys.okapi.url;
     this.tenant = this.sys.okapi.tenant;
     if (props.autoLogin && props.autoLogin.username) {
       this.handleSubmit(props.autoLogin);
@@ -54,7 +54,7 @@ class LoginCtrl extends Component {
   }
 
   handleSubmit = (data) => {
-    return requestLogin(this.okapiUrl, this.context.store, this.tenant, data)
+    return requestLogin(this.props.okapiUrl, this.context.store, this.tenant, data)
       .then(this.handleSuccessfulLogin)
       .catch(e => {
         console.error(e); // eslint-disable-line no-console
@@ -62,7 +62,7 @@ class LoginCtrl extends Component {
   }
 
   handleSSOLogin = () => {
-    requestSSOLogin(this.okapiUrl, this.tenant);
+    requestSSOLogin(this.props.okapiUrl, this.tenant);
   }
 
   render() {
@@ -82,6 +82,7 @@ class LoginCtrl extends Component {
 const mapStateToProps = state => ({
   authFailure: state.okapi.authFailure,
   ssoEnabled: state.okapi.ssoEnabled,
+  okapiUrl: state.okapi.url,
 });
 const mapDispatchToProps = dispatch => ({
   clearAuthErrors: () => dispatch(setAuthError([])),


### PR DESCRIPTION
Refs [STCOR-942](https://folio-org.atlassian.net/browse/STCOR-942). 
Previously, changes were partially reverted because the tenant was stored in localStorage after login, and that tenant was then set in the stripes store. The okapi.url is set in the store—not from localStorage or other external sources—but from stripes-config, making it safe to use from the store.
I would like to leave the rest of the functionality as it is for now, but we definitely need to refine our login handling strategies for the cases listed below.
1. single tenant;
2. multi-tenant with multi-select option;
3. multi-tenant, ECS - [Single tenant UX](https://folio-org.atlassian.net/browse/STCOR-946).
