### PR TITLE
STCOR-978 Focus refresh

### DIFF
--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -49,7 +49,7 @@ import {
   setRtrFlsWarningTimeout,
 } from '../../okapiActions';
 
-import { getTokenExpiry } from '../../loginServices';
+import { getTokenExpiry, SESSION_NAME } from '../../loginServices';
 import {
   getPromise,
   isAuthenticationRequest,
@@ -150,13 +150,16 @@ export class FFetch {
     sessionStorage.setItem(SESSION_ACTIVE_WINDOW_ID, window.stripesRTRWindowId);
     this.focusEventSet = false;
     // check if RTR is needed and initiate it if the access token is expired
-    getTokenExpiry().then((expiry) => {
-      if (expiry?.atExpires && expiry.atExpires < Date.now()) {
-        this.logger.log('rtr', 'Window focused - access token expired, initiating RTR');
+    const sessionString = localStorage.getItem(SESSION_NAME);
+    if (sessionString) {
+      const sess = JSON.parse(sessionString);
+      const atExpires = sess?.tokenExpiration?.atExpires;
+      if (atExpires && atExpires < Date.now()) {
+        this.logger.log('rtr', 'Focus handler - access token expired, initiating RTR');
         const { okapi } = this.store.getState();
         rtr(this.nativeFetch, this.logger, this.rotateCallback, okapi);
       }
-    });
+    }
   };
 
   /**

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -149,6 +149,14 @@ export class FFetch {
     this.bc.postMessage({ type: RTR_ACTIVE_WINDOW_MSG, activeWindow: window.stripesRTRWindowId });
     sessionStorage.setItem(SESSION_ACTIVE_WINDOW_ID, window.stripesRTRWindowId);
     this.focusEventSet = false;
+    // check if RTR is needed and initiate it if the access token is expired
+    getTokenExpiry().then((expiry) => {
+      if (expiry?.atExpires && expiry.atExpires < Date.now()) {
+        this.logger.log('rtr', 'Window focused - access token expired, initiating RTR');
+        const { okapi } = this.store.getState();
+        rtr(this.nativeFetch, this.logger, this.rotateCallback, okapi);
+      }
+    });
   };
 
   /**

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -22,7 +22,7 @@ import { getQueryResourceKey, getCurrentModule } from '../../locationService';
 import Stripes from '../../Stripes';
 import RootWithIntl from '../../RootWithIntl';
 import SystemSkeleton from '../SystemSkeleton';
-import { configureRtr, documentFocusHandler } from './token-util';
+import { configureRtr } from './token-util';
 
 import './Root.css';
 
@@ -84,7 +84,6 @@ class Root extends Component {
     const locale = this.props.config.locale ?? 'en-US';
     // TODO: remove this after we load locale and translations at start from a public endpoint
     loadTranslations(store, locale, defaultTranslations);
-    document.addEventListener('focus', documentFocusHandler);
   }
 
   shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
This PR appends the focus handler to check the access token expiry and possibly refresh before any data calls can be made.
This resolves a situation where a user navigates away from FOLIO entirely (different window, app, etc) and closes their most recent window without going to any previously used FOLIO tab... once they refocus a FOLIO tab, if the at is expired, the logic will refresh.