### PR TITLE
STCOR-985 Use optional chaining for safe value extraction

### DIFF
--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -161,7 +161,7 @@ export const getLoginTenant = (stripesOkapi, stripesConfig) => {
   }
 
   // derive from stripes.config.js::config::tenantOptions
-  if (stripesConfig.tenantOptions && Object.keys(stripesConfig?.tenantOptions).length === 1) {
+  if (stripesConfig?.tenantOptions && Object.keys(stripesConfig?.tenantOptions).length === 1) {
     const key = Object.keys(stripesConfig.tenantOptions)[0];
     tenant = stripesConfig.tenantOptions[key]?.name;
     clientId = stripesConfig.tenantOptions[key]?.clientId;


### PR DESCRIPTION
Based on #1649 

## Purpose
A lot of tests fail because of an attempt to get `tenantOptions` from `stripesConfig` in [getLoginTenant](https://github.com/folio-org/stripes-core/blob/master/src/loginServices.js#L164).

Why `getLoginTenant` called in tests?
Actually we use `stripes-core` mock in tests, but also use `jest.requireActual('@folio/stripes/core')` that import stuff from `stripes-core`. [This place in the code](https://github.com/folio-org/stripes-core/blob/master/src/components/OIDCLanding.js#L102) **executes** inside the module, as a result `getLoginTenant` is triggered.

---

In this PR, I'm not going to discuss the feasibility of calling `exchangeOtp` inside the module. This PR simply unblocks the other PRs from failing tests.