### PR TITLE
STCOR-957 provide useQueryLimit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 11.1.0 IN PROGRESS
 * CSS Support for printing of results lists content. Refs STCOR-956.
 * Improve useModuleInfo hook. Refs STCOR-955.
+* Provide `useQueryLimit()` hook. Refs STCOR-616, STCOR-617.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -49,6 +49,16 @@
         "permissionName": "mod-settings.owner.write.stripes-core.prefs.manage",
         "displayName": "UI: update the user's own central preferences, such as order of links in the main navigation.",
         "visible": false
+      },
+      {
+        "permissionName": "mod-settings.global.read.stripes-core.prefs.manage",
+        "displayName": "UI: read the tenant's preferences",
+        "visible": false
+      },
+      {
+        "permissionName": "mod-settings.global.write.stripes-core.prefs.manage",
+        "displayName": "UI: update the tenant's preferences",
+        "visible": false
       }
     ]
   },

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -6,3 +6,4 @@ export { default as defaultErrors } from './defaultErrors';
 export { default as packageName } from './packageName';
 export { default as delimiters } from './delimiters';
 export { default as eventsPortal } from './eventsPortal';
+export { default as settings } from './settings';

--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -1,0 +1,6 @@
+const settings = {
+  SCOPE: 'stripes-core.prefs.manage',
+};
+
+export default settings;
+

--- a/src/hooks/useQueryLimit.js
+++ b/src/hooks/useQueryLimit.js
@@ -1,0 +1,37 @@
+import { useStripes } from '../StripesContext';
+import useTenantPreferences from './useTenantPreferences';
+import { settings } from '../constants';
+
+/** settings key for this tenant-level preference */
+export const SETTINGS_KEY = 'query-limit';
+
+/** default value, absent values from tenant-settings or stripes.confing.js */
+export const MAX_UNPAGED_RESOURCE_COUNT = 2000;
+
+/**
+ * useQueryLimit
+ * Provide the value to use in the `limit=` clause of an unpaged-records query,
+ *
+ * usage: const limit = useQueryLimit();
+ *
+ * i.e. when retrieving entries from a lookup table, how many entries should be
+ * retrieved? Look first in tenant-settings, then in stripes.config.js, then
+ * return a default, hard-coded value.
+ *
+ * @returns {Promise} number of records to retrieve in an unpaged-query
+ */
+export const useQueryLimit = async () => {
+  const { stripes } = useStripes();
+  const { getTenantPreference } = useTenantPreferences();
+
+  let limit = await getTenantPreference({ scope: settings.SCOPE, key: SETTINGS_KEY });
+  if (!limit) {
+    if (stripes.config.maxUnpagedResourceCount) {
+      limit = stripes.config.maxUnpagedResourceCount;
+    } else {
+      limit = MAX_UNPAGED_RESOURCE_COUNT;
+    }
+  }
+
+  return limit;
+};

--- a/src/hooks/useQueryLimit.js
+++ b/src/hooks/useQueryLimit.js
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { useStripes } from '../StripesContext';
 import useTenantPreferences from './useTenantPreferences';
 import { settings } from '../constants';
@@ -18,20 +20,29 @@ export const MAX_UNPAGED_RESOURCE_COUNT = 2000;
  * retrieved? Look first in tenant-settings, then in stripes.config.js, then
  * return a default, hard-coded value.
  *
- * @returns {Promise} number of records to retrieve in an unpaged-query
+ * @returns {Number} number of records to retrieve in an unpaged-query
  */
 export const useQueryLimit = async () => {
+  const [limit, setLimit] = useState(null);
   const { stripes } = useStripes();
   const { getTenantPreference } = useTenantPreferences();
 
-  let limit = await getTenantPreference({ scope: settings.SCOPE, key: SETTINGS_KEY });
-  if (!limit) {
-    if (stripes.config.maxUnpagedResourceCount) {
-      limit = stripes.config.maxUnpagedResourceCount;
-    } else {
-      limit = MAX_UNPAGED_RESOURCE_COUNT;
-    }
-  }
+  useEffect(() => {
+    const getLimit = async () => {
+      let value = await getTenantPreference({ scope: settings.SCOPE, key: SETTINGS_KEY });
+      if (!value) {
+        if (stripes.config.maxUnpagedResourceCount) {
+          value = stripes.config.maxUnpagedResourceCount;
+        } else {
+          value = MAX_UNPAGED_RESOURCE_COUNT;
+        }
+      }
+
+      setLimit(value);
+    };
+
+    getLimit();
+  }, [getTenantPreference, stripes.config.maxUnpagedResourceCount]);
 
   return limit;
 };

--- a/src/hooks/useQueryLimit.js
+++ b/src/hooks/useQueryLimit.js
@@ -22,7 +22,7 @@ export const MAX_UNPAGED_RESOURCE_COUNT = 2000;
  *
  * @returns {Number} number of records to retrieve in an unpaged-query
  */
-export const useQueryLimit = async () => {
+export const useQueryLimit = () => {
   const [limit, setLimit] = useState(null);
   const { stripes } = useStripes();
   const { getTenantPreference } = useTenantPreferences();

--- a/src/hooks/useQueryLimit.test.js
+++ b/src/hooks/useQueryLimit.test.js
@@ -20,8 +20,11 @@ describe('useQueryLimit', () => {
       const mockUseStripes = useStripes;
       mockUseStripes.mockReturnValue({ stripes: { config: { } } });
 
-      const renderedHook = renderHook(() => useQueryLimit());
-      const limit = await act(() => renderedHook.result.current);
+      const { result } = renderHook(() => useQueryLimit());
+
+      await waitFor(() => expect(result.current.limit).not.toBeNull());
+      const limit = await act(() => result.current);
+
       expect(limit).toEqual(testLimit);
     });
   });
@@ -37,10 +40,12 @@ describe('useQueryLimit', () => {
         const maxUnpagedResourceCount = 123;
         mockUseStripes.mockReturnValue({ stripes: { config: { maxUnpagedResourceCount } } });
 
-        const renderedHook = renderHook(() => useQueryLimit());
-        const limit = await act(() => renderedHook.result.current);
+        const { result } = renderHook(() => useQueryLimit());
 
-        await waitFor(() => expect(limit).toEqual(maxUnpagedResourceCount));
+        await waitFor(() => expect(result.current.limit).not.toBeNull());
+        const limit = await act(() => result.current);
+
+        expect(limit).toEqual(maxUnpagedResourceCount);
       });
     });
 
@@ -52,10 +57,12 @@ describe('useQueryLimit', () => {
         const mockUseStripes = useStripes;
         mockUseStripes.mockReturnValue({ stripes: { config: { } } });
 
-        const renderedHook = renderHook(() => useQueryLimit());
-        const limit = await act(() => renderedHook.result.current);
+        const { result } = renderHook(() => useQueryLimit());
 
-        await waitFor(() => expect(limit).toEqual(MAX_UNPAGED_RESOURCE_COUNT));
+        await waitFor(() => expect(result.current.limit).not.toBeNull());
+        const limit = await act(() => result.current);
+
+        expect(limit).toEqual(MAX_UNPAGED_RESOURCE_COUNT);
       });
     });
   });

--- a/src/hooks/useQueryLimit.test.js
+++ b/src/hooks/useQueryLimit.test.js
@@ -1,0 +1,62 @@
+import { renderHook, waitFor, act } from '@folio/jest-config-stripes/testing-library/react';
+
+import { useQueryLimit, MAX_UNPAGED_RESOURCE_COUNT } from './useQueryLimit';
+import { useStripes } from '../StripesContext';
+
+const testLimit = 42;
+const mockGetTenantPreference = jest.fn(() => Promise.resolve(testLimit));
+jest.mock('./useTenantPreferences', () => ({
+  __esModule: true, // this property makes it work
+  default: jest.fn(() => ({
+    getTenantPreference: mockGetTenantPreference,
+  }))
+}));
+
+jest.mock('../StripesContext');
+
+describe('useQueryLimit', () => {
+  describe('with stored preference', () => {
+    it('returns preference value', async () => {
+      const mockUseStripes = useStripes;
+      mockUseStripes.mockReturnValue({ stripes: { config: { } } });
+
+      const renderedHook = renderHook(() => useQueryLimit());
+      const limit = await act(() => renderedHook.result.current);
+      expect(limit).toEqual(testLimit);
+    });
+  });
+
+  describe('without saved preferences', () => {
+    describe('with value in stripes.config', () => {
+      it('returns value from stripes.config', async () => {
+        // we'll get nothing from settings
+        mockGetTenantPreference.mockReturnValue(undefined);
+
+        // we'll get a value from stripes
+        const mockUseStripes = useStripes;
+        const maxUnpagedResourceCount = 123;
+        mockUseStripes.mockReturnValue({ stripes: { config: { maxUnpagedResourceCount } } });
+
+        const renderedHook = renderHook(() => useQueryLimit());
+        const limit = await act(() => renderedHook.result.current);
+
+        await waitFor(() => expect(limit).toEqual(maxUnpagedResourceCount));
+      });
+    });
+
+    describe('without value in stripes.config', () => {
+      it('returns default', async () => {
+        // we'll get nothing from settings
+        mockGetTenantPreference.mockReturnValue(undefined);
+        // we'll get nothing from stripes.config
+        const mockUseStripes = useStripes;
+        mockUseStripes.mockReturnValue({ stripes: { config: { } } });
+
+        const renderedHook = renderHook(() => useQueryLimit());
+        const limit = await act(() => renderedHook.result.current);
+
+        await waitFor(() => expect(limit).toEqual(MAX_UNPAGED_RESOURCE_COUNT));
+      });
+    });
+  });
+});

--- a/src/hooks/useQueryLimit.test.js
+++ b/src/hooks/useQueryLimit.test.js
@@ -1,4 +1,4 @@
-import { renderHook, waitFor, act } from '@folio/jest-config-stripes/testing-library/react';
+import { renderHook, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 
 import { useQueryLimit, MAX_UNPAGED_RESOURCE_COUNT } from './useQueryLimit';
 import { useStripes } from '../StripesContext';
@@ -22,10 +22,9 @@ describe('useQueryLimit', () => {
 
       const { result } = renderHook(() => useQueryLimit());
 
-      await waitFor(() => expect(result.current.limit).not.toBeNull());
-      const limit = await act(() => result.current);
+      await waitFor(() => expect(result.current).not.toBeNull());
 
-      expect(limit).toEqual(testLimit);
+      expect(result.current).toEqual(testLimit);
     });
   });
 
@@ -42,10 +41,9 @@ describe('useQueryLimit', () => {
 
         const { result } = renderHook(() => useQueryLimit());
 
-        await waitFor(() => expect(result.current.limit).not.toBeNull());
-        const limit = await act(() => result.current);
+        await waitFor(() => expect(result.current).not.toBeNull());
 
-        expect(limit).toEqual(maxUnpagedResourceCount);
+        expect(result.current).toEqual(maxUnpagedResourceCount);
       });
     });
 
@@ -59,10 +57,9 @@ describe('useQueryLimit', () => {
 
         const { result } = renderHook(() => useQueryLimit());
 
-        await waitFor(() => expect(result.current.limit).not.toBeNull());
-        const limit = await act(() => result.current);
+        await waitFor(() => expect(result.current).not.toBeNull());
 
-        expect(limit).toEqual(MAX_UNPAGED_RESOURCE_COUNT);
+        expect(result.current).toEqual(MAX_UNPAGED_RESOURCE_COUNT);
       });
     });
   });

--- a/src/hooks/useTenantPreferences.js
+++ b/src/hooks/useTenantPreferences.js
@@ -1,0 +1,84 @@
+import { useCallback, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+import useOkapiKy from '../useOkapiKy';
+import { useStripes } from '../StripesContext';
+
+export default () => {
+  const { logger } = useStripes();
+  const ky = useOkapiKy();
+  const [id, setId] = useState(null);
+
+  const getTenantPreference = useCallback(async ({ scope, key }) => {
+    // get preferences by querying preferences with the userId, scope, and key...
+    // this will return an array that's likely a single item long. We store the item's id in state so that we can update it later.
+    let respJSON = null;
+    let resp;
+    try {
+      resp = await ky.get(`settings/entries?query=scope=="${scope}" and key=="${key}"`);
+      if (resp.ok) {
+        respJSON = await resp.json();
+        if (respJSON.items.length > 0) {
+          logger.log('pref', `found preference at scope: ${scope}, and key: ${key}`);
+          setId(respJSON.items[0].id);
+          return respJSON.items[0].value;
+        } else {
+          setId(null);
+          logger.log('pref', `no preference found at scope: ${scope}, and key: ${key}`);
+          return undefined;
+        }
+      }
+    } catch (err) {
+      logger.log('pref', `error getting preference at scope: ${scope}, and key: ${key} - ${err.message}`);
+    }
+    return undefined;
+  }, [id, ky]); // eslint-disable-line
+
+  const setTenantPreference = useCallback(async ({ scope, key, value }) => {
+    const prefId = id || uuidv4();
+    const payload = {
+      id: prefId,
+      scope,
+      key,
+      value,
+    };
+
+    // if we didn't store an id upon retrieving user preferences, then one probably doesn't exist,
+    // so we use the `POST` endpoint for saving... 'PUT', and including the id in the path is used for updating
+    if (!id) {
+      try {
+        await ky.post('settings/entries', { json: payload });
+        setId(prefId);
+        logger.log('pref', `created preference at scope: ${scope}, and key: ${key} with id: ${id} and value: ${value}`);
+      } catch (err) {
+        logger.log('pref', `error creating preference at scope: ${scope}, and key: ${key} - ${err.message}`);
+      }
+    } else {
+      try {
+        await ky.put(`settings/entries/${prefId}`, { json: payload });
+        logger.log('pref', `updated preference at scope: ${scope}, and key: ${key} with ${value}`);
+      } catch (err) {
+        logger.log('pref', `error updating preference at scope: ${scope}, and key: ${key} - ${err.message}`);
+      }
+    }
+  }, [id, ky, logger]);
+
+  const removeTenantPreference = useCallback(async ({ scope, key }) => {
+    try {
+      if (id) {
+        await ky.delete(`settings/entries/${id}`);
+        setId(null);
+        logger.log('pref', `deleted preference at scope: ${scope}, and key: ${key} at id: ${id}`);
+        return;
+      }
+    } catch (err) {
+      logger.log('pref', `error deleting preference at scope: ${scope}, and key: ${key} at id: ${id} - ${err.message}`);
+    }
+  }, [id, ky, logger]);
+
+  return {
+    setTenantPreference,
+    getTenantPreference,
+    removeTenantPreference,
+  };
+};

--- a/src/hooks/useTenantPreferences.test.js
+++ b/src/hooks/useTenantPreferences.test.js
@@ -1,0 +1,139 @@
+import { renderHook, waitFor, act } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import useTenantPreferences from './useTenantPreferences';
+
+const testValue = { pref: '22' };
+const response = {
+  items: [
+    {
+      id: '2ae496b4-244e-4d19-aee7-61f195cdd524',
+      scope: 'test.manage',
+      key: 'testPref',
+      value: { pref: '22' },
+    },
+  ],
+  'resultInfo': {
+    'totalRecords': 1,
+    'diagnostics': []
+  }
+};
+
+const emptyResponse = {
+  items: [],
+  'resultInfo': {
+    'totalRecords': 0,
+    'diagnostics': []
+  }
+};
+
+const mockGet = jest.fn(() => ({
+  ok: true,
+  json: () => response,
+}));
+const mockPut = jest.fn();
+const mockPost = jest.fn();
+const mockDelete = jest.fn();
+
+jest.mock('../useOkapiKy', () => ({
+  __esModule: true, // this property makes it work
+  default: jest.fn(() => ({
+    get: mockGet,
+    put: mockPut,
+    post: mockPost,
+    delete: mockDelete
+  }))
+}));
+
+jest.mock('../StripesContext', () => ({
+  useStripes: () => ({
+    user: {
+      user: {
+        id: 'test-user'
+      }
+    },
+    okapi: {
+      tenant: 't',
+    },
+    logger: {
+      log: () => {},
+    }
+  }),
+}));
+
+const queryClient = new QueryClient();
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useTenantPreferences', () => {
+  let renderedHook;
+
+  beforeAll(() => {
+    renderedHook = renderHook(() => useTenantPreferences(), { wrapper });
+  });
+
+  describe('getTenantPreference', () => {
+    let pref;
+    beforeEach(async () => {
+      pref = await act(() => renderedHook.result.current.getTenantPreference({ scope: 'test.manage', key: 'testPref' }));
+    });
+
+    it('getTenantPreference returns preference value', () => {
+      expect(pref).toEqual(testValue);
+    });
+
+    describe('subsequent setTenantPreference call ', () => {
+      beforeEach(async () => {
+        await renderedHook.result.current.setTenantPreference({ scope: 'test.manage', key: 'testPref', value: { pref: 25 } });
+      });
+
+      it('uses "put" method', () => {
+        expect(mockPut).toHaveBeenCalled();
+      });
+    });
+
+    describe('subsequent deleteTenantPreference call ', () => {
+      beforeEach(async () => {
+        await renderedHook.result.current.removeTenantPreference({ scope: 'test.manage', key: 'testPref' });
+      });
+
+      it('uses "delete" method', () => {
+        expect(mockDelete).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('with no saved preferences', () => {
+    let pref;
+    beforeEach(async () => {
+      renderedHook = renderHook(() => useTenantPreferences(), { wrapper });
+      mockGet.mockImplementation(() => ({
+        ok: true,
+        json: () => emptyResponse,
+      }));
+      pref = await act(() => renderedHook.result.current.getTenantPreference({ scope: 'test.manage', key: 'testPref' }));
+    });
+
+    it('getTenantPreference returns undefined', async () => {
+      await waitFor(() => expect(pref).toEqual(undefined));
+    });
+
+    describe('subsequent setTenantPreference call ', () => {
+      beforeEach(async () => {
+        await renderedHook.result.current.setTenantPreference({ scope: 'test.manage', key: 'testPref', value: { pref: 25 } });
+      });
+
+      it('uses "post" method', async () => {
+        await waitFor(() => expect(mockPost).toHaveBeenCalled());
+      });
+    });
+  });
+});


### PR DESCRIPTION
The `useQueryLimit()` hook returns a number which can be used in a query's limit clause when retrieving entries from a lookup table and you want _all_ the records.

```
const limit = useQueryLimit();
```

`useQueryLimit()` first looks for a tenant-level mod-settings entry, then for `stripes.config.maxUnpagedResourceCount` from `stripes.config.js`, and then finally gives up and returns the value of the constant `MAX_UNPAGED_RESOURCE_COUNT`, currently set to 2000.

`userTenantPreferences` was shamelessly copied from `usePreferences`; both should be rewritten to share common code. Probably we want `usePreferences` to be the top-level, which looks up a value in user-settings, then tenant-settings.

Refs [STCOR-957](https://folio-org.atlassian.net/browse/STCOR-957)