### PR TITLE
STCOR-972 passing tenant as a URL param to keycloak redirect_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 * Don't show IST modal if `flsTimeRemaining` less than config.rtr.idleModalTTL. STCOR-884.
 * Allow customizing request timeout in `useOkapiKy`. STCOR-967.
 * Enhance locale management to support user and tenant locale configurations from both mod-configuration and mod-settings. STCOR-968.
-* When a session-restart request fails, trap errors and purge both redux and browser-storage. Refs STCOR-970. 
+* When a session-restart request fails, trap errors and purge both redux and browser-storage. Refs STCOR-970.
+* For OIDC login - store `tenant` and `clientId` in `redirect_uri` url parameter, instead of localStorage. Refs STCOR-972.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/App.js
+++ b/src/App.js
@@ -76,6 +76,8 @@ export default class StripesCore extends Component {
       const okapi = (typeof okapiConfig === 'object' && Object.keys(okapiConfig).length > 0)
         ? { ...okapiConfig, tenant: parsedTenant?.tenantName || okapiConfig.tenant, clientId: parsedTenant?.clientId || okapiConfig.clientId } : { withoutOkapi: true };
 
+
+      console.log(`Okapi tenant is ${okapi.tenant}`);
       const initialState = merge({}, { okapi }, props.initialState);
 
       this.logger = configureLogger(config);

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import css from './components/SessionEventContainer/style.css';
 
 import Root from './components/Root';
 import { eventsPortal } from './constants';
-import { getStoredTenant } from './loginServices';
+import { getTenantAndClientIdFromLoginURL } from './loginServices';
 
 const StrictWrapper = ({ children }) => {
   if (config.disableStrictMode) {
@@ -71,7 +71,7 @@ export default class StripesCore extends Component {
     super(props);
 
     if (isStorageEnabled()) {
-      const parsedTenant = getStoredTenant();
+      const parsedTenant = getTenantAndClientIdFromLoginURL();
 
       const okapi = (typeof okapiConfig === 'object' && Object.keys(okapiConfig).length > 0)
         ? { ...okapiConfig, tenant: parsedTenant?.tenantName || okapiConfig.tenant, clientId: parsedTenant?.clientId || okapiConfig.clientId } : { withoutOkapi: true };

--- a/src/App.js
+++ b/src/App.js
@@ -76,8 +76,6 @@ export default class StripesCore extends Component {
       const okapi = (typeof okapiConfig === 'object' && Object.keys(okapiConfig).length > 0)
         ? { ...okapiConfig, tenant: parsedTenant?.tenantName || okapiConfig.tenant, clientId: parsedTenant?.clientId || okapiConfig.clientId } : { withoutOkapi: true };
 
-
-      console.log(`Okapi tenant is ${okapi.tenant}`);
       const initialState = merge({}, { okapi }, props.initialState);
 
       this.logger = configureLogger(config);

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -5,7 +5,10 @@ import PreLoginLanding from '../PreLoginLanding';
 import Login from '../Login';
 
 import { setOkapiTenant } from '../../okapiActions';
-import { setUnauthorizedPathToSession } from '../../loginServices';
+import {
+  setUnauthorizedPathToSession,
+  getOIDCRedirectUri,
+} from '../../loginServices';
 
 const AuthnLogin = ({ stripes }) => {
   const { config, okapi } = stripes;
@@ -52,7 +55,7 @@ const AuthnLogin = ({ stripes }) => {
     // If only 1 tenant is defined in config, skip the tenant selection screen.
     if (tenants.length === 1) {
       const loginTenant = tenants[0];
-      const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;
+      const redirectUri = getOIDCRedirectUri(loginTenant.name, loginTenant.clientId);
       const authnUri = `${okapi.authnUrl}/realms/${loginTenant.name}/protocol/openid-connect/auth?client_id=${loginTenant.clientId}&response_type=code&redirect_uri=${redirectUri}&scope=openid`;
       return <Redirect to={authnUri} />;
     }

--- a/src/components/AuthnLogin/AuthnLogin.js
+++ b/src/components/AuthnLogin/AuthnLogin.js
@@ -14,7 +14,6 @@ const AuthnLogin = ({ stripes }) => {
   const tenants = Object.values(tenantOptions);
 
   const setTenant = (tenant, clientId) => {
-    localStorage.setItem('tenant', JSON.stringify({ tenantName: tenant, clientId }));
     stripes.store.dispatch(setOkapiTenant({ tenant, clientId }));
   };
 

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -10,7 +10,7 @@ import { ConnectContext } from '@folio/stripes-connect';
 import {
   requestLogin,
   requestSSOLogin,
-  TENANT_LOCAL_STORAGE_KEY,
+  storeLogoutTenant,
 } from '../../loginServices';
 import { setAuthError } from '../../okapiActions';
 import Login from './Login';
@@ -55,7 +55,7 @@ class LoginCtrl extends Component {
 
     // need to store tenant id in localStorage for logout purposes
     // `logout` function in loginServices.js provides details about this.
-    localStorage.setItem(TENANT_LOCAL_STORAGE_KEY, JSON.stringify({ tenantName: this.tenant }));
+    storeLogoutTenant(this.tenant);
   }
 
   handleSubmit = (data) => {

--- a/src/components/Login/LoginCtrl.js
+++ b/src/components/Login/LoginCtrl.js
@@ -10,6 +10,7 @@ import { ConnectContext } from '@folio/stripes-connect';
 import {
   requestLogin,
   requestSSOLogin,
+  TENANT_LOCAL_STORAGE_KEY,
 } from '../../loginServices';
 import { setAuthError } from '../../okapiActions';
 import Login from './Login';
@@ -51,6 +52,10 @@ class LoginCtrl extends Component {
     if (matchPath(this.props.location.pathname, '/login')) {
       this.props.history.push('/');
     }
+
+    // need to store tenant id in localStorage for logout purposes
+    // `logout` function in loginServices.js provides details about this.
+    localStorage.setItem(TENANT_LOCAL_STORAGE_KEY, JSON.stringify({ tenantName: this.tenant }));
   }
 
   handleSubmit = (data) => {

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -17,7 +17,7 @@ import {
   getOIDCRedirectUri,
   requestUserWithPerms,
   setTokenExpiry,
-  TENANT_LOCAL_STORAGE_KEY,
+  storeLogoutTenant,
 } from '../loginServices';
 import { useStripes } from '../StripesContext';
 
@@ -87,9 +87,9 @@ const OIDCLanding = () => {
               })
               .then(() => {
                 // for login itself we're storing selected tenant and clientId in the url
-                // but we still need to store the same data in localStorage for logout purposes
+                // but we still need to store tenantId in localStorage for logout purposes
                 // `logout` function in loginServices.js provides details about this.
-                localStorage.setItem(TENANT_LOCAL_STORAGE_KEY, JSON.stringify({ tenantName: okapi.tenant, clientId: okapi.clientId }));
+                storeLogoutTenant(okapi.tenant);
               });
           } else {
             return resp.json().then((error) => {

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -13,10 +13,14 @@ import {
 } from '@folio/stripes-components';
 
 import OrganizationLogo from './OrganizationLogo';
-import { requestUserWithPerms, setTokenExpiry } from '../loginServices';
+import {
+  getOIDCRedirectUri,
+  requestUserWithPerms,
+  setTokenExpiry,
+} from '../loginServices';
+import { useStripes } from '../StripesContext';
 
 import css from './Front.css';
-import { useStripes } from '../StripesContext';
 
 /**
  * OIDCLanding: un-authenticated route handler for /oidc-landing.
@@ -60,8 +64,10 @@ const OIDCLanding = () => {
 
     const otp = getOtp();
 
+    const redirectUri = getOIDCRedirectUri(okapi.tenant, okapi.clientId);
+
     if (otp) {
-      fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${window.location.protocol}//${window.location.host}/oidc-landing`, {
+      fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${redirectUri}`, {
         credentials: 'include',
         headers: { 'X-Okapi-tenant': okapi.tenant, 'Content-Type': 'application/json' },
         mode: 'cors',

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -17,6 +17,7 @@ import {
   getOIDCRedirectUri,
   requestUserWithPerms,
   setTokenExpiry,
+  TENANT_LOCAL_STORAGE_KEY,
 } from '../loginServices';
 import { useStripes } from '../StripesContext';
 
@@ -83,6 +84,12 @@ const OIDCLanding = () => {
               })
               .then(() => {
                 return requestUserWithPerms(okapi.url, store, okapi.tenant);
+              })
+              .then(() => {
+                // for login itself we're storing selected tenant and clientId in the url
+                // but we still need to store the same data in localStorage for logout purposes
+                // `logout` function in loginServices.js provides details about this.
+                localStorage.setItem(TENANT_LOCAL_STORAGE_KEY, JSON.stringify({ tenantName: okapi.tenant, clientId: okapi.clientId }));
               });
           } else {
             return resp.json().then((error) => {

--- a/src/components/OIDCLanding.test.js
+++ b/src/components/OIDCLanding.test.js
@@ -29,6 +29,7 @@ jest.mock('../loginServices', () => ({
   setTokenExpiry: () => mockSetTokenExpiry(),
   requestUserWithPerms: () => mockRequestUserWithPerms(),
   foo: () => mockFoo(),
+  getOIDCRedirectUri: () => '',
 }));
 
 

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -1,16 +1,18 @@
 import React, { useRef } from 'react';
-import { Button, Select, Col, Row } from '@folio/stripes-components';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
+
+import { Button, Select, Col, Row } from '@folio/stripes-components';
 import OrganizationLogo from '../OrganizationLogo';
-import styles from './index.css';
 import { useStripes } from '../../StripesContext';
+import { getOIDCRedirectUri } from '../../loginServices';
+import styles from './index.css';
 
 function PreLoginLanding({ onSelectTenant }) {
   const intl = useIntl();
   const { okapi, config: { tenantOptions = {} } } = useStripes();
 
-  const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing?tenant=${okapi.tenant}`;
+  const redirectUri = getOIDCRedirectUri(okapi.tenant, okapi.clientId);
   const options = Object.values(tenantOptions).map(i => ({ value: i.name, label: i.displayName ?? i.name }));
 
   const getLoginUrl = () => {

--- a/src/components/PreLoginLanding/PreLoginLanding.js
+++ b/src/components/PreLoginLanding/PreLoginLanding.js
@@ -10,7 +10,7 @@ function PreLoginLanding({ onSelectTenant }) {
   const intl = useIntl();
   const { okapi, config: { tenantOptions = {} } } = useStripes();
 
-  const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing`;
+  const redirectUri = `${window.location.protocol}//${window.location.host}/oidc-landing?tenant=${okapi.tenant}`;
   const options = Object.values(tenantOptions).map(i => ({ value: i.name, label: i.displayName ?? i.name }));
 
   const getLoginUrl = () => {

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -136,13 +136,20 @@ export const getOIDCRedirectUri = (tenant, clientId) => {
   return encodeURIComponent(`${window.location.protocol}//${window.location.host}/oidc-landing?tenant=${tenant}&client_id=${clientId}`);
 };
 
-export const getStoredTenant = () => {
+export const getTenantAndClientIdFromLoginURL = () => {
   const urlParams = new URLSearchParams(window.location.search);
 
   return {
     tenantName: urlParams.get('tenant'),
     clientId: urlParams.get('client_id'),
   };
+};
+
+export const TENANT_LOCAL_STORAGE_KEY = 'tenant';
+
+export const getStoredTenant = () => {
+  const storedTenant = localStorage.getItem(TENANT_LOCAL_STORAGE_KEY);
+  return storedTenant ? JSON.parse(storedTenant) : undefined;
 };
 
 // export config values for storing user locale

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -767,6 +767,7 @@ export async function logout(okapiUrl, store, queryClient) {
     // clear shared storage
     .then(localforage.removeItem(SESSION_NAME))
     .then(localforage.removeItem('loginResponse'))
+    .then(() => localStorage.removeItem(TENANT_LOCAL_STORAGE_KEY))
     .catch(e => {
       console.error('error during logout', e); // eslint-disable-line no-console
     })

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -131,12 +131,18 @@ export const setUnauthorizedPathToSession = (pathname) => {
 };
 export const getUnauthorizedPathFromSession = () => sessionStorage.getItem(UNAUTHORIZED_PATH);
 
-const TENANT_LOCAL_STORAGE_KEY = 'tenant';
+export const getOIDCRedirectUri = (tenant, clientId) => {
+  // we need to use `encodeURIComponent` to separate `redirect_uri` URL parameters from the rest of URL parameters that `redirect_uri` itself is part of
+  return encodeURIComponent(`${window.location.protocol}//${window.location.host}/oidc-landing?tenant=${tenant}&client_id=${clientId}`);
+};
+
 export const getStoredTenant = () => {
-  // This is WIP
-  return { tenantName: new URLSearchParams(window.location.search).get('tenant') };
-  // const storedTenant = localStorage.getItem(TENANT_LOCAL_STORAGE_KEY);
-  // return storedTenant ? JSON.parse(storedTenant) : undefined;
+  const urlParams = new URLSearchParams(window.location.search);
+
+  return {
+    tenantName: urlParams.get('tenant'),
+    clientId: urlParams.get('client_id'),
+  };
 };
 
 // export config values for storing user locale

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -133,8 +133,10 @@ export const getUnauthorizedPathFromSession = () => sessionStorage.getItem(UNAUT
 
 const TENANT_LOCAL_STORAGE_KEY = 'tenant';
 export const getStoredTenant = () => {
-  const storedTenant = localStorage.getItem(TENANT_LOCAL_STORAGE_KEY);
-  return storedTenant ? JSON.parse(storedTenant) : undefined;
+  // This is WIP
+  return { tenantName: new URLSearchParams(window.location.search).get('tenant') };
+  // const storedTenant = localStorage.getItem(TENANT_LOCAL_STORAGE_KEY);
+  // return storedTenant ? JSON.parse(storedTenant) : undefined;
 };
 
 // export config values for storing user locale

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -30,6 +30,7 @@ import {
   loadResources,
   getOIDCRedirectUri,
   getStoredTenant,
+  getLogoutTenant,
 } from './loginServices';
 
 import { discoverServices } from './discoverServices';
@@ -742,15 +743,15 @@ describe('unauthorizedPath functions', () => {
     });
   });
 
-  describe('getStoredTenant', () => {
+  describe('getLogoutTenant', () => {
     afterEach(() => {
       localStorage.clear();
     });
 
     it('retrieves the value from localstorage', () => {
-      const value = { tenantName: 'diku', clientId: 'diku-id' };
+      const value = { tenantId: 'diku' };
       localStorage.setItem('tenant', JSON.stringify(value));
-      const parsedTenant = getStoredTenant();
+      const parsedTenant = getLogoutTenant();
       expect(parsedTenant).toStrictEqual(value);
     });
   });

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -740,19 +740,6 @@ describe('unauthorizedPath functions', () => {
     });
   });
 
-  describe('getStoredTenant', () => {
-    afterEach(() => {
-      localStorage.clear();
-    });
-    it('retrieves the value from localstorage', () => {
-      const value = { tenantName: 'diku', clientId: 'diku-id' };
-      localStorage.setItem('tenant', JSON.stringify(value));
-      const parsedTenant = getStoredTenant();
-
-      expect(parsedTenant).toStrictEqual(value);
-    });
-  });
-
   describe('requestLogin', () => {
     afterEach(() => {
       mockFetchCleanUp();

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -23,7 +23,7 @@ import {
   updateUser,
   validateUser,
   IS_LOGGING_OUT,
-  SESSION_NAME, getStoredTenant,
+  SESSION_NAME,
   requestLogin,
   requestUserWithPerms,
   fetchOverriddenUserWithPerms,

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -28,6 +28,7 @@ import {
   requestUserWithPerms,
   fetchOverriddenUserWithPerms,
   loadResources,
+  getOIDCRedirectUri,
 } from './loginServices';
 
 import { discoverServices } from './discoverServices';
@@ -737,6 +738,18 @@ describe('unauthorizedPath functions', () => {
       const value = 'monkey';
       setUnauthorizedPathToSession(value);
       expect(getUnauthorizedPathFromSession()).toBe(value);
+    });
+  });
+
+  describe('getOIDCRedirectUri', () => {
+    it('should return encoded return_uri', () => {
+      window.location.protocol = 'http';
+      window.location.host = 'localhost';
+
+      const tenant = 'tenant';
+      const clientId = 'client_id';
+
+      expect(getOIDCRedirectUri(tenant, clientId)).toEqual('http%3A%2F%2Flocalhost%2Foidc-landing%3Ftenant%3Dtenant%26client_id%3Dclient_id');
     });
   });
 

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -29,6 +29,7 @@ import {
   fetchOverriddenUserWithPerms,
   loadResources,
   getOIDCRedirectUri,
+  getStoredTenant,
 } from './loginServices';
 
 import { discoverServices } from './discoverServices';
@@ -738,6 +739,19 @@ describe('unauthorizedPath functions', () => {
       const value = 'monkey';
       setUnauthorizedPathToSession(value);
       expect(getUnauthorizedPathFromSession()).toBe(value);
+    });
+  });
+
+  describe('getStoredTenant', () => {
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('retrieves the value from localstorage', () => {
+      const value = { tenantName: 'diku', clientId: 'diku-id' };
+      localStorage.setItem('tenant', JSON.stringify(value));
+      const parsedTenant = getStoredTenant();
+      expect(parsedTenant).toStrictEqual(value);
     });
   });
 


### PR DESCRIPTION
## Description
I'm going to use @zburke explanation on this because I couldn't have explained the issue better myself

> In an ECS setup, there are three required steps to authentication; keycloak is step-2, and skipping step-1 causes step-3 to fail:
> 1. choose a tenant and save it to local-storage, then redirect to keycloak
> 2. authenticate in keycloak, then redirect to stripes with an OTP in the URL
> 3. make an API request to trade the OTP for AT/RT cookies, /authn/token?otp=${OTP from step-2} with the X-Okapi-Tenant header set to the tenant from step-1
>
> Bookmarking the authentication URL in step-2 means the tenant is never stored to local-storage, thus causing step-3 to fail. 
IIRC, we can pass values to Keycloak in the URL and it will include them along with the OTP when it redirects back to Stripes.

Instead of storing selected `tenant` and `client_id` in `localStorage`, we can in step 1 pass them as part of `redirect_uri`, so that we can read them from url and use in step 3.
We're still keeping code related to storing tenant in localStorage, because we actually need to keep the tenant that a user has initially logged in with, so if they change affiliation - we can logout with the initial tenant.

## Screenshots

https://github.com/user-attachments/assets/6c031f1d-5659-4049-99fc-419af59bbce8



## Issues
[STCOR-972](https://folio-org.atlassian.net/browse/STCOR-972)