### PR TITLE
STCOR-964: Sort app navigation by localized displayName by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Improve useModuleInfo hook. Refs STCOR-955.
 * Provide `useQueryLimit()` hook. Refs STCOR-616, STCOR-617.
 * Show user-friendly labels on ECS pre-login screen. Refs STCOR-899.
+* Sort app links in the main navigation by their `displayName` by default. Refs STCOR-964.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/components/MainNav/AppOrderProvider.js
+++ b/src/components/MainNav/AppOrderProvider.js
@@ -2,6 +2,7 @@ import { createContext, useContext, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { useQuery } from 'react-query';
+import sortBy from 'lodash/sortBy';
 
 import { useStripes } from '../../StripesContext';
 import { useModules } from '../../ModulesContext';
@@ -103,7 +104,7 @@ function getAllowedApps(appModules, stripes, pathname, lastVisited, formatMessag
       route: SETTINGS_ROUTE
     });
   }
-  return apps;
+  return sortBy(apps, ['displayName']);
 }
 
 /**

--- a/src/components/MainNav/AppOrderProvider.test.js
+++ b/src/components/MainNav/AppOrderProvider.test.js
@@ -117,20 +117,8 @@ const testAppModules = [
   }
 ];
 
-// default order - same as config.
+// default order - sorted by displayName.
 const testOrderedNoPref = [
-  {
-    id: 'clickable-invoice-module',
-    href: '/invoice',
-    active: false,
-    name: 'invoice',
-    displayName: 'Invoices',
-    route: '/invoice',
-    queryResource: 'query',
-    module: '@folio/invoice',
-    description: 'Invoice',
-    version: '6.1.1090000001259'
-  },
   {
     id: 'clickable-agreements-module',
     href: '/erm/agreements',
@@ -169,14 +157,23 @@ const testOrderedNoPref = [
     description: 'Item Check-in',
     version: '9.3.109000000926'
   },
+  {
+    id: 'clickable-invoice-module',
+    href: '/invoice',
+    active: false,
+    name: 'invoice',
+    displayName: 'Invoices',
+    route: '/invoice',
+    queryResource: 'query',
+    module: '@folio/invoice',
+    description: 'Invoice',
+    version: '6.1.1090000001259'
+  },
   ...settingsOnly
 ];
 
-// default order preference (value that's derived when no user preferred order is present) - same order as config.
+// default order preference (value that's derived when no user preferred order is present) - ordered by displayName of the original app objects.
 const testPreferencedOrderNoPref = [
-  {
-    name: 'invoice',
-  },
   {
     name: 'agreements',
   },
@@ -185,6 +182,9 @@ const testPreferencedOrderNoPref = [
   },
   {
     name: 'checkin',
+  },
+  {
+    name: 'invoice',
   },
   {
     name: 'settings',


### PR DESCRIPTION
Currently, apps order defaults to the order from stripes-config. This is not-as-nice for users when they reset defaults and expect to have a predictable time finding their app's name in the list so that they can move it to it's preferred position.

This PR sorts them by localized `displayName` to save their eyes.