### PR TITLE
STCOR-884: IST modal with long TTL shows even when FLST warning with short TTL is already displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
--# Change history for stripes-core
+- # Change history for stripes-core
 
 ## 11.1.0 IN PROGRESS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change history for stripes-core
+-# Change history for stripes-core
 
 ## 11.1.0 IN PROGRESS
 
@@ -9,6 +9,7 @@
 * Sort app links in the main navigation by their `displayName` by default. Refs STCOR-964.
 * Change default Idle Session Timeout to `4h` from `1h`. Refs STCOR-962.
 * Prune unused `./utils/` scripts, deps. Refs STCOR-959.
+* Don't show IST modal if `flsTimeRemaining` less than config.rtr.idleModalTTL. STCOR-884.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- # Change history for stripes-core
+# Change history for stripes-core
 
 ## 11.1.0 IN PROGRESS
 

--- a/src/components/SessionEventContainer/FixedLengthSessionWarning.js
+++ b/src/components/SessionEventContainer/FixedLengthSessionWarning.js
@@ -10,7 +10,7 @@ import css from './style.css';
  *
  * @param {function} callback function to call when clicking "Keep working" button
  */
-const FixedLengthSessionWarning = ({ flsTimer }) => {
+const FixedLengthSessionWarning = ({ timeRemainingMillis }) => {
   /**
    * timestampFormatter
    * convert time-remaining to mm:ss. Given the remaining time can easily be
@@ -20,8 +20,8 @@ const FixedLengthSessionWarning = ({ flsTimer }) => {
    * like `1970-01-01T00:01:39.000Z`; extract the `01:39`.
    */
   const timestampFormatter = () => {
-    if (flsTimer >= 1000) {
-      return new Date(flsTimer).toISOString().substring(14, 19);
+    if (timeRemainingMillis >= 1000) {
+      return new Date(timeRemainingMillis).toISOString().substring(14, 19);
     }
 
     return '00:00';
@@ -31,7 +31,7 @@ const FixedLengthSessionWarning = ({ flsTimer }) => {
 };
 
 FixedLengthSessionWarning.propTypes = {
-  flsTimer: PropTypes.number.isRequired,
+  timeRemainingMillis: PropTypes.number.isRequired,
 };
 
 export default FixedLengthSessionWarning;

--- a/src/components/SessionEventContainer/FixedLengthSessionWarning.js
+++ b/src/components/SessionEventContainer/FixedLengthSessionWarning.js
@@ -1,12 +1,6 @@
-import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import ms from 'ms';
-
-import {
-  MessageBanner
-} from '@folio/stripes-components';
-
-import { useStripes } from '../../StripesContext';
+import { MessageBanner } from '@folio/stripes-components';
 import css from './style.css';
 
 /**
@@ -16,23 +10,7 @@ import css from './style.css';
  *
  * @param {function} callback function to call when clicking "Keep working" button
  */
-const FixedLengthSessionWarning = () => {
-  const stripes = useStripes();
-  const [remainingMillis, setRemainingMillis] = useState(ms(stripes.config.rtr.fixedLengthSessionWarningTTL));
-
-  // configure an interval timer that sets state each second,
-  // counting down to 0.
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setRemainingMillis(i => i - 1000);
-    }, 1000);
-
-    // cleanup: clear the timer
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
-
+const FixedLengthSessionWarning = ({ flsTimer }) => {
   /**
    * timestampFormatter
    * convert time-remaining to mm:ss. Given the remaining time can easily be
@@ -42,14 +20,18 @@ const FixedLengthSessionWarning = () => {
    * like `1970-01-01T00:01:39.000Z`; extract the `01:39`.
    */
   const timestampFormatter = () => {
-    if (remainingMillis >= 1000) {
-      return new Date(remainingMillis).toISOString().substring(14, 19);
+    if (flsTimer >= 1000) {
+      return new Date(flsTimer).toISOString().substring(14, 19);
     }
 
     return '00:00';
   };
 
   return <MessageBanner show contentClassName={css.fixedSessionBanner}><FormattedMessage id="stripes-core.rtr.fixedLengthSession.timeRemaining" /> {timestampFormatter()}</MessageBanner>;
+};
+
+FixedLengthSessionWarning.propTypes = {
+  flsTimer: PropTypes.number.isRequired,
 };
 
 export default FixedLengthSessionWarning;

--- a/src/components/SessionEventContainer/FixedLengthSessionWarning.test.js
+++ b/src/components/SessionEventContainer/FixedLengthSessionWarning.test.js
@@ -1,35 +1,18 @@
 import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 
-import Harness from '../../../test/jest/helpers/harness';
 import FixedLengthSessionWarning from './FixedLengthSessionWarning';
 
 jest.mock('../Root/token-util');
 
-const stripes = {
-  config: {
-    rtr: {
-      fixedLengthSessionWarningTTL: '99s'
-    }
-  }
-};
-
 describe('FixedLengthSessionWarning', () => {
   it('renders a warning with seconds remaining', async () => {
-    render(<Harness stripes={stripes}><FixedLengthSessionWarning /></Harness>);
+    render(<FixedLengthSessionWarning flsTimer={99000} />);
     screen.getByText(/stripes-core.rtr.fixedLengthSession.timeRemaining/);
     screen.getByText(/01:39/);
   });
 
   it('renders 0:00 when time expires', async () => {
-    const zeroSecondsStripes = {
-      config: {
-        rtr: {
-          fixedLengthSessionWarningTTL: '0s'
-        }
-      }
-    };
-
-    render(<Harness stripes={zeroSecondsStripes}><FixedLengthSessionWarning /></Harness>);
+    render(<FixedLengthSessionWarning flsTimer={0} />);
     screen.getByText(/stripes-core.rtr.fixedLengthSession.timeRemaining/);
     screen.getByText(/0:00/);
   });
@@ -39,21 +22,9 @@ describe('FixedLengthSessionWarning', () => {
   // two seconds. Great? Nope. Good enough? Sure is.
   describe('uses timers', () => {
     it('"like sand through an hourglass, so are the elapsed seconds of this warning" -- Soh Kraits', async () => {
-      jest.spyOn(global, 'setInterval');
-      const zeroSecondsStripes = {
-        config: {
-          rtr: {
-            fixedLengthSessionWarningTTL: '10s'
-          }
-        }
-      };
+      render(<FixedLengthSessionWarning flsTimer={10000} />);
 
-      render(<Harness stripes={zeroSecondsStripes}><FixedLengthSessionWarning /></Harness>);
-
-      expect(setInterval).toHaveBeenCalledTimes(1);
-      expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 1000);
-
-      await waitFor(() => screen.getByText(/00:09/), { timeout: 2000 });
+      await waitFor(() => screen.getByText(/00:10/));
     });
   });
 });

--- a/src/components/SessionEventContainer/FixedLengthSessionWarning.test.js
+++ b/src/components/SessionEventContainer/FixedLengthSessionWarning.test.js
@@ -6,13 +6,13 @@ jest.mock('../Root/token-util');
 
 describe('FixedLengthSessionWarning', () => {
   it('renders a warning with seconds remaining', async () => {
-    render(<FixedLengthSessionWarning flsTimer={99000} />);
+    render(<FixedLengthSessionWarning timeRemainingMillis={99000} />);
     screen.getByText(/stripes-core.rtr.fixedLengthSession.timeRemaining/);
     screen.getByText(/01:39/);
   });
 
   it('renders 0:00 when time expires', async () => {
-    render(<FixedLengthSessionWarning flsTimer={0} />);
+    render(<FixedLengthSessionWarning timeRemainingMillis={0} />);
     screen.getByText(/stripes-core.rtr.fixedLengthSession.timeRemaining/);
     screen.getByText(/0:00/);
   });
@@ -22,7 +22,7 @@ describe('FixedLengthSessionWarning', () => {
   // two seconds. Great? Nope. Good enough? Sure is.
   describe('uses timers', () => {
     it('"like sand through an hourglass, so are the elapsed seconds of this warning" -- Soh Kraits', async () => {
-      render(<FixedLengthSessionWarning flsTimer={10000} />);
+      render(<FixedLengthSessionWarning timeRemainingMillis={10000} />);
 
       await waitFor(() => screen.getByText(/00:10/));
     });

--- a/src/components/SessionEventContainer/SessionEventContainer.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.js
@@ -142,13 +142,13 @@ const SessionEventContainer = ({ history }) => {
   // inactivity timers
   const timers = useRef();
   const stripes = useStripes();
-  const [timeRemainingMillis, setTimeRemainingMillis] = useState(ms(stripes.config.rtr.fixedLengthSessionWarningTTL));
+  const [flsTimeRemaining, setFlsTimeRemaining] = useState(ms(stripes.config.rtr.fixedLengthSessionWarningTTL));
 
   useEffect(() => {
     let interval;
     if (isFlsVisible) {
       interval = setInterval(() => {
-        setTimeRemainingMillis(i => i - 1000);
+        setFlsTimeRemaining(i => i - 1000);
       }, 1000);
     }
     return () => clearInterval(interval);
@@ -159,7 +159,7 @@ const SessionEventContainer = ({ history }) => {
    * used to determine if the keepWorking modal should be shown during the Fls countdown.
    */
 
-  const isModalRelevant = timeRemainingMillis < ms(stripes.config.rtr.idleModalTTL);
+  const isModalRelevant = flsTimeRemaining < ms(stripes.config.rtr.idleModalTTL);
 
   /**
    * keepWorkingCallback
@@ -297,7 +297,7 @@ const SessionEventContainer = ({ history }) => {
 
   // show the fixed-length session warning?
   if (isFlsVisible) {
-    renderList.push(<FixedLengthSessionWarning key="FixedLengthSessionWarning" timeRemainingMillis={timeRemainingMillis} />);
+    renderList.push(<FixedLengthSessionWarning key="FixedLengthSessionWarning" timeRemainingMillis={flsTimeRemaining} />);
   }
 
   return renderList.length ? createPortal(renderList, document.getElementById(eventsPortal)) : null;

--- a/src/components/SessionEventContainer/SessionEventContainer.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.js
@@ -154,12 +154,8 @@ const SessionEventContainer = ({ history }) => {
     return () => clearInterval(interval);
   }, [isFlsVisible]);
 
-  /**
-   * Indicator that fixed-length session warning countdown has exceeded the modal TTL,
-   * used to determine if the keepWorking modal should be shown during the Fls countdown.
-   */
-
-  const isModalRelevant = flsTimeRemaining < ms(stripes.config.rtr.idleModalTTL);
+  // Indicator that fixed-length session warning timer will expire before the modal's TTL
+  const isModalIgnorable = flsTimeRemaining < ms(stripes.config.rtr.idleModalTTL);
 
   /**
    * keepWorkingCallback
@@ -211,8 +207,7 @@ const SessionEventContainer = ({ history }) => {
 
     // inactive timer: show the "keep working?" modal
     const showModalIT = createInactivityTimer(ms(idleSessionTTL) - ms(idleModalTTL), () => {
-      // Don't show the keepWorking modal if the fixed-length session warning countdown has exceeded the modal TTL.
-      if (isModalRelevant) return;
+      if (isModalIgnorable) return;
 
       stripes.logger.log('rtr', 'session idle; showing modal');
       stripes.store.dispatch(toggleRtrModal(true));
@@ -282,11 +277,11 @@ const SessionEventContainer = ({ history }) => {
       bc.close();
     };
 
-    // isModalRelevant only? It should be history and stripes!!! >:)
-    // We only want to configure the event listeners once or on isModalRelevant
+    // isModalIgnorable only? It should be history and stripes!!! >:)
+    // We only want to configure the event listeners once or on isModalIgnorable
     // change that could happen very rarely, not every time there is a change to stripes or history.
-    // Hence, only isModalRelevant in dependency array.
-  }, [isModalRelevant]); // eslint-disable-line react-hooks/exhaustive-deps
+    // Hence, only isModalIgnorable in dependency array.
+  }, [isModalIgnorable]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const renderList = [];
 

--- a/src/components/SessionEventContainer/SessionEventContainer.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.js
@@ -158,7 +158,7 @@ const SessionEventContainer = ({ history }) => {
    * used to determine if the keepWorking modal should be shown during the Fls countdown.
    */
 
-  const isFlsExceededModalTTL = flsTimer < ms(stripes.config.rtr.idleModalTTL);
+  const isFlsExceededModalTTL = isFlsVisible && (flsTimer < ms(stripes.config.rtr.idleModalTTL));
 
   /**
    * keepWorkingCallback

--- a/src/components/SessionEventContainer/SessionEventContainer.test.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.test.js
@@ -27,7 +27,8 @@ const stripes = {
     rtr: {
       idleModalTTL: '3s',
       idleSessionTTL: '3s',
-      activityEvents: ['right thing', 'hustle', 'hand jive']
+      activityEvents: ['right thing', 'hustle', 'hand jive'],
+      fixedLengthSessionWarningTTL: '60s'
     }
   },
   okapi: {


### PR DESCRIPTION
## Purpose

[STCOR-884](https://folio-org.atlassian.net/browse/STCOR-884) - IST modal with long TTL shows even when FLST warning with short TTL is already displayed

## Approach
The issue was that the `fixedLengthSessionTimeout` timer had a life of its own, and we didn’t have access to it in `SessionEventContainer` to determine whether we could trigger the keepWorking modal.
Just lift the fls timer state up and check if it is less than `idleModalTTL`. If so, don’t show the keepWorking modal; otherwise, show it.



