### PR TITLE
STCOR-986 handle OTP in StrictMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Removed code that switches locale, numbering system etc to tenant settings when user doesn't have a locale preference. Refs STCOR-981.
 * Implement active window id/messaging for RTR functionality. The last window/tab the user interacted with will handle token rotation. Refs STCOR-978.
 * Remove `RTR_IS_ROTATING` from local storage before dispatching the `RTR_SUCCESS_EVENT` to correctly determine the `RTR_IS_ROTATING` state in the `rotationHandler` function. Refs STCOR-983.
+* Handle OTP in `<StrictMode>` where effects run twice. Refs STCOR-986.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -1,155 +1,169 @@
-import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
-import queryString from 'query-string';
+import React, { useEffect, useRef, useState } from 'react';
 import { useStore } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
+import { okapi as okapiConfig, config } from 'stripes-config';
 
 import {
-  Button,
-  Col,
-  Headline,
   Loading,
-  Row,
 } from '@folio/stripes-components';
 
-import OrganizationLogo from './OrganizationLogo';
 import {
+  getLoginTenant,
   getOIDCRedirectUri,
+  getTokenExpiry,
   requestUserWithPerms,
   setTokenExpiry,
   storeLogoutTenant,
 } from '../loginServices';
 import { useStripes } from '../StripesContext';
-
+import OIDCLandingError from './OIDCLandingError';
 import css from './Front.css';
+
+//
+// This page defines exhcangeOtp(), and then calls it outside the lifecycle of
+// the component defined here, OIDCLanding. The request that exchanges the OTP
+// from Keycloak for AT/RT cookies must only run once, which is _exactly_ the
+// kind of "only once" application initialization described in the React docs:
+// https://react.dev/learn/synchronizing-with-effects#not-an-effect-initializing-the-application
+//
+// But ... there is also a component here, and it uses a ref to avoid an effect
+// running multiple times, which is explictly called out as an anti-pattern
+// in that same document. What gives?!? Once we know OTP exchange was
+// successful, then we need to initialize the session, including populating
+// the redux, which means application init can't happen completely outside the
+// component lifecycle where the store isn't available.
+//
+// Additionally, effects run twice in development in order to simulate when a
+// component mounts, unmounts, and remounts, but that will never happen here
+// because the ONLY legit time for this component to mount is when Keycloak
+// redirects to this route. That is the only time this component mounts, and
+// then _by design_ it never mounts again.
+//
+// Fin
+
+const OTP_EXCHANGE_SUCCESS = '@folio/stripes/core::OTPExchangeSuccess';
+let otpError = null;
+
+const exchangeOtp = () => {
+  otpError = null;
+  const urlParams = new URLSearchParams(window.location.search);
+  const otp = urlParams.get('code');
+  const { tenant, clientId } = getLoginTenant(okapiConfig, config);
+
+  const redirectUri = getOIDCRedirectUri(tenant, clientId);
+
+  if (otp) {
+    fetch(`${okapiConfig.url}/authn/token?code=${otp}&redirect-uri=${redirectUri}`, {
+      credentials: 'include',
+      headers: { 'X-Okapi-tenant': tenant, 'Content-Type': 'application/json' },
+      mode: 'cors',
+    })
+      .then((resp) => {
+        if (resp.ok) {
+          return resp.json()
+            .then((json) => {
+              return setTokenExpiry({
+                // if AT/RT values are missing in the response from _self,
+                // store near-future expiration values instead of the (missing)
+                // actual values. given that we arrived here, we know the request
+                // was successful, i.e. cookies are present, even though their
+                // values are (oddly) missing in the response body.
+                atExpires: json.accessTokenExpiration ? new Date(json.accessTokenExpiration).getTime() : Date.now() + (60 * 1000),
+                rtExpires: json.refreshTokenExpiration ? new Date(json.refreshTokenExpiration).getTime() : Date.now() + (2 * 60 * 1000),
+              });
+            })
+            .then(() => {
+              // for login itself we're storing selected tenant and clientId in the url
+              // but we still need to store tenantId in localStorage for logout purposes
+              // `logout` function in loginServices.js provides details about this.
+              storeLogoutTenant(tenant);
+
+              // emit OPT_EXCHANGE_SUCCESS just in case the component mounted
+              // before OTP exchange completed. otherwise, the component would
+              // not know about the status of OTP exchange, and would never
+              // begin session-init.
+              window.dispatchEvent(new Event(OTP_EXCHANGE_SUCCESS));
+            });
+        } else {
+          return resp.json().then((error) => {
+            throw error;
+          });
+        }
+      })
+      .catch(e => {
+        // eslint-disable-next-line no-console
+        console.error('@@ Oh, snap, OTP exchange failed!', e);
+        // copy the error into the global otpError
+        otpError = e;
+      });
+  }
+};
+
+exchangeOtp();
 
 /**
  * OIDCLanding: un-authenticated route handler for /oidc-landing.
  *
- * * Read one-time-code from URL params
- * * make an API call to /authn/token to exchange the OTP for cookies
- * * call requestUserWithPerms to make an API call to .../_self,
- *   eventually dispatching session and Okapi-ready, resulting in a
- *   re-render of RoothWithIntl with prop isAuthenticated: true
+ * After OTP exchange completes successfully, make an API request to .../_self.
+ * The handlers that parse the response from this request will eventually
+ * dispatch session-ready and okapi-ready events, causing RootWithIntl to
+ * re-render with the prop isAuthenticated set to true, and providing an
+ * alternative component to handle this route. That handler, OIDCRedirect,
+ * does what you expect, redirecting the user to the root URL for their
+ * session.
  *
  * @see RootWithIntl
  */
 const OIDCLanding = () => {
-  const location = useLocation();
   const store = useStore();
   const { okapi } = useStripes();
-  const [oidcError, setOIDCError] = useState();
+  const [userFetchError, setUserFetchError] = useState();
 
-  /**
-   * Exchange the otp for AT/RT cookies, then retrieve the user.
-   *
-   * See https://ebscoinddev.atlassian.net/wiki/spaces/TEUR/pages/12419306/mod-login-keycloak#mod-login-keycloak-APIs
-   * for additional details. May not be necessary for SAML-specific pages
-   * to exist since the workflow is the same for SSO. We can just inspect
-   * the response for SSO-y values or SAML-y values and act accordingly.
-   */
-  useEffect(() => {
-    const getParams = () => {
-      const search = location.search;
-      if (!search) return undefined;
-      return queryString.parse(search) || {};
-    };
+  // React docs SPECIFICALLY warn against using refs to prevent effects from
+  // firing 2x in development, yet here is this ref. WTF?!?
+  //
+  // We have this ref because session init needs to happen EXACTLY once, and
+  // there is no legit path to this component, except on the redirect-from-
+  // login. IOW, there is not legit reason for this component to be remounted;
+  // once OTP exchange and session-init kick off, it is impossible to return
+  // here.
+  const isInitializingRef = useRef(false);
 
-    /**
-     * retrieve the OTP
-     * @returns {string}
-     */
-    const getOtp = () => {
-      return getParams()?.code;
-    };
-
-    const otp = getOtp();
-
-    const redirectUri = getOIDCRedirectUri(okapi.tenant, okapi.clientId);
-
-    if (otp) {
-      fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${redirectUri}`, {
-        credentials: 'include',
-        headers: { 'X-Okapi-tenant': okapi.tenant, 'Content-Type': 'application/json' },
-        mode: 'cors',
-      })
-        .then((resp) => {
-          if (resp.ok) {
-            return resp.json()
-              .then((json) => {
-                return setTokenExpiry({
-                  atExpires: json.accessTokenExpiration ? new Date(json.accessTokenExpiration) : Date.now() + (60 * 1000),
-                  rtExpires: json.refreshTokenExpiration ? new Date(json.refreshTokenExpiration) : Date.now() + (2 * 60 * 1000),
-                });
-              })
-              .then(() => {
-                return requestUserWithPerms(okapi.url, store, okapi.tenant);
-              })
-              .then(() => {
-                // for login itself we're storing selected tenant and clientId in the url
-                // but we still need to store tenantId in localStorage for logout purposes
-                // `logout` function in loginServices.js provides details about this.
-                storeLogoutTenant(okapi.tenant);
-              });
-          } else {
-            return resp.json().then((error) => {
-              throw error;
+  const handleOTPExchangeSuccess = () => {
+    if (!isInitializingRef.current && !okapi.isAuthenticated) {
+      isInitializingRef.current = true;
+      getTokenExpiry().then(res => {
+        if (res?.atExpires && res.atExpires > Date.now()) {
+          requestUserWithPerms(okapiConfig.url, store, okapi.tenant)
+            .catch(e => {
+              setUserFetchError(e);
             });
-          }
-        })
-        .catch(e => {
-          // eslint-disable-next-line no-console
-          console.error('@@ Oh, snap, OTP exchange failed!', e);
-          setOIDCError(e);
-        });
+        }
+      });
     }
-    // we only want to run this effect once, on load.
-    // keycloak authentication will redirect here and the other deps will be constant:
-    // location.search: the query string; this will never change
-    // okapi.tenant, okapi.url: these are defined in stripes.config.js
-    // store: the redux store
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  /**
-   * formatOIDCError
-   * Return formatted OIDC error message, or null
-   * @returns
-   */
-  const formatOIDCError = () => {
-    if (Array.isArray(oidcError?.errors)) {
-      return (
-        <Row center="xs">
-          <Col xs={12}>
-            <Headline>{oidcError.errors[0]?.message}</Headline>
-          </Col>
-        </Row>
-      );
-    }
-
-    return null;
   };
 
-  if (oidcError) {
-    return (
-      <main data-test-saml-error>
-        <Row center="xs">
-          <Col xs={12}>
-            <OrganizationLogo />
-          </Col>
-        </Row>
-        <Row center="xs">
-          <Col xs={12}>
-            <Headline size="large"><FormattedMessage id="stripes-core.errors.oidc" /></Headline>
-          </Col>
-        </Row>
-        {formatOIDCError()}
-        <Row center="xs">
-          <Col xs={12}>
-            <Button to="/"><FormattedMessage id="stripes-core.rtr.idleSession.logInAgain" /></Button>
-          </Col>
-        </Row>
-      </main>
-    );
+  // the OTP exchange process will emit an OTP_EXCHANGE_SUCCESS event ...
+  window.addEventListener(OTP_EXCHANGE_SUCCESS, handleOTPExchangeSuccess);
+
+  // ... but if the event emits before the application is initialized and
+  // this component loads, of course we still want to react to the fact that
+  // OTP exchange completed successfully, so this effect does the same thing.
+  //
+  // exhaustive-dep checking is off because this component must never remount
+  // since OTP exchange is a one-time thing.
+  useEffect(() => {
+    handleOTPExchangeSuccess();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+
+  // failure during OTP-exchange request
+  if (otpError) {
+    return <OIDCLandingError error={otpError} />;
+  }
+
+  // failure during session-init
+  if (userFetchError) {
+    return <OIDCLandingError error={userFetchError} />;
   }
 
   return (

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -43,7 +43,7 @@ import css from './Front.css';
 const OTP_EXCHANGE_SUCCESS = '@folio/stripes/core::OTPExchangeSuccess';
 let otpError = null;
 
-const exchangeOtp = () => {
+export const exchangeOtp = (setToken, setTenant) => {
   otpError = null;
   const urlParams = new URLSearchParams(window.location.search);
   const otp = urlParams.get('code');
@@ -61,7 +61,7 @@ const exchangeOtp = () => {
         if (resp.ok) {
           return resp.json()
             .then((json) => {
-              return setTokenExpiry({
+              return setToken({
                 // if AT/RT values are missing in the response from _self,
                 // store near-future expiration values instead of the (missing)
                 // actual values. given that we arrived here, we know the request
@@ -75,7 +75,7 @@ const exchangeOtp = () => {
               // for login itself we're storing selected tenant and clientId in the url
               // but we still need to store tenantId in localStorage for logout purposes
               // `logout` function in loginServices.js provides details about this.
-              storeLogoutTenant(tenant);
+              setTenant(tenant);
 
               // emit OPT_EXCHANGE_SUCCESS just in case the component mounted
               // before OTP exchange completed. otherwise, the component would
@@ -98,7 +98,7 @@ const exchangeOtp = () => {
   }
 };
 
-exchangeOtp();
+exchangeOtp(setTokenExpiry, storeLogoutTenant);
 
 /**
  * OIDCLanding: un-authenticated route handler for /oidc-landing.

--- a/src/components/OIDCLanding.test.js
+++ b/src/components/OIDCLanding.test.js
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 
-import OIDCLanding from './OIDCLanding';
+import OIDCLanding, { exchangeOtp } from './OIDCLanding';
 
 jest.mock('react-router-dom', () => ({
   useLocation: () => ({
@@ -121,4 +121,49 @@ describe('OIDCLanding', () => {
 
     mockFetchCleanUp();
   });
+});
+
+describe('exchangeOtp', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('sets token and tenant data on success', async () => {
+    window.location.search = '?code=code&redirect-url=redirect-url';
+    window.dispatchEvent = jest.fn();
+    mockFetchSuccess({
+      accessTokenExpiration: '2024-05-23T09:47:17.000-04:00',
+      refreshTokenExpiration: '2024-05-23T10:07:17.000-04:00',
+    });
+
+    const setToken = jest.fn();
+    const setTenant = jest.fn();
+    exchangeOtp(setToken, setTenant);
+    await waitFor(() => {
+      expect(setToken).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(setTenant).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(window.dispatchEvent).toHaveBeenCalled();
+    });
+  });
+
+  it('logs an error on failure', async () => {
+    window.location.search = '?code=code&redirect-url=redirect-url';
+    console.error = jest.fn();
+    mockFetchError({
+      accessTokenExpiration: '2024-05-23T09:47:17.000-04:00',
+      refreshTokenExpiration: '2024-05-23T10:07:17.000-04:00',
+    });
+
+    const setToken = jest.fn();
+    const setTenant = jest.fn();
+    exchangeOtp(setToken, setTenant);
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
 });

--- a/src/components/OIDCLanding.test.js
+++ b/src/components/OIDCLanding.test.js
@@ -165,5 +165,4 @@ describe('exchangeOtp', () => {
       expect(console.error).toHaveBeenCalled();
     });
   });
-
 });

--- a/src/components/OIDCLandingError.js
+++ b/src/components/OIDCLandingError.js
@@ -1,0 +1,41 @@
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+  Col,
+  Headline,
+  Row,
+} from '@folio/stripes-components';
+
+import OrganizationLogo from './OrganizationLogo';
+
+const OIDCLandingError = ({ error }) => {
+  const message = error?.errors?.[0]?.message || <pre>{JSON.stringify(error, null, 2)}</pre>;
+
+  return (
+    <main data-test-saml-error>
+      <Row center="xs">
+        <Col xs={12}>
+          <OrganizationLogo />
+        </Col>
+      </Row>
+      <Row center="xs">
+        <Col xs={12}>
+          <Headline size="large"><FormattedMessage id="stripes-core.errors.oidc" /></Headline>
+        </Col>
+      </Row>
+      <Row center="xs">
+        <Col xs={12}>
+          <Headline>{message}</Headline>
+        </Col>
+      </Row>
+      <Row center="xs">
+        <Col xs={12}>
+          <Button to="/"><FormattedMessage id="stripes-core.rtr.idleSession.logInAgain" /></Button>
+        </Col>
+      </Row>
+    </main>
+  );
+};
+
+export default OIDCLandingError;

--- a/src/components/OIDCLandingError.js
+++ b/src/components/OIDCLandingError.js
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
 
 import {
   Button,
@@ -38,4 +39,13 @@ const OIDCLandingError = ({ error }) => {
   );
 };
 
+OIDCLandingError.propTypes = {
+  error: PropTypes.oneOfType([
+    PropTypes.shape({
+      errors: PropTypes.arrayOf(PropTypes.shape({
+        message: PropTypes.string
+      }))
+    }),
+    PropTypes.string])
+};
 export default OIDCLandingError;

--- a/src/components/OIDCLandingError.test.js
+++ b/src/components/OIDCLandingError.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 import OIDCLandingError from './OIDCLandingError';
 
-jest.mock('./OrganizationLogo', () => () => 'Logo')
+jest.mock('./OrganizationLogo', () => () => 'Logo');
 
 describe('OIDCLandingError', () => {
   it('handles expected error shape', () => {

--- a/src/components/OIDCLandingError.test.js
+++ b/src/components/OIDCLandingError.test.js
@@ -1,0 +1,25 @@
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import OIDCLandingError from './OIDCLandingError';
+
+jest.mock('./OrganizationLogo', () => () => 'Logo')
+
+describe('OIDCLandingError', () => {
+  it('handles expected error shape', () => {
+    const error = {
+      errors: [
+        {
+          message: "To gain a standard for the appreciation of others' work"
+        }
+      ]
+
+    };
+    render(<OIDCLandingError error={error} />);
+    expect(screen.getByText(error.errors[0].message)).toBeInTheDocument();
+  });
+
+  it('handles unexpected error shape', () => {
+    const error = 'And the criticism of your own';
+    render(<OIDCLandingError error={error} />);
+    expect(screen.getByText(error, { exact: false })).toBeInTheDocument();
+  });
+});

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -746,32 +746,6 @@ export const getLogoutTenant = () => {
   return storedTenant ? JSON.parse(storedTenant) : undefined;
 };
 
-export const getLoginTenant = (stripesOkapi, stripesConfig) => {
-  // derive from the URL
-  const urlParams = new URLSearchParams(window.location.search);
-  let tenant = urlParams.get('tenant');
-  let clientId = urlParams.get('client_id');
-  if (tenant && clientId) {
-    return { tenant, clientId };
-  }
-
-  // derive from stripes.config.js::config::tenantOptions
-  if (stripesConfig.tenantOptions && Object.keys(stripesConfig?.tenantOptions).length === 1) {
-    const key = Object.keys(stripesConfig.tenantOptions)[0];
-    tenant = stripesConfig.tenantOptions[key]?.name;
-    clientId = stripesConfig.tenantOptions[key]?.clientId;
-    if (tenant && clientId) {
-      return { tenant, clientId };
-    }
-  }
-
-  // default to stripes.config.js::okapi
-  return {
-    tenant: stripesOkapi?.tenant,
-    clientId: stripesOkapi?.clientId,
-  };
-};
-
 export async function logout(okapiUrl, store, queryClient) {
   // check the private-storage sentinel: if logout has already started
   // in this window, we don't want to start it again.

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -714,6 +714,32 @@ export const getLogoutTenant = () => {
   return storedTenant ? JSON.parse(storedTenant) : undefined;
 };
 
+export const getLoginTenant = (stripesOkapi, stripesConfig) => {
+  // derive from the URL
+  const urlParams = new URLSearchParams(window.location.search);
+  let tenant = urlParams.get('tenant');
+  let clientId = urlParams.get('client_id');
+  if (tenant && clientId) {
+    return { tenant, clientId };
+  }
+
+  // derive from stripes.config.js::config::tenantOptions
+  if (stripesConfig.tenantOptions && Object.keys(stripesConfig?.tenantOptions).length === 1) {
+    const key = Object.keys(stripesConfig.tenantOptions)[0];
+    tenant = stripesConfig.tenantOptions[key]?.name;
+    clientId = stripesConfig.tenantOptions[key]?.clientId;
+    if (tenant && clientId) {
+      return { tenant, clientId };
+    }
+  }
+
+  // default to stripes.config.js::okapi
+  return {
+    tenant: stripesOkapi?.tenant,
+    clientId: stripesOkapi?.clientId,
+  };
+};
+
 export async function logout(okapiUrl, store, queryClient) {
   // check the private-storage sentinel: if logout has already started
   // in this window, we don't want to start it again.

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -30,7 +30,6 @@ import {
   fetchOverriddenUserWithPerms,
   loadResources,
   getOIDCRedirectUri,
-  getLoginTenant,
   getLogoutTenant,
 } from './loginServices';
 
@@ -744,36 +743,6 @@ describe('unauthorizedPath functions', () => {
     });
   });
 
-  describe('getLoginTenant', () => {
-    it('uses URL values when present', () => {
-      window.location.search = '?tenant=t&client_id=c';
-      const res = getLoginTenant(
-        { tenant: 'ot', clientId: 'oc' },
-        { tenantOptions: { to: { name: 'to', clientId: 'toc' } } },
-      );
-
-      expect(res).toMatchObject({ tenant: 't', clientId: 'c' });
-    });
-
-    it('uses stripes-config::config::tenantOptions', () => {
-      const stripesOkapi = { tenant: 't', clientId: 'c' };
-      const config = { tenantOptions: { to: { name: 'to', clientId: 'toc' } } };
-      const res = getLoginTenant(stripesOkapi, config);
-
-      expect(res).toMatchObject({
-        tenant: config.tenantOptions.to.name,
-        clientId: config.tenantOptions.to.clientId,
-      });
-    });
-
-    it('defaults to stripes-config::okapi values when all else fails', () => {
-      const stripesOkapi = { tenant: 't', clientId: 'c' };
-      const res = getLoginTenant(stripesOkapi, {});
-
-      expect(res).toMatchObject(stripesOkapi);
-    });
-  });
-
   describe('getLogoutTenant', () => {
     afterEach(() => {
       localStorage.clear();
@@ -1335,4 +1304,3 @@ describe('getLoginTenant', () => {
 
   describe('ECS', () => { });
 });
-


### PR DESCRIPTION
Effects run twice in `<StrictMode>`, but OTP must only happen once; make it so.

This PR changes the way OIDCLanding handles OTP exchange, moving it from an effect (which will run x2 in development when `<StrictMode>` is turned on, which of course we want it to be), [outside the component lifecycle](https://react.dev/learn/synchronizing-with-effects#not-an-effect-initializing-the-application) so it only runs once no matter how many times the component is [mounted/unmounted/remounted in development-mode](https://react.dev/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development).

It may bother you that there is both an event-handler and an effect to handle the same thing, and that's fair. The problem is, there is a race condition between the OTP-exchange request and the component loading, and we want to initialize the session no matter who wins the race:
* if the component loads before the request finishes, then storage will be empty when the effect runs so nothing will happen then 😢 but the event handler will catch the event emitted when the request finally finishes 😍 
* if the request finishes before the component loads, then there won’t be a handler to listen for the event so nothing will happen 😢 but the effect runs when the component mounts and will find the data in storage 😍 


Refs [STCOR-986](https://folio-org.atlassian.net/browse/STCOR-986)