### PR TITLE
STCOR-968: Use the isEnabled flag, which specifies whether tenant settings should be applied when handling locale (follow-up).

### DIFF
--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -531,8 +531,7 @@ const processLocaleSettings = (store, tenantLocaleData, userLocaleData) => {
   let timezone = userLocaleSettings?.timezone || tenantLocaleSettings?.timezone;
   let currency = userLocaleSettings?.currency || tenantLocaleSettings?.currency;
 
-  // we should use tenant's settings if user has not set their own locale or their locale is the same as tenant's locale
-  if (!userLocaleSettings?.locale || userLocaleSettings?.locale === tenantLocaleSettings?.locale) {
+  if (!userLocaleSettings?.isEnabled) {
     locale = tenantLocaleSettings?.locale;
     numberingSystem = tenantLocaleSettings?.numberingSystem;
     timezone = tenantLocaleSettings?.timezone;


### PR DESCRIPTION
## Description
User locale settings must follow the tenant's locale settings when the tenant's locale is selected in `Settings - My profile - language localization`. Currently in stripes-core we apply the tenant's locale settings only if user has not set their own locale or their locale is the same as the tenant's locale `if (!userLocaleSettings?.locale || userLocaleSettings?.locale === tenantLocaleSettings?.locale) {}`, but the tenant's locale can be changed and the condition ` userLocaleSettings?.locale === tenantLocaleSettings?.locale` will not be true anymore. The solution is to add the `isEnabled` flag which will indicate whether we need to use user's settings or not. The flag is added in https://github.com/folio-org/ui-myprofile/pull/252.

The recording of the issue is the first [video ](https://folio-org.atlassian.net/browse/UIMPROF-107?focusedCommentId=263844).

## Issues
[STCOR-968](https://folio-org.atlassian.net/browse/STCOR-968)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Screencasts

https://github.com/user-attachments/assets/96908ea3-a7f2-49d4-93fd-61483463ee92