### PR TITLE
STCOR-955 Improve useModuleInfo hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 11.1.0 IN PROGRESS
 * CSS Support for printing of results lists content. Refs STCOR-956.
+* Improve useModuleInfo hook. Refs STCOR-955.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/discoverServices.js
+++ b/src/discoverServices.js
@@ -306,7 +306,7 @@ export function discoveryReducer(state = {}, action) {
             ...(state.interfaceProviders ?? []),
             {
               id: action.data.id,
-              provides: action.data.provides.map(i => ({ id: i.id, version: i.version })),
+              provides: action.data.provides.map(i => ({ id: i.id, version: i.version, handlers: i.handlers })),
             },
           ]
         });


### PR DESCRIPTION
This PR enhances the performance of the `useModuleInfo(path)` hook by eliminating unnecessary network requests that previously occurred on every page render.

Changes: 

- Replaced the `react-query` based implementation with `useStripes()`.
- Now leverages module information already available from the `discoverServices` (`modules?full=true`) after login, avoiding extra network calls.
- Since this hook is new and there are no explicit requirements for the returned information, I suggest limiting it to 3 fields -  `{id, name, provides}`, so as not to overload it with `permissions` and other `meta information`, which can be a thousand lines for one module. 
For example, in `bulk-edit`, where this hook will be used first, only the `module name` is needed.

Potential problems:

- Since the module data is collected once at login, there is a small chance that if module information changes later, the user might still see outdated data. However, the probability of this happening is extremely low, I hope 😄 

Some tests:
![image](https://github.com/user-attachments/assets/e26a7ec9-c3d8-4290-96e8-770cb3db1014)

Refs: [STCOR-955](https://folio-org.atlassian.net/browse/STCOR-955)




