### PR TITLE
STCOR-952 break QueryStateUpdates out to their own class-based component.

### DIFF
--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -36,6 +36,7 @@ import {
   AppCtxMenuProvider,
   SessionEventContainer,
   AppOrderProvider,
+  QueryStateUpdater
 } from './components';
 import StaleBundleWarning from './components/StaleBundleWarning';
 import { StripesContext } from './StripesContext';
@@ -64,6 +65,7 @@ const RootWithIntl = ({ stripes, token = '', isAuthenticated = false, disableAut
                 <Router history={history}>
                   { isAuthenticated || token || disableAuth ?
                     <>
+                      <QueryStateUpdater stripes={connectedStripes} queryClient={queryClient} />
                       <MainContainer>
                         <AppCtxMenuProvider>
                           <AppOrderProvider>

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -1,19 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { isEqual } from 'lodash';
 import { useIntl } from 'react-intl';
-import { useLocation, useHistory } from 'react-router-dom';
-import { useQueryClient } from 'react-query';
 
 import { branding } from 'stripes-config';
 import { Icon } from '@folio/stripes-components';
-import {
-  updateQueryResource,
-  getLocationQuery,
-  updateLocation,
-  getCurrentModule,
-  isQueryResourceModule,
-  getQueryResourceState,
-} from '../../locationService';
 
 import css from './MainNav.css';
 import NavButton from './NavButton';
@@ -22,65 +11,23 @@ import { CurrentAppGroup } from './CurrentApp';
 import ProfileDropdown from './ProfileDropdown';
 import AppList from './AppList';
 import { SkipLink } from './components';
-
 import { useAppOrderContext } from './AppOrderProvider';
-
 import { useStripes } from '../../StripesContext';
-import { useModules } from '../../ModulesContext';
 
 const MainNav = () => {
   const {
     apps,
   } = useAppOrderContext();
-  const queryClient = useQueryClient();
   const stripes = useStripes();
-  const location = useLocation();
-  const modules = useModules();
-  const history = useHistory();
   const intl = useIntl();
 
-  const [curModule, setCurModule] = useState(getCurrentModule(modules, location));
   const [selectedApp, setSelectedApp] = useState(apps.find(entry => entry.active));
   const helpUrl = useRef(stripes.config.helpUrl ?? 'https://docs.folio.org').current;
 
-  useEffect(() => {
-    let curQuery = getLocationQuery(location);
-    const prevQueryState = {};
-
-    const { store } = stripes;
-    const _unsubscribe = store.subscribe(() => {
-      const module = curModule;
-
-      if (module && isQueryResourceModule(module, location)) {
-        const { moduleName } = module;
-        const queryState = getQueryResourceState(module, stripes.store);
-
-        // only update location if query state has changed
-        if (!isEqual(queryState, prevQueryState[moduleName])) {
-          curQuery = updateLocation(module, curQuery, stripes.store, history, location);
-          prevQueryState[moduleName] = queryState;
-        }
-      }
-    });
-
-    // remove QueryProvider cache to be 100% sure we're starting from a clean slate.
-    queryClient.removeQueries();
-
-    return () => {
-      _unsubscribe();
-    };
-  }, [location]); // eslint-disable-line
-
-  // if the location changes, we need to update the current module/query resource.
   // This logic changes the visible current app at the starting side of the Main Navigation.
   useEffect(() => {
     setSelectedApp(apps.find(entry => entry.active));
-    const nextCurModule = getCurrentModule(modules, location);
-    if (nextCurModule) {
-      setCurModule(getCurrentModule(modules, location));
-      updateQueryResource(location, nextCurModule, stripes.store);
-    }
-  }, [modules, location, stripes.store, apps]);
+  }, [apps]);
 
   return (
     <header className={css.navRoot} style={branding?.style?.mainNav ?? {}}>

--- a/src/components/MainNav/QueryStateUpdater.js
+++ b/src/components/MainNav/QueryStateUpdater.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'redux';
+import { injectIntl } from 'react-intl';
+import { withRouter } from 'react-router';
+import { isEqual } from 'lodash';
+
+import { withModules } from '../Modules';
+
+import {
+  updateQueryResource,
+  getLocationQuery,
+  updateLocation,
+  getCurrentModule,
+  isQueryResourceModule,
+  getQueryResourceState,
+} from '../../locationService';
+
+// onMount of stripes, sync the query state to the location.
+class QueryStateUpdater extends React.Component {
+  static PropTypes = {
+    queryClient: PropTypes.shape({
+      removeQueries: PropTypes.func.isRequired,
+    }).isRequired,
+    stripes: PropTypes.shape({
+      store: PropTypes.shape({
+        subscribe: PropTypes.func.isRequired,
+      }),
+    }),
+  }
+
+  constructor(props) {
+    super(props);
+    this.store = props.stripes.store;
+  }
+
+  componentDidMount() {
+    let curQuery = getLocationQuery(this.props.location);
+    const prevQueryState = {};
+
+    this._unsubscribe = this.store.subscribe(() => {
+      const { history, location } = this.props;
+      const module = this.curModule;
+      const state = this.store.getState();
+
+      // If user has timed out, force them to log in again.
+      if (state?.okapi?.token && state.okapi.authFailure
+        && find(state.okapi.authFailure, { type: 'error', code: 'user.timeout' })) {
+        this.returnToLogin();
+      }
+
+      if (module && isQueryResourceModule(module, location)) {
+        const { moduleName } = module;
+        const queryState = getQueryResourceState(module, this.store);
+
+        // only update location if query state has changed
+        if (!isEqual(queryState, prevQueryState[moduleName])) {
+          curQuery = updateLocation(module, curQuery, this.store, history, location);
+          prevQueryState[moduleName] = queryState;
+        }
+      }
+    });
+
+    // remove QueryProvider cache to be 100% sure we're starting from a clean slate.
+    this.props.queryClient.removeQueries();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { modules, location } = this.props;
+    this.curModule = getCurrentModule(modules, location);
+    if (this.curModule && !isEqual(location, prevProps.location)) {
+      updateQueryResource(location, this.curModule, this.store);
+    }
+  }
+
+  componentWillUnmount() {
+    this._unsubscribe();
+  }
+
+  render = () => this.props.children;
+};
+
+export default compose(
+  injectIntl,
+  withRouter,
+  withModules,
+)(QueryStateUpdater);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,6 +8,7 @@ export { default as Login } from './Login';
 export { default as Logout } from './Logout';
 export { default as MainContainer } from './MainContainer';
 export { default as MainNav } from './MainNav';
+export { default as QueryStateUpdater } from './MainNav/QueryStateUpdater';
 export { AppOrderProvider } from './MainNav/AppOrderProvider';
 export { default as ModuleContainer } from './ModuleContainer';
 export { withModule, withModules } from './Modules';


### PR DESCRIPTION
Changes from [App reordering](https://folio-org.atlassian.net/browse/STCOR-936) - specifically a functional refactor of `MainNav` unearthed a handful of errors at the app level, causing behaviors with logic that updates query parameters/location. This PR takes the previous code from the class-based `MainNav` and places it in its own component: `QueryStateUpdater` - naming aside, this removes the potentially offending logic from `MainNav`, leaving it to the task of simply rendering the navigation/menus of the UI.

The useEffect implementations of the functional `MainNav` were  written to mirror the `componentDidMount` and `componentDidUpdate` lifestyle methods of the class-based version. When the `location` was added to the `cDM` dependency array in [This PR](https://github.com/folio-org/stripes-core/pull/1600), this meant that the logic would no longer execute stricly on mount/dismount - but anytime that the `location` updated... this would cause page refreshes, as the logic would find a black `prevQueryState` every time and always update the location, causing a refresh.

`componentDidUpdate` carried around its `prevProps`, unlike functional react, where a state might be needed to accomplish such a comparison - but this doesn't seem like an ideal solution for the functional version, so here we are.

