### PR TITLE
STCOR-985 correctly implement tenant-selection on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Removed code that switches locale, numbering system etc to tenant settings when user doesn't have a locale preference. Refs STCOR-981.
 * Implement active window id/messaging for RTR functionality. The last window/tab the user interacted with will handle token rotation. Refs STCOR-978.
 * Remove `RTR_IS_ROTATING` from local storage before dispatching the `RTR_SUCCESS_EVENT` to correctly determine the `RTR_IS_ROTATING` state in the `rotationHandler` function. Refs STCOR-983.
+* Correctly implement tenant-selection ringdown during application init. Refs STCOR-985.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,4 +1,4 @@
-import { isStorageEnabled } from './App';
+import { getLoginTenant, isStorageEnabled } from './App';
 
 const storageMock = () => ({
   getItem: () => {
@@ -33,4 +33,48 @@ describe('isStorageEnabled', () => {
       expect(isEnabled).toBeFalse;
     });
   });
+});
+
+describe('getLoginTenant', () => {
+  it('uses URL values when present', () => {
+    const search = { tenant: 't', client_id: 'c' };
+    Object.defineProperty(window, 'location', { value: { search } });
+
+    const res = getLoginTenant({}, {});
+    expect(res.tenant).toBe(search.tenant);
+    expect(res.clientId).toBe(search.client_id);
+  });
+
+  describe('single-tenant', () => {
+    it('uses config.tenantOptions values when URL values are absent', () => {
+      const config = {
+        tenantOptions: {
+          denzel: { name: 'denzel', clientId: 'nolan' }
+        }
+      };
+
+      const res = getLoginTenant({}, config);
+      expect(res.tenant).toBe(config.tenantOptions.denzel.name);
+      expect(res.clientId).toBe(config.tenantOptions.denzel.clientId);
+    });
+
+    it('uses okapi.tenant and okapi.clientId when config.tenantOptions is missing', () => {
+      const okapi = {
+        tenant: 't',
+        clientId: 'c',
+      };
+
+      const res = getLoginTenant(okapi, {});
+      expect(res.tenant).toBe(okapi.tenant);
+      expect(res.clientId).toBe(okapi.clientId);
+    });
+
+    it('returns undefined when all options are exhausted', () => {
+      const res = getLoginTenant({}, {});
+      expect(res.tenant).toBeUndefined();
+      expect(res.clientId).toBeUndefined();
+    });
+  });
+
+  describe('ECS', () => { });
 });

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -136,15 +136,6 @@ export const getOIDCRedirectUri = (tenant, clientId) => {
   return encodeURIComponent(`${window.location.protocol}//${window.location.host}/oidc-landing?tenant=${tenant}&client_id=${clientId}`);
 };
 
-export const getTenantAndClientIdFromLoginURL = () => {
-  const urlParams = new URLSearchParams(window.location.search);
-
-  return {
-    tenantName: urlParams.get('tenant'),
-    clientId: urlParams.get('client_id'),
-  };
-};
-
 // export config values for storing user locale
 export const userLocaleConfig = {
   'configName': 'localeSettings',


### PR DESCRIPTION
During initialization, derive the tenant via one of the following sources, in order of preference:
1. URL in the `tenant` and `client_id` search params
2. stripes-config in the `config.tenantOptions` object
3. stripes-config in the `okapi` object

Previous implementations ignored option-2, causing tenant to be undefined in Eureka-FOLIO builds where the (deprecated) `okapi` object had been omitted from `stripes.config.js` and a session has not been started, e.g. because the user has not authenticated and is submitting the "Forgot password" form.

Refs [STCOR-985](https://folio-org.atlassian.net/browse/STCOR-985)