### PR TITLE
STCOR-983: Remove `RTR_IS_ROTATING` from local storage before dispatching the `RTR_SUCCESS_EVENT` to correctly determine the `RTR_IS_ROTATING` state in the `rotationHandler` function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Disclose personal data disclosure (i.e. user data cached in storage). Refs STCOR-973.
 * Removed code that switches locale, numbering system etc to tenant settings when user doesn't have a locale preference. Refs STCOR-981.
 * Implement active window id/messaging for RTR functionality. The last window/tab the user interacted with will handle token rotation. Refs STCOR-978.
+* Remove `RTR_IS_ROTATING` from local storage before dispatching the `RTR_SUCCESS_EVENT` to correctly determine the `RTR_IS_ROTATING` state in the `rotationHandler` function. Refs STCOR-983.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -287,14 +287,15 @@ export const rtr = (fetchfx, logger, callback, okapi) => {
         rtExpires: new Date(json.refreshTokenExpiration).getTime(),
       };
       setTokenExpiry(te);
+      // Removing `RTR_IS_ROTATING` from local storage must be done before dispatching the `RTR_SUCCESS_EVENT`
+      // to correctly determine the `RTR_IS_ROTATING` state in the `rotationHandler` function.
+      localStorage.removeItem(RTR_IS_ROTATING);
       window.dispatchEvent(new Event(RTR_SUCCESS_EVENT));
     })
     .catch((err) => {
       console.error('RTR_ERROR_EVENT', err); // eslint-disable-line no-console
-      window.dispatchEvent(new Event(RTR_ERROR_EVENT));
-    })
-    .finally(() => {
       localStorage.removeItem(RTR_IS_ROTATING);
+      window.dispatchEvent(new Event(RTR_ERROR_EVENT));
     });
 };
 

--- a/src/components/Root/token-util.test.js
+++ b/src/components/Root/token-util.test.js
@@ -11,7 +11,10 @@ import {
   RTR_IS_ROTATING,
   RTR_MAX_AGE,
 } from './token-util';
-import { RTR_SUCCESS_EVENT } from './constants';
+import { 
+  RTR_SUCCESS_EVENT,
+  RTR_ERROR_EVENT,
+} from './constants';
 
 const okapi = {
   tenant: 'diku',
@@ -275,6 +278,81 @@ describe('rtr', () => {
     expect(console.error).toHaveBeenCalledWith('RTR_ERROR_EVENT', expect.any(RTRError));
     expect(window.dispatchEvent).toHaveBeenCalledWith(expect.any(Event));
     expect(ex).toBe(null);
+  });
+
+  it('should remove RTR_IS_ROTATING from localStorage before dispatching RTR_SUCCESS_EVENT', async () => {
+    const logger = {
+      log: jest.fn(),
+    };
+    const fetchfx = {
+      apply: () => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          accessTokenExpiration: '2023-11-17T10:39:15.000Z',
+          refreshTokenExpiration: '2023-11-27T10:39:15.000Z'
+        }),
+      })
+    };
+
+    const mockRemoveItem = jest.spyOn(Storage.prototype, 'removeItem');
+    const mockDispatchEvent = jest.spyOn(window, 'dispatchEvent');
+
+    let removalBeforeDispatch = false;
+    mockDispatchEvent.mockImplementation((event) => {
+      if (event.type === RTR_SUCCESS_EVENT) {
+        removalBeforeDispatch = mockRemoveItem.mock.calls.some(call => call[0] === RTR_IS_ROTATING);
+      }
+      return true;
+    });
+
+    await rtr(fetchfx, logger, jest.fn(), okapi);
+
+    expect(removalBeforeDispatch).toBe(true);
+    expect(mockRemoveItem).toHaveBeenCalledWith(RTR_IS_ROTATING);
+    expect(mockDispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: RTR_SUCCESS_EVENT })
+    );
+
+    mockRemoveItem.mockRestore();
+    mockDispatchEvent.mockRestore();
+  });
+
+  it('should remove RTR_IS_ROTATING from localStorage before dispatching RTR_ERROR_EVENT on error', async () => {
+    const logger = {
+      log: jest.fn(),
+    };
+    const errors = [{ message: 'Token refresh failed', code: 'AUTH_ERROR' }];
+    const fetchfx = {
+      apply: () => Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({
+          errors,
+        }),
+      })
+    };
+
+    const mockRemoveItem = jest.spyOn(Storage.prototype, 'removeItem');
+    const mockDispatchEvent = jest.spyOn(window, 'dispatchEvent');
+    jest.spyOn(console, 'error');
+
+    let removalBeforeDispatch = false;
+    mockDispatchEvent.mockImplementation((event) => {
+      if (event.type === RTR_ERROR_EVENT) {
+        removalBeforeDispatch = mockRemoveItem.mock.calls.some(call => call[0] === RTR_IS_ROTATING);
+      }
+      return true;
+    });
+
+    await rtr(fetchfx, logger, jest.fn(), okapi);
+
+    expect(removalBeforeDispatch).toBe(true);
+    expect(mockRemoveItem).toHaveBeenCalledWith(RTR_IS_ROTATING);
+    expect(mockDispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: RTR_ERROR_EVENT })
+    );
+
+    mockRemoveItem.mockRestore();
+    mockDispatchEvent.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Description

When a `/authn/refresh` request is triggered, and a new request is made while the `/authn/refresh` request is pending, the new request will not be sent to the server after the response from `/authn/refresh`.

This bug is difficult to reproduce because a new request must be made immediately after the `/authn/refresh` request has been made but the response has not yet returned. The `/authn/refresh` request is made automatically at a certain interval.

Also because of this problem e2e tests fail periodically.

## Here is the exact sequence that causes the bug:
1. Scheduled RTR starts automatically
2. RTR sets `RTR_IS_ROTATING` flag
3. Click search button immediately after
4. Search calls `isRotating()` -> true
5. Search waits for `rotationPromise`
6. RTR completes successfully
7. `.then()` block dispatches `RTR_SUCCESS_EVENT` (**Event fires immediately**)
3. `rotationHandler()` is called immediately
4. `rotationHandler` checks `localStorage.getItem(RTR_IS_ROTATING)`
5. BUT `localStorage.removeItem()` hasn't run yet! (it's in `.finally()`)
6. `localStorage` still contains the `RTR_IS_ROTATING` value
7. `rotationHandler` does nothing because the check fails
8. `.finally()` block runs and clears `localStorage`
9. Promise never resolves

The `RTR_SUCCESS_EVENT` is dispatched before the `localStorage.removeItem()` in the `.finally()` block. So when `rotationHandler` checks `localStorage.getItem(RTR_IS_ROTATING)`, it's still there.

## Issues
[STCOR-983](https://folio-org.atlassian.net/browse/STCOR-983)

## Video recording of the bug


https://github.com/user-attachments/assets/9b1d386a-669c-4040-abc3-64be47779638

