### PR TITLE
STCOR-899 show user-friendly labels on ECS pre-login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * CSS Support for printing of results lists content. Refs STCOR-956.
 * Improve useModuleInfo hook. Refs STCOR-955.
 * Provide `useQueryLimit()` hook. Refs STCOR-616, STCOR-617.
+* Show user-friendly labels on ECS pre-login screen. Refs STCOR-899.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import { Button, Select, Col, Row } from '@folio/stripes-components';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { OrganizationLogo } from '../index';
+import OrganizationLogo from '../OrganizationLogo';
 import styles from './index.css';
 import { useStripes } from '../../StripesContext';
 
@@ -11,7 +11,7 @@ function PreLoginLanding({ onSelectTenant }) {
   const { okapi, config: { tenantOptions = {} } } = useStripes();
 
   const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;
-  const options = Object.keys(tenantOptions).map(tenantName => ({ value: tenantName, label: tenantName }));
+  const options = Object.values(tenantOptions).map(i => ({ value: i.name, label: i.displayName ?? i.name }));
 
   const getLoginUrl = () => {
     if (!okapi.tenant) return '';

--- a/src/components/PreLoginLanding/PreLoginLanding.test.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.test.js
@@ -1,0 +1,115 @@
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import { userEvent } from '@folio/jest-config-stripes/testing-library/user-event';
+
+import { useStripes } from '../../StripesContext';
+import PreLoginLanding from './PreLoginLanding';
+import OrganizationLogo from '../OrganizationLogo';
+
+jest.mock('react-router', () => ({
+  Redirect: jest.fn(),
+}));
+
+jest.mock('../../StripesContext');
+
+jest.mock('../OrganizationLogo', () => () => 'OrganizationLogo');
+
+describe('PreLoginLanding', () => {
+  describe('clicking continue', () => {
+    // this test looks fake, but it actually works because choosing
+    // a tenant updates redux which updates okapi.tenant.
+    // so, even though okapi.tenant is hard-coded here, that's what we actually
+    // want to check.
+    it('redirects when a tenant has been selected', async () => {
+      const mockUseStripes = useStripes;
+      const authnUrl = 'https://authn-url.edu';
+      mockUseStripes.mockReturnValue({
+        okapi: { authnUrl, tenant: 't' },
+        config: {
+          tenantOptions: {
+            p: { name: 'p', clientId: 'p-client', displayName: 'Pangolin' },
+            q: { name: 'q', clientId: 'q-client', displayName: 'Quetzal' },
+            r: { name: 'rhinoceros', clientId: 'r-client' },
+          }
+        }
+      });
+
+      delete window.location;
+      window.location = { assign: jest.fn() };
+      const onSelectTenant = jest.fn();
+
+      render(<PreLoginLanding onSelectTenant={onSelectTenant} />);
+      await userEvent.click(screen.getByText('stripes-core.button.continue'));
+      expect(window.location.assign).toHaveBeenCalledWith(expect.stringContaining(authnUrl));
+    });
+
+    // this test looks fake, but it actually works because choosing
+    // a tenant updates redux which updates okapi.tenant.
+    // so, checking that nothing happens when okapi.tenant is empty is exactly
+    // what we want to check.
+    it('does nothing if no tenant is selected', async () => {
+      const mockUseStripes = useStripes;
+      mockUseStripes.mockReturnValue({
+        okapi: { authnUrl: 'https://authn-url.edu' },
+        config: {
+          tenantOptions: {
+            p: { name: 'p', clientId: 'p-client', displayName: 'Pangolin' },
+            q: { name: 'q', clientId: 'q-client', displayName: 'Quetzal' },
+            r: { name: 'rhinoceros', clientId: 'r-client' },
+          }
+        }
+      });
+
+      delete window.location;
+      window.location = { assign: jest.fn() };
+
+      const onSelectTenant = jest.fn();
+
+      render(<PreLoginLanding onSelectTenant={onSelectTenant} />);
+      await userEvent.click(screen.getByText('stripes-core.button.continue'));
+      expect(window.location.assign).toHaveBeenCalledWith('');
+    });
+  });
+
+
+  describe('tenant-select list', () => {
+    beforeEach(() => {
+      const mockUseStripes = useStripes;
+      mockUseStripes.mockReturnValue({
+        okapi: {},
+        config: {
+          tenantOptions: {
+            p: { name: 'p', clientId: 'p-client', displayName: 'Pangolin' },
+            q: { name: 'q', clientId: 'q-client', displayName: 'Quetzal' },
+            r: { name: 'rhinoceros', clientId: 'r-client' },
+          }
+        }
+      });
+    });
+
+    it('uses "displayName" when available', () => {
+      const onSelectTenant = jest.fn();
+      render(<PreLoginLanding onSelectTenant={onSelectTenant} />);
+
+      expect(screen.getByText('Pangolin')).toBeInTheDocument();
+    });
+
+    it('uses name when "displayName" is unavailable', () => {
+      const onSelectTenant = jest.fn();
+      render(<PreLoginLanding onSelectTenant={onSelectTenant} />);
+
+      expect(screen.getByText('rhinoceros')).toBeInTheDocument();
+    });
+
+    // I give up trying to get the Select mock to render an onChange property.
+    // maybe it is some wacky problem with jest-dom? I have no idea, but I have
+    // no interest in bashing my head against this wall any longer either.
+    // it('clicky click click', async () => {
+    //   const onSelectTenant = jest.fn();
+    //   render(<PreLoginLanding onSelectTenant={onSelectTenant} />);
+
+    //   await userEvent.click(screen.getByRole('option', { name: 'Pangolin' }));
+    //   expect(screen.getByRole('option', { name: 'stripes-core.tenantChoose' }).selected).toBe(true);
+    //   expect(onSelectTenant).toHaveBeenCalledWith('p', 'p-client')
+    // });
+  });
+});

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -47,6 +47,7 @@ jest.mock('@folio/stripes-components', () => ({
       </div>
     </div>
   )),
+  'datepicker-util': jest.fn(),
   Datepicker: jest.fn(({ ref, children, ...rest }) => (
     <div ref={ref} {...rest}>
       {children}
@@ -187,10 +188,10 @@ jest.mock('@folio/stripes-components', () => ({
     </fieldset>
   )),
   Row: jest.fn(({ children }) => <div className="row">{ children }</div>),
-  Select: jest.fn(({ children, dataOptions }) => (
+  Select: jest.fn(({ children, dataOptions, ...props }) => (
     <div>
-      <select>
-        {dataOptions.forEach((option, i) => (
+      <select {...props}>
+        {dataOptions.map((option, i) => (
           <option
             value={option.value}
             key={option.id || `option-${i}`}

--- a/test/jest/fixtures/okapi-modules.json
+++ b/test/jest/fixtures/okapi-modules.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "mod-users-19.4.5-SNAPSHOT.330",
+    "name": "users",
+    "provides": [
+      {
+        "id": "users",
+        "version": "16.3",
+        "handlers": [
+          {
+            "methods": [
+              "GET"
+            ],
+            "pathPattern": "/users",
+            "permissionsRequired": [
+              "users.collection.get"
+            ],
+            "permissionsDesired": [
+              "users.basic-read.execute",
+              "users.restricted-read.execute"
+            ]
+          },
+          {
+            "methods": [
+              "GET"
+            ],
+            "pathPattern": "/users/{id}",
+            "permissionsRequired": [
+              "users.item.get"
+            ],
+            "permissionsDesired": [
+              "users.basic-read.execute",
+              "users.restricted-read.execute"
+            ]
+          },
+          {
+            "methods": [
+              "POST"
+            ],
+            "pathPattern": "/users",
+            "permissionsRequired": [
+              "users.item.post"
+            ]
+          },
+          {
+            "methods": [
+              "GET"
+            ],
+            "pathPattern": "/users/profile-picture/{id}",
+            "permissionsRequired": [
+              "users.profile-picture.item.get"
+            ]
+          },
+        ]
+      }
+    ]
+  },
+  {
+    "id": "mod-circulation-24.4.0",
+    "name": "Circulation Module",
+    "provides": [
+      {
+        "id": "requests-reports",
+        "version": "0.8",
+        "handlers": [
+          {
+            "methods": [
+              "GET"
+            ],
+            "pathPattern": "/circulation/requests-reports/hold-shelf-clearance/{id}",
+            "permissionsRequired": [
+              "circulation.requests.hold-shelf-clearance-report.get"
+            ],
+            "modulePermissions": [
+              "modperms.circulation.requests.hold-shelf-clearance-report.get"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "inventory-reports",
+        "version": "0.4",
+        "handlers": [
+          {
+            "methods": [
+              "GET"
+            ],
+            "pathPattern": "/inventory-reports/items-in-transit",
+            "permissionsRequired": [
+              "circulation.inventory.items-in-transit-report.get"
+            ],
+            "modulePermissions": [
+              "modperms.inventory.items-in-transit-report.get"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "pick-slips",
+        "version": "0.4",
+        "handlers": [
+          {
+            "methods": [
+              "GET"
+            ],
+            "pathPattern": "/circulation/pick-slips/{servicePointId}",
+            "permissionsRequired": [
+              "circulation.pick-slips.get"
+            ],
+            "modulePermissions": [
+              "modperms.circulation.pick-slips.get"
+            ]
+          }
+        ]
+      }
+    ],
+  }
+]


### PR DESCRIPTION
The pre-login screen for ECS tenants with per-tenant authentication configured shows a select-list with each tenant as an option. This PR adds the ability to read a new attribute, `displayName`, from the tenant-object to be used as the label on that list in order to make it more user friendly.

Previously, the list in `stripes.config.js::config.tenantOptions` was shaped like this:
```
{
  k1: { name: "k1", clientId: "k1-application" },
  k2: { name: "k2", clientId: "k2-application" },
}
```
but now there is an optional, additional key, so it can be shaped like
```
{
  k1: { name: "k1", clientId: "k1-application", displayName: "Milli" },
  k2: { name: "k2", clientId: "k2-application", displayName: "Vanilli" },
}
```
This change should be 100% backwards compatible. The tenant value remains duplicated across the key and the `name` attribute, and the select-list will fall back on `name` if `displayName` is not present, preserving existing behavior.

Refs [STCOR-899](https://folio-org.atlassian.net/browse/STCOR-899)