### PR TITLE
STCOR-978 Use BroadcastChannel to isolate token to last-focused window.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-core
 
+## 11.0.9 IN PROGRESS
+
+* Implement active window id/messaging for RTR functionality. The last window/tab the user interacted with will handle token rotation. Refs STCOR-978.
+
 ## [11.0.8](https://github.com/folio-org/stripes-core/tree/v11.0.8) (2025-06-04)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.0.7...v11.0.8)
 

--- a/src/components/Root/FFetch-activeWindow.test.js
+++ b/src/components/Root/FFetch-activeWindow.test.js
@@ -1,0 +1,88 @@
+import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import { getTokenExpiry } from '../../loginServices';
+import * as TokenUtil from './token-util';
+import { FFetch } from './FFetch';
+
+jest.mock('../../loginServices', () => ({
+  ...(jest.requireActual('../../loginServices')),
+  setTokenExpiry: jest.fn(() => Promise.resolve()),
+  getTokenExpiry: jest.fn(() => Promise.resolve())
+}));
+
+const mockBroadcastChannel = {
+  postMessage: jest.fn(),
+  onmessage: null,
+  close: jest.fn(),
+  addEventListener: jest.fn((event, callback) => {
+    if (event === 'message') {
+      mockBroadcastChannel.onmessage = callback;
+    }
+  }),
+  removeEventListener: jest.fn(),
+};
+
+const log = jest.fn();
+
+describe('RTR - active window messaging', () => {
+  let testFfetch;
+  let rtrSpy;
+  beforeEach(() => {
+    global.BroadcastChannel = jest.fn(() => mockBroadcastChannel);
+    rtrSpy = jest.spyOn(TokenUtil, 'rtr');
+    rtrSpy.mockImplementation(() => { console.log('rtr called'); Promise.resolve(); });
+    testFfetch = new FFetch({
+      logger: { log },
+      okapi: {
+        url: 'okapiUrl',
+        tenant: 'okapiTenant',
+      },
+      store: {
+        getState: () => ({
+          okapi: {}
+        })
+      }
+    });
+    rtrSpy.mockClear();
+  });
+
+  it('sends a message when setActiveWindow is called', async () => {
+    getTokenExpiry.mockResolvedValue({
+      atExpires: Date.now() - (10 * 60 * 1000),
+      rtExpires: Date.now() - (10 * 60 * 1000),
+    });
+    const windowId = window.stripesRTRWindowId;
+    testFfetch.documentFocusHandler();
+    expect(mockBroadcastChannel.postMessage).toHaveBeenCalledWith({
+      type: '@folio/stripes/core::activeWindowMessage',
+      activeWindow: windowId,
+    });
+  });
+
+  // await waitFor(() => expect(rtrSpy).toHaveBeenCalledTimes(1));
+  it('rotates if token expired', async () => {
+    getTokenExpiry.mockResolvedValue({
+      atExpires: Date.now() - (10 * 60 * 1000),
+      rtExpires: Date.now() - (10 * 60 * 1000),
+    });
+    testFfetch.replaceFetch();
+    testFfetch.replaceXMLHttpRequest();
+    testFfetch.documentFocusHandler();
+    await waitFor(() => expect(rtrSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it('focusHandler does NOT rotate if token is still valid', async () => {
+    getTokenExpiry.mockResolvedValue({
+      atExpires: Date.now() + (10 * 60 * 1000),
+      rtExpires: Date.now() + (10 * 60 * 1000),
+    });
+    testFfetch.documentFocusHandler();
+    expect(rtrSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('handles messages from other windows', async () => {
+    const windowId = 'test-window-id';
+    mockBroadcastChannel.onmessage({ data: { type: '@folio/stripes/core::activeWindowMessage', activeWindow: windowId } });
+
+    expect(sessionStorage.getItem('@folio/stripes/core::activeWindowId')).toEqual(windowId);
+  });
+});

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -42,6 +42,7 @@
  */
 
 import ms from 'ms';
+import { v4 as uuidv4 } from 'uuid';
 import {
   setRtrTimeout,
   setRtrFlsTimeout,
@@ -67,8 +68,13 @@ import {
   RTR_TIME_MARGIN_IN_MS,
   RTR_FLS_WARNING_EVENT,
   RTR_RT_EXPIRY_IF_UNKNOWN,
+  SESSION_ACTIVE_WINDOW_ID,
+  RTR_ACTIVE_WINDOW_MSG,
+  RTR_ACTIVE_WINDOW_MSG_CHANNEL
 } from './constants';
 import FXHR from './FXHR';
+
+
 
 const OKAPI_FETCH_OPTIONS = {
   credentials: 'include',
@@ -81,6 +87,10 @@ export class FFetch {
     this.store = store;
     this.rtrConfig = rtrConfig;
     this.okapi = okapi;
+    this.focusEventSet = false;
+    this.bc = new BroadcastChannel(RTR_ACTIVE_WINDOW_MSG_CHANNEL);
+    this.setWindowIdMessageEvent();
+    this.setDocumentFocusHandler();
   }
 
   /**
@@ -98,6 +108,62 @@ export class FFetch {
     this.NativeXHR = global.XMLHttpRequest;
     global.XMLHttpRequest = FXHR(this);
   };
+
+  /**
+   * onActiveWindowIdMessage
+   * Handles receiving messages from other windows via the BroadcastChannel.
+   * The broadcast windowId is stored in sessionStorage as SESSION_ACTIVE_WINDOW_ID.
+   * and used in the rtr function (token-utils) to determine if rotation should proceed.
+   */
+  onActiveWindowIdMessage = ({ data }) => {
+    if (data?.type === RTR_ACTIVE_WINDOW_MSG) {
+      this.logger.log('rtr', `Message handler: Active window changed: ${data.activeWindow}`);
+      sessionStorage.setItem(SESSION_ACTIVE_WINDOW_ID, data.activeWindow);
+      // If the current window is not the active one, set focus handler to catch focus when it returns.
+      if (!document.hasFocus()) {
+        this.setDocumentFocusHandler();
+      }
+    }
+  }
+
+  /**
+   * setWindowIdMessageEvent
+   * Sets the window.windowId to a UUID if it doesn't already exist.
+   * Also sets up a 'message' eventHandler to catch the current active windowId
+   * when it's broadcast from another window.
+   */
+  setWindowIdMessageEvent = () => {
+    window.stripesRTRWindowId = window.stripesRTRWindowId ? window.stripesRTRWindowId : uuidv4();
+    this.bc.addEventListener('message', this.onActiveWindowIdMessage);
+  }
+
+  /**
+   * Document Focus Handler
+   * Posts a message to the BroadcastChannel with the current window's windowId.
+   * Sets the SESSION_ACTIVE_WINDOW_ID in sessionStorage to the current window's windowId.
+   * Sets the focusEventSet flag to false to allow setting a new focus handler.
+   * @return {void}
+   */
+  documentFocusHandler = () => {
+    this.logger.log('rtr', 'Focus handler - new window focused, broadcasting active window ID');
+    this.bc.postMessage({ type: RTR_ACTIVE_WINDOW_MSG, activeWindow: window.stripesRTRWindowId });
+    sessionStorage.setItem(SESSION_ACTIVE_WINDOW_ID, window.stripesRTRWindowId);
+    this.focusEventSet = false;
+  };
+
+  /**
+   * setDocumentFocusHandler
+   * Sets up a document-level focus handler that will check if RTR is needed
+   * and initiate it if the access token is expired.
+   * The 'once' setting ensures that the handler removes itself after the first focus event.
+   * To reduce chattiness, we only assign one of these handlers at a time, hence the `focusEventSet` flag.
+  */
+  setDocumentFocusHandler = () => {
+    if (!this.focusEventSet) {
+      this.focusEventSet = true;
+      window.addEventListener('focusin', this.documentFocusHandler, { once: true });
+    }
+  }
 
   /**
    * scheduleRotation

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -149,6 +149,14 @@ export class FFetch {
     this.bc.postMessage({ type: RTR_ACTIVE_WINDOW_MSG, activeWindow: window.stripesRTRWindowId });
     sessionStorage.setItem(SESSION_ACTIVE_WINDOW_ID, window.stripesRTRWindowId);
     this.focusEventSet = false;
+    // check if RTR is needed and initiate it if the access token is expired
+    getTokenExpiry().then((expiry) => {
+      if (expiry?.atExpires && expiry.atExpires < Date.now()) {
+        this.logger.log('rtr', 'Focus handler - access token expired, initiating RTR');
+        const { okapi } = this.store.getState();
+        rtr(this.nativeFetch, this.logger, this.rotateCallback, okapi);
+      }
+    });
   };
 
   /**

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -2,10 +2,11 @@
 // FFetch for the reassign globals side-effect in its constructor.
 /* eslint-disable no-unused-vars */
 
+import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import ms from 'ms';
-import '../../../test/jest/__mock__';
 
 import { getTokenExpiry } from '../../loginServices';
+import * as TokenUtil from './token-util';
 import { FFetch } from './FFetch';
 import { RTRError, UnexpectedResourceError } from './Errors';
 import {
@@ -107,6 +108,9 @@ describe('FFetch class', () => {
         logger: { log },
         store: {
           dispatch: jest.fn(),
+          getState: () => ({
+            okapi: {}
+          })
         },
         okapi: {
           url: 'okapiUrl',
@@ -222,6 +226,9 @@ describe('FFetch class', () => {
         logger: { log },
         store: {
           dispatch: jest.fn(),
+          getState: () => ({
+            okapi: {}
+          })
         },
         rtrConfig: {
           fixedLengthSessionWarningTTL: '1m',
@@ -282,6 +289,9 @@ describe('FFetch class', () => {
         logger: { log },
         store: {
           dispatch: jest.fn(),
+          getState: () => ({
+            okapi: {}
+          })
         },
         rtrConfig: {
           fixedLengthSessionWarningTTL: '1m',
@@ -324,6 +334,9 @@ describe('FFetch class', () => {
         logger: { log },
         store: {
           dispatch: jest.fn(),
+          getState: () => ({
+            okapi: {}
+          })
         },
         rtrConfig: {
           fixedLengthSessionWarningTTL: '1m',
@@ -367,6 +380,9 @@ describe('FFetch class', () => {
         logger: { log },
         store: {
           dispatch: jest.fn(),
+          getState: () => ({
+            okapi: {}
+          })
         },
         okapi: {
           url: 'okapiUrl',
@@ -411,6 +427,9 @@ describe('FFetch class', () => {
         logger: { log },
         store: {
           dispatch: jest.fn(),
+          getState: () => ({
+            okapi: {}
+          })
         },
         rtrConfig: {
           fixedLengthSessionWarningTTL: '1m',
@@ -634,37 +653,6 @@ describe('FFetch class', () => {
         expect(e instanceof UnexpectedResourceError).toBeTrue;
         expect(mockFetch.mock.calls).toHaveLength(0);
       }
-    });
-  });
-
-  describe('active window messaging', () => {
-    let testFfetch;
-    beforeEach(() => {
-      testFfetch = new FFetch({
-        logger: { log },
-        okapi: {
-          url: 'okapiUrl',
-          tenant: 'okapiTenant'
-        }
-      });
-      testFfetch.replaceFetch();
-      testFfetch.replaceXMLHttpRequest();
-    });
-
-    it('sends a message when setActiveWindow is called', async () => {
-      const windowId = window.stripesRTRWindowId;
-      testFfetch.documentFocusHandler();
-      expect(mockBroadcastChannel.postMessage).toHaveBeenCalledWith({
-        type: '@folio/stripes/core::activeWindowMessage',
-        activeWindow: windowId,
-      });
-    });
-
-    it('handles messages from other windows', async () => {
-      const windowId = 'test-window-id';
-      mockBroadcastChannel.onmessage({ data: { type: '@folio/stripes/core::activeWindowMessage', activeWindow: windowId } });
-
-      expect(sessionStorage.getItem('@folio/stripes/core::activeWindowId')).toEqual(windowId);
     });
   });
 });

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-unused-vars */
 
 import ms from 'ms';
+import '../../../test/jest/__mock__';
 
 import { getTokenExpiry } from '../../loginServices';
 import { FFetch } from './FFetch';
@@ -24,8 +25,21 @@ const log = jest.fn();
 
 const mockFetch = jest.fn();
 
+const mockBroadcastChannel = {
+  postMessage: jest.fn(),
+  onmessage: null,
+  close: jest.fn(),
+  addEventListener: jest.fn((event, callback) => {
+    if (event === 'message') {
+      mockBroadcastChannel.onmessage = callback;
+    }
+  }),
+  removeEventListener: jest.fn(),
+};
+
 describe('FFetch class', () => {
   beforeEach(() => {
+    global.BroadcastChannel = jest.fn(() => mockBroadcastChannel);
     global.fetch = mockFetch;
     getTokenExpiry.mockResolvedValue({
       atExpires: Date.now() + (10 * 60 * 1000),
@@ -40,11 +54,13 @@ describe('FFetch class', () => {
   describe('Calling a non-FOLIO API', () => {
     it('calls native fetch once', async () => {
       mockFetch.mockResolvedValueOnce('non-okapi-success');
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -57,11 +73,13 @@ describe('FFetch class', () => {
   describe('Calling a FOLIO API fetch', () => {
     it('calls native fetch once', async () => {
       mockFetch.mockResolvedValueOnce('okapi-success');
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
       const response = await global.fetch('okapiUrl/whatever', { testOption: 'test' });
@@ -90,7 +108,7 @@ describe('FFetch class', () => {
         store: {
           dispatch: jest.fn(),
         },
-        okapi:{
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
         }
@@ -112,11 +130,13 @@ describe('FFetch class', () => {
   describe('logging out', () => {
     it('calls native fetch once to log out', async () => {
       mockFetch.mockResolvedValueOnce('logged out');
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -130,11 +150,13 @@ describe('FFetch class', () => {
     it('fetch failure is silently trapped', async () => {
       mockFetch.mockRejectedValueOnce('logged out FAIL');
 
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -153,11 +175,13 @@ describe('FFetch class', () => {
   describe('logging out', () => {
     it('Calling an okapi fetch with valid token...', async () => {
       mockFetch.mockResolvedValueOnce('okapi success');
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -202,7 +226,7 @@ describe('FFetch class', () => {
         rtrConfig: {
           fixedLengthSessionWarningTTL: '1m',
         },
-        okapi:{
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
         }
@@ -262,7 +286,7 @@ describe('FFetch class', () => {
         rtrConfig: {
           fixedLengthSessionWarningTTL: '1m',
         },
-        okapi:{
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
         }
@@ -304,7 +328,7 @@ describe('FFetch class', () => {
         rtrConfig: {
           fixedLengthSessionWarningTTL: '1m',
         },
-        okapi:{
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
         }
@@ -344,7 +368,7 @@ describe('FFetch class', () => {
         store: {
           dispatch: jest.fn(),
         },
-        okapi:{
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
         }
@@ -391,7 +415,7 @@ describe('FFetch class', () => {
         rtrConfig: {
           fixedLengthSessionWarningTTL: '1m',
         },
-        okapi:{
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
         }
@@ -423,11 +447,13 @@ describe('FFetch class', () => {
     it('returns the error', async () => {
       mockFetch.mockResolvedValue('success')
         .mockResolvedValueOnce('failure');
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -449,11 +475,13 @@ describe('FFetch class', () => {
             },
           }
         ));
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -477,11 +505,13 @@ describe('FFetch class', () => {
           }
         ))
         .mockRejectedValueOnce(new Error('token error message'));
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -516,11 +546,13 @@ describe('FFetch class', () => {
             }
           }
         ));
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -550,11 +582,13 @@ describe('FFetch class', () => {
             }
           }
         ));
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -584,11 +618,13 @@ describe('FFetch class', () => {
             }
           }
         ));
-      const testFfetch = new FFetch({ logger: { log },
-        okapi:{
+      const testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
           url: 'okapiUrl',
           tenant: 'okapiTenant'
-        } });
+        }
+      });
       testFfetch.replaceFetch();
       testFfetch.replaceXMLHttpRequest();
 
@@ -598,6 +634,37 @@ describe('FFetch class', () => {
         expect(e instanceof UnexpectedResourceError).toBeTrue;
         expect(mockFetch.mock.calls).toHaveLength(0);
       }
+    });
+  });
+
+  describe('active window messaging', () => {
+    let testFfetch;
+    beforeEach(() => {
+      testFfetch = new FFetch({
+        logger: { log },
+        okapi: {
+          url: 'okapiUrl',
+          tenant: 'okapiTenant'
+        }
+      });
+      testFfetch.replaceFetch();
+      testFfetch.replaceXMLHttpRequest();
+    });
+
+    it('sends a message when setActiveWindow is called', async () => {
+      const windowId = window.stripesRTRWindowId;
+      testFfetch.documentFocusHandler();
+      expect(mockBroadcastChannel.postMessage).toHaveBeenCalledWith({
+        type: '@folio/stripes/core::activeWindowMessage',
+        activeWindow: windowId,
+      });
+    });
+
+    it('handles messages from other windows', async () => {
+      const windowId = 'test-window-id';
+      mockBroadcastChannel.onmessage({ data: { type: '@folio/stripes/core::activeWindowMessage', activeWindow: windowId } });
+
+      expect(sessionStorage.getItem('@folio/stripes/core::activeWindowId')).toEqual(windowId);
     });
   });
 });

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -22,7 +22,7 @@ import { getQueryResourceKey, getCurrentModule } from '../../locationService';
 import Stripes from '../../Stripes';
 import RootWithIntl from '../../RootWithIntl';
 import SystemSkeleton from '../SystemSkeleton';
-import { configureRtr, documentFocusHandler } from './token-util';
+import { configureRtr } from './token-util';
 
 import './Root.css';
 
@@ -84,7 +84,6 @@ class Root extends Component {
     const locale = this.props.config.locale ?? 'en-US';
     // TODO: remove this after we load locale and translations at start from a public endpoint
     loadTranslations(store, locale, defaultTranslations);
-    document.addEventListener('focus', documentFocusHandler);
   }
 
   shouldComponentUpdate(nextProps) {

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -22,7 +22,7 @@ import { getQueryResourceKey, getCurrentModule } from '../../locationService';
 import Stripes from '../../Stripes';
 import RootWithIntl from '../../RootWithIntl';
 import SystemSkeleton from '../SystemSkeleton';
-import { configureRtr } from './token-util';
+import { configureRtr, documentFocusHandler } from './token-util';
 
 import './Root.css';
 
@@ -84,6 +84,7 @@ class Root extends Component {
     const locale = this.props.config.locale ?? 'en-US';
     // TODO: remove this after we load locale and translations at start from a public endpoint
     loadTranslations(store, locale, defaultTranslations);
+    document.addEventListener('focus', documentFocusHandler);
   }
 
   shouldComponentUpdate(nextProps) {
@@ -179,8 +180,8 @@ class Root extends Component {
                 currency={currency}
                 messages={translations}
                 textComponent={Fragment}
-                onError={config?.suppressIntlErrors ? () => {} : undefined}
-                onWarn={config?.suppressIntlWarnings ? () => {} : undefined}
+                onError={config?.suppressIntlErrors ? () => { } : undefined}
+                onWarn={config?.suppressIntlWarnings ? () => { } : undefined}
                 defaultRichTextElements={this.defaultRichTextElements}
               >
                 <RootWithIntl

--- a/src/components/Root/constants.js
+++ b/src/components/Root/constants.js
@@ -4,6 +4,9 @@ export const RTR_SUCCESS_EVENT = '@folio/stripes/core::RTRSuccess';
 /** dispatched during RTR if RTR itself fails */
 export const RTR_ERROR_EVENT = '@folio/stripes/core::RTRError';
 
+/** dispatched if window isn't focused when RTR is attempted */
+export const RTR_DELAYED_NOT_FOCUSED = '@folio/stripes/core::RTRDelayedNotFocused';
+
 /**
  * dispatched if the session is idle (without activity) for too long
  */
@@ -93,3 +96,13 @@ export const RTR_RT_EXPIRY_IF_UNKNOWN = '10m';
  * this is a small amount of time to wait so the proper order can be ensured if they happen simultaneously.
  */
 export const RTR_TIME_MARGIN_IN_MS = 200;
+
+/**
+ * Used by RTR logic to determine the priority window - only windows with matching ID's can rotate.
+*/
+export const SESSION_ACTIVE_WINDOW_ID = '@folio/stripes/core::activeWindowId';
+
+/** Message type for the BroadcastChannel to indicate the active window */
+export const RTR_ACTIVE_WINDOW_MSG = '@folio/stripes/core::activeWindowMessage';
+/** Message channel for the BroadcastChannel to indicate the active window */
+export const RTR_ACTIVE_WINDOW_MSG_CHANNEL = '@folio/stripes/core::activeWindowMessageChannel';

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -10,6 +10,7 @@ import {
   RTR_IDLE_MODAL_TTL,
   RTR_IDLE_SESSION_TTL,
   RTR_SUCCESS_EVENT,
+  SESSION_ACTIVE_WINDOW_ID
 } from './constants';
 
 /** localstorage flag indicating whether an RTR request is already under way. */
@@ -212,6 +213,27 @@ export const isRotating = () => {
 export const rtr = (fetchfx, logger, callback, okapi) => {
   logger.log('rtr', '** RTR ...');
 
+  /**
+   * Check the windowId against the active windowId stored in sessionStorage.
+   * If they don't match, this window is not the active one, so we skip the
+   * rotation request and return a promise that resolves
+   * with the current token expiry data. This is to prevent multiple windows
+   * from trying to rotate the token at the same time.
+   */
+  const thisWindowId = window.stripesRTRWindowId;
+  const activeWindowId = sessionStorage.getItem(SESSION_ACTIVE_WINDOW_ID);
+
+  if (activeWindowId && thisWindowId !== activeWindowId) {
+    return new Promise(() => {
+      logger.log('rtr', `Skipping rotation because this window (${thisWindowId}) is not the active window (${activeWindowId})`);
+      // skip and schedule future rotations via the callback;
+      getTokenExpiry().then((te) => {
+        callback(te, true);
+        window.dispatchEvent(new Event(RTR_SUCCESS_EVENT));
+      });
+    });
+  }
+
   // rotation is already in progress, maybe in this window,
   // maybe in another: wait until RTR_MAX_AGE has elapsed,
   // which means the RTR request will either be finished or
@@ -275,6 +297,7 @@ export const rtr = (fetchfx, logger, callback, okapi) => {
       localStorage.removeItem(RTR_IS_ROTATING);
     });
 };
+
 
 
 

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -228,7 +228,7 @@ export const rtr = (fetchfx, logger, callback, okapi) => {
       logger.log('rtr', `Skipping rotation because this window (${thisWindowId}) is not the active window (${activeWindowId})`);
       // skip and schedule future rotations via the callback;
       getTokenExpiry().then((te) => {
-        callback(te, true);
+        callback(te);
         window.dispatchEvent(new Event(RTR_SUCCESS_EVENT));
       });
     });


### PR DESCRIPTION
Refs [STCOR-978](https://folio-org.atlassian.net/browse/STCOR-978) (Sunflower backport: [STCOR-84](https://folio-org.atlassian.net/browse/STCOR-984))

This PR resolves an issue where users experienced an abrupt logout due
to failures in token rotation across multiple tabs of usage - one bad
apple among all of their open tabs spoiled it for the rest.

Only a single, active tab is able to actually rotate. The rest just
schedule their next rotation and *don't* actually rotate. This will be
the last tab that the user interacted with and will persist through
usage of other applications.

With this approach, each new tab (single `FFetch` instance) creates a
unique id for the tab and sets up a `focusin` handler so that when a new
tab is focused, it will broadcast the focused tab's unique id so that
other windows can set it in their session and use it to check whether
token rotation should occur. If the id in session doesn't match the
current tab's id, rotation will not occur in that tab. All tabs share
the same cookie, so as long as its kept alive by the current window, it
will remain for other tabs to use. Each tab stores the last-focused tab
in their session.

Other attempts:
- relying solely on `document.hasFocus()` to dictate whether or not a
window *can* rotate. This is limited because the browser tab that only
has the tab focus (and focus isn't in the UI) will not be considered
focused, leaving the status in limbo. It also causes rtr to not happen
if other apps are in use when rotation happens - and we don't need that!

- syncing via `storage` event. This seemed very difficult to debug - the
events didn't seem to fire with sessionStorage updates across windows. I
ended up switching to a `localStorage` implementation, but even that was
problematic. The events just didn't want to stick across windows. The
persistent nature of `localStorage` disqualifies it as a lone
possibility since the previously generated window id would stick around
and fail to match a new window after the entire application is closed.

The video displays the logic in action (with rtr logging set in
stripes-config) you can see when the focus changes and the newly focused
tab's id is broadcast to all of the other tabs...

https://github.com/user-attachments/assets/fb1fffee-c698-4c56-9904-9608bc955f5f
(cherry picked from commit 9676cbc8d52ddb63afe822beb1eb22efb47874cf)

This PR appends the focus handler to check the access token expiry and
possibly refresh before any data calls can be made.
This resolves a situation where a user navigates away from FOLIO
entirely (different window, app, etc) and closes their most recent
window without going to any previously used FOLIO tab... once they
refocus a FOLIO tab, if the at is expired, the logic will refresh.

(cherry picked from commit e739f7b78e68406ea922c45d7cb5f87e53816642)
