### PR TITLE
STCOR-941 Convert test suites to Newschool BT

### DIFF
--- a/src/components/AppIcon/tests/appIcon-test.js
+++ b/src/components/AppIcon/tests/appIcon-test.js
@@ -4,17 +4,30 @@
 
 import React from 'react';
 import { beforeEach, it, describe } from 'mocha';
-import { expect } from 'chai';
+import {
+  HTML,
+  Image,
+  including
+} from '@folio/stripes-testing';
 
 import { mount } from '../../../../test/bigtest/helpers/render-helpers';
 
 import AppIcon from '../AppIcon';
-import AppIconInteractor from './interactor';
 import png from './users-app-icon.png';
 import svg from './users-app-icon.svg';
 
+const AppIconInteractor = HTML.extend('AppIcon')
+  .selector('[class^=appIcon]')
+  .filters({
+    hasImg: el => Boolean(el.querySelector('img')),
+    tag: el => el.tagName.toLowerCase(),
+    className: el => el.className,
+    label: el => el.innerText
+  });
+
+
 describe('AppIcon', async () => {
-  const appIcon = new AppIconInteractor();
+  const appIcon = AppIconInteractor();
   const alt = 'My alt';
   const label = 'My label';
   const tag = 'div';
@@ -54,13 +67,9 @@ describe('AppIcon', async () => {
       );
     });
 
-    it('Should render an <img>', () => {
-      expect(appIcon.hasImg).to.equal(true);
-    });
+    it('Should render an <img>', () => appIcon.has({ hasImg: true }));
 
-    it('Should render an img with an alt-attribute', () => {
-      expect(appIcon.img.alt).to.equal(stripesMock.icons.users.app.alt);
-    });
+    it('Should render an img with an alt-attribute', () => Image({ alt: stripesMock.icons.users.app.alt }).exists());
   });
 
   describe('Rendering an AppIcon using an icon-object', () => {
@@ -73,17 +82,11 @@ describe('AppIcon', async () => {
       );
     });
 
-    it('Should render an <img>', () => {
-      expect(appIcon.hasImg).to.equal(true);
-    });
+    it('Should render an <img>', () => appIcon.has({ hasImg: true }));
 
-    it('Should render an img with an alt-attribute', () => {
-      expect(appIcon.img.alt).to.equal(alt);
-    });
+    it('Should render an img with an alt-attribute', () => Image({ alt }).exists());
 
-    it(`Should render with a className of "${className}"`, () => {
-      expect(appIcon.className).to.include(className);
-    });
+    it(`Should render with a className of "${className}"`, () => appIcon.has({ className: including(className) }));
   });
 
   describe('Passing a string using the children-prop', () => {
@@ -95,9 +98,7 @@ describe('AppIcon', async () => {
       );
     });
 
-    it('Should render an AppIcon with a label', () => {
-      expect(appIcon.label).to.equal(label);
-    });
+    it('Should render an AppIcon with a label', () => appIcon.has({ label }));
   });
 
   describe('Passing a string to the tag-prop', () => {
@@ -110,9 +111,7 @@ describe('AppIcon', async () => {
       );
     });
 
-    it(`Should render an AppIcon with a HTML tag of "${tag}"`, () => {
-      expect(appIcon.tag.toLowerCase()).to.equal(tag);
-    });
+    it(`Should render an AppIcon with a HTML tag of "${tag}"`, () => appIcon.has({ tag }));
   });
 
   const sizeTest = (size) => {
@@ -126,9 +125,7 @@ describe('AppIcon', async () => {
         );
       });
 
-      it(`Should render an icon into a ${size}-sized container`, () => {
-        expect(appIcon.className).to.match(new RegExp(size));
-      });
+      it(`Should render an icon into a ${size}-sized container`, () => appIcon.has({ className: including(size) }));
     });
   };
 

--- a/src/components/MainNav/AppList/components/ResizeContainer/tests/ResizeContainer-test.js
+++ b/src/components/MainNav/AppList/components/ResizeContainer/tests/ResizeContainer-test.js
@@ -5,11 +5,22 @@
 import React from 'react';
 import times from 'lodash/times';
 import { beforeEach, it, describe } from 'mocha';
-import { expect } from 'chai';
+import {
+  HTML
+} from '@folio/stripes-testing';
+
 import { mount } from '../../../../../../../test/bigtest/helpers/render-helpers';
 
 import ResizeContainer from '../ResizeContainer';
-import ResizeContainerInteractor from './interactor';
+
+const ResizeContainerInteractor = HTML.extend('ResizeContainer')
+  .selector('[data-test-resize-container]')
+  .filters({
+    visibleCount: el => el.querySelectorAll('[data-test-resize-container-visible-item]').length,
+    hiddenCount: el => el.querySelectorAll('[data-test-resize-container-hidden-item]').length,
+  });
+
+
 
 // The width of each item
 // These values would vary depending on the length of the label in a real app
@@ -72,7 +83,7 @@ const ResizeContainerMock = ({ items, wrapperWidth, itemWidth, hideAllWidth, off
 };
 
 describe('ResizeContainer', () => {
-  const resizeContainer = new ResizeContainerInteractor('.my-test-interactor');
+  const resizeContainer = ResizeContainerInteractor();
 
   beforeEach(async () => {
     await mount(
@@ -86,13 +97,9 @@ describe('ResizeContainer', () => {
     );
   });
 
-  it(`renders ${EXPECTED_VISIBLE_ITEMS} visible items`, () => {
-    expect(resizeContainer.visibleItems.length).to.equal(EXPECTED_VISIBLE_ITEMS);
-  });
+  it(`renders ${EXPECTED_VISIBLE_ITEMS} visible items`, () => resizeContainer.has({ visibleCount: EXPECTED_VISIBLE_ITEMS }));
 
-  it(`should have ${EXPECTED_HIDDEN_ITEMS} hidden items`, () => {
-    expect(resizeContainer.hiddenItems.length).to.equal(EXPECTED_HIDDEN_ITEMS);
-  });
+  it(`should have ${EXPECTED_HIDDEN_ITEMS} hidden items`, () => resizeContainer.has({ hiddenCount: EXPECTED_HIDDEN_ITEMS }));
 
   describe('If the value of the "hideAllWidth"-prop is larger than the width of the window', () => {
     beforeEach(async () => {
@@ -107,13 +114,9 @@ describe('ResizeContainer', () => {
       );
     });
 
-    it('renders 0 visible items', () => {
-      expect(resizeContainer.visibleItems.length).to.equal(0);
-    });
+    it('renders 0 visible items', () => resizeContainer.has({ visibleCount: 0 }));
 
-    it(`renders ${ITEMS.length} hidden items (equal to all items)`, () => {
-      expect(resizeContainer.hiddenItems.length).to.equal(ITEMS.length);
-    });
+    it(`renders ${ITEMS.length} hidden items (equal to all items)`, () => resizeContainer.has({ hiddenCount: ITEMS.length }));
   });
 
   describe('If rendered with right-to-left direction', () => {
@@ -130,12 +133,8 @@ describe('ResizeContainer', () => {
       );
     });
 
-    it(`renders ${EXPECTED_VISIBLE_ITEMS} visible items`, () => {
-      expect(resizeContainer.visibleItems.length).to.equal(EXPECTED_VISIBLE_ITEMS);
-    });
+    it(`renders ${EXPECTED_VISIBLE_ITEMS} visible items`, () => resizeContainer.has({ visibleCount: EXPECTED_VISIBLE_ITEMS }));
 
-    it(`should have ${EXPECTED_HIDDEN_ITEMS} hidden items`, () => {
-      expect(resizeContainer.hiddenItems.length).to.equal(EXPECTED_HIDDEN_ITEMS);
-    });
+    it(`should have ${EXPECTED_HIDDEN_ITEMS} hidden items`, () => resizeContainer.has({ hiddenCount: EXPECTED_HIDDEN_ITEMS }));
   });
 });


### PR DESCRIPTION
Much of this was accomplished back when we 'jettisoned bigtest-mocha'. This PR cleans up the remainder of test suites making used of old-school interactors. The interactors ARE still provided but can be flat_out removed w/o breaking _this_ test suite. As we tread forward, we'll eventually get around to removing all `@bigtest` deps and moving necessary interactors (if needed) to `@folio/stripes-testing`.