### PR TITLE
STCOR-967: allow customizing request timeout in useOkapiKy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Change default Idle Session Timeout to `4h` from `1h`. Refs STCOR-962.
 * Prune unused `./utils/` scripts, deps. Refs STCOR-959.
 * Don't show IST modal if `flsTimeRemaining` less than config.rtr.idleModalTTL. STCOR-884.
+* Allow customizing request timeout in `useOkapiKy`. STCOR-967.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/useOkapiKy.js
+++ b/src/useOkapiKy.js
@@ -1,8 +1,8 @@
 import ky from 'ky';
 import { useStripes } from './StripesContext';
 
-export default ({ tenant } = {}) => {
-  const { locale = 'en', timeout = 30000, tenant: currentTenant, token, url } = useStripes().okapi;
+export default ({ tenant, timeout } = {}) => {
+  const { locale = 'en', timeout: defaultTimeout = 30000, tenant: currentTenant, token, url } = useStripes().okapi;
 
   return ky.create({
     credentials: 'include',
@@ -20,6 +20,6 @@ export default ({ tenant } = {}) => {
     mode: 'cors',
     prefixUrl: url,
     retry: 0,
-    timeout,
+    timeout: timeout || defaultTimeout,
   });
 };

--- a/src/useOkapiKy.test.js
+++ b/src/useOkapiKy.test.js
@@ -26,11 +26,11 @@ describe('useOkapiKy', () => {
       }
     };
 
-    const { result } = renderHook(() => useOkapiKy());
+    const { result } = renderHook(() => useOkapiKy({ timeout: 30 }));
     result.current.hooks.beforeRequest[0](r);
 
     expect(result.current.prefixUrl).toBe(okapi.url);
-    expect(result.current.timeout).toBe(okapi.timeout);
+    expect(result.current.timeout).toBe(30);
 
     expect(r.headers.set).toHaveBeenCalledWith('Accept-Language', okapi.locale);
     expect(r.headers.set).toHaveBeenCalledWith('X-Okapi-Tenant', okapi.tenant);
@@ -74,6 +74,7 @@ describe('useOkapiKy', () => {
 
     const { result } = renderHook(() => useOkapiKy({ tenant: 'monkey' }));
     result.current.hooks.beforeRequest[0](r);
+    expect(result.current.timeout).toBe(okapi.timeout);
 
     expect(r.headers.set).toHaveBeenCalledWith('X-Okapi-Tenant', 'monkey');
   });


### PR DESCRIPTION
Refs [STCOR-967](https://folio-org.atlassian.net/browse/STCOR-967). 