### PR TITLE
STCOR-970 validateUser should return null on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Don't show IST modal if `flsTimeRemaining` less than config.rtr.idleModalTTL. STCOR-884.
 * Allow customizing request timeout in `useOkapiKy`. STCOR-967.
 * Enhance locale management to support user and tenant locale configurations from both mod-configuration and mod-settings. STCOR-968.
+* When a session-restart request fails, trap errors and purge both redux and browser-storage. Refs STCOR-970. 
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/components/SSOLogin/SSOLogin.js
+++ b/src/components/SSOLogin/SSOLogin.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@folio/stripes-components';
-import styles from '../CreateResetPassword/CreateResetPassword.css';
+import styles from '../Login/Login.css';
 
 const propTypes = {
   handleSSOLogin: PropTypes.func.isRequired,
@@ -19,7 +19,7 @@ function SSOLogin(props) {
         data-test-sso-login-button
         buttonStyle="primary"
         type="button"
-        buttonClass={styles.submitButton}
+        buttonClass={styles.loginSubmitButton}
         fullWidth
         onClick={handleSSOLogin}
       >

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -21,7 +21,6 @@ import {
   setAuthError,
   checkSSO,
   setOkapiReady,
-  setServerDown,
   setSessionData,
   setLoginData,
   updateCurrentUser,
@@ -992,18 +991,26 @@ export function processOkapiSession(store, tenant, resp, ssoToken) {
 
 /**
  * validateUser
- * return a promise that fetches from .../_self.
- * if successful, dispatch the result to create a session
- * if not, clear the session and token.
+ * Data in localstorage has led us to believe a session is active. To confirm,
+ * fetch from .../_self and dispatch the results, allowing any changes to authz
+ * since that session data was persisted to take effect immediately.
+ *
+ * If the fetch succeeds, dispatch the result to update the session.
+ * Otherwise, call logout() to purge redux and storage because either:
+ *   1. the session data was corrupt. yikes!
+ *   2. the session data was valid but cookies were missing. yikes!
+ * Either way, our belief that a session is active has been proven wrong, so
+ * we want to clear out all relevant storage.
  *
  * @param {string} okapiUrl
  * @param {redux store} store
  * @param {string} tenant
  * @param {object} session
+ * @param {function} handleError error-handler function; returns a Promise that returns null
  *
  * @returns {Promise}
  */
-export function validateUser(okapiUrl, store, tenant, session) {
+export function validateUser(okapiUrl, store, tenant, session, handleError) {
   const { token, tenant: sessionTenant = tenant } = session;
   const usersPath = store.getState()?.okapi?.authnUrl ? 'users-keycloak' : 'bl-users';
   return fetch(`${okapiUrl}/${usersPath}/_self?expandPermissions=true`, {
@@ -1044,15 +1051,14 @@ export function validateUser(okapiUrl, store, tenant, session) {
         return loadResources(store, sessionTenant, user.id);
       });
     } else {
-      store.dispatch(clearCurrentUser());
-      return resp.text((text) => {
+      return resp.text().then(text => {
         throw text;
       });
     }
   }).catch((error) => {
+    // log a warning, then call the error handler if we received one
     console.error(error); // eslint-disable-line no-console
-    store.dispatch(setServerDown());
-    return error;
+    return handleError ? handleError() : Promise.resolve();
   });
 }
 
@@ -1071,7 +1077,8 @@ export function validateUser(okapiUrl, store, tenant, session) {
 export function checkOkapiSession(okapiUrl, store, tenant) {
   getOkapiSession()
     .then((sess) => {
-      return sess?.user?.id ? validateUser(okapiUrl, store, tenant, sess) : null;
+      const handleError = () => logout(okapiUrl, store);
+      return sess?.user?.id ? validateUser(okapiUrl, store, tenant, sess, handleError) : null;
     })
     .then((res) => {
       // check whether SSO is enabled if either

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -290,11 +290,13 @@ describe('validateUser', () => {
       dispatch: jest.fn(),
       getState: () => ({ okapi: { tenant: 'monkey', url: 'monkeyUrl' } }),
     };
+    const handleError = jest.fn().mockReturnValue(Promise.resolve());
 
     mockFetchError();
 
-    await validateUser('url', store, 'tenant', {});
-    expect(store.dispatch).toHaveBeenCalledWith(setServerDown());
+    const res = await validateUser('url', store, 'tenant', {}, handleError);
+    expect(handleError).toHaveBeenCalled();
+    expect(res).toBeUndefined();
     mockFetchCleanUp();
   });
 
@@ -407,14 +409,15 @@ describe('validateUser', () => {
       dispatch: jest.fn(),
       getState: () => ({ okapi: { tenant: 'monkey', url: 'monkeyUrl' } }),
     };
+    const handleError = jest.fn().mockReturnValue(Promise.resolve());
 
     global.fetch = jest.fn().mockImplementation(() => {
-      return Promise.resolve({ ok: false });
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('boom') });
     });
 
-    await validateUser('url', store, 'tenant', {});
-    expect(store.dispatch).toHaveBeenCalledWith(clearCurrentUser());
-    expect(store.dispatch).toHaveBeenCalledWith(setServerDown());
+    const res = await validateUser('url', store, 'tenant', {}, handleError);
+    expect(handleError).toHaveBeenCalled();
+    expect(res).toBeUndefined();
     mockFetchCleanUp();
   });
 });


### PR DESCRIPTION
`validateUser()` is expected to return session data on success or null on failure. Previously, it wrongly returned an error message on failure, causing its calling function (`checkOkapiSession()`) to act as though an existing session were being restored (which of course is not the case given that session restoration had just failed...) and skip the SSO-check that happens only once, when stripes is initializing.

Related, restore the CSS for the "Log in via SSO" button so it remains prominently visible when it is present.

## Approach

If cookies are revoked for any reason -- maybe a user deletes them, maybe the backend revokes them -- then the UI will be in a state where it has valid session data in redux and in localstorage, but it no longer has the corresponding cookies. This is an awkward state for Stripes, because it doesn't know it's in this state, because the cookies are HTTPOnly, so it never knows if cookies are acutally present.

When reloading, the valid-session/invalid-cookies state was particularly problematic. Stripes would find session data in storage and thus try to restore the session with a request to `.../_self`, a request which would fail due to the missing cookies. Because `validateUser()` was incorrectly returning an error message, however, this caused Stripes to skip the SSO-check that normally runs when Stripes is initializing without an active session.

Minor refactoring of `checkOkapiSession()` and `validateUser()` (the former now passes an error-handler to the latter, because DI simplifies testing) is a happy side-effect. The actual bug being squashed is that `validateUser()` now returns undefined on error, and correctly calls an error-handler.

Refs [STCOR-970](https://folio-org.atlassian.net/browse/STCOR-970)