### PR TITLE
STCOR-962 set default idle session timeout to 4h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Improve useModuleInfo hook. Refs STCOR-955.
 * Provide `useQueryLimit()` hook. Refs STCOR-616, STCOR-617.
 * Show user-friendly labels on ECS pre-login screen. Refs STCOR-899.
+* Change default Idle Session Timeout to `4h` from `1h`. Refs STCOR-962.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/components/Root/constants.js
+++ b/src/components/Root/constants.js
@@ -57,7 +57,7 @@ export const RTR_ACTIVITY_EVENTS = ['keydown', 'mousedown'];
  * overridden in stripes.config.js::config.rtr.idleSessionTTL
  * value must be a string parsable by ms()
  */
-export const RTR_IDLE_SESSION_TTL = '60m';
+export const RTR_IDLE_SESSION_TTL = '4h';
 
 /**
  * how long is the "keep working?" modal visible

--- a/src/components/Root/token-util.test.js
+++ b/src/components/Root/token-util.test.js
@@ -344,7 +344,7 @@ describe('getPromise', () => {
 describe('configureRtr', () => {
   it('sets idleSessionTTL and idleModalTTL', () => {
     const res = configureRtr({});
-    expect(res.idleSessionTTL).toBe('60m');
+    expect(res.idleSessionTTL).toBe('4h');
     expect(res.idleModalTTL).toBe('1m');
   });
 


### PR DESCRIPTION
Change the default idle session timeout to `4h` from the arbitrary, insufficient, and inconvenient `1h` value that was set in PR #1463.

Refs [STCOR-962](https://folio-org.atlassian.net/browse/STCOR-962)