### PR TITLE
STCOR-985 handle undefined config values

### DIFF
--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -161,7 +161,7 @@ export const getLoginTenant = (stripesOkapi, stripesConfig) => {
   }
 
   // derive from stripes.config.js::config::tenantOptions
-  if (stripesConfig.tenantOptions && Object.keys(stripesConfig?.tenantOptions).length === 1) {
+  if (stripesConfig?.tenantOptions && Object.keys(stripesConfig?.tenantOptions).length === 1) {
     const key = Object.keys(stripesConfig.tenantOptions)[0];
     tenant = stripesConfig.tenantOptions[key]?.name;
     clientId = stripesConfig.tenantOptions[key]?.clientId;

--- a/src/loginServices.test.js
+++ b/src/loginServices.test.js
@@ -1296,7 +1296,7 @@ describe('getLoginTenant', () => {
     });
 
     it('returns undefined when all options are exhausted', () => {
-      const res = getLoginTenant({}, {});
+      const res = getLoginTenant();
       expect(res.tenant).toBeUndefined();
       expect(res.clientId).toBeUndefined();
     });


### PR DESCRIPTION
`getLoginTenant(okapiConfig, config)` must be robust to empty arguments.

Addresses a small-but-crucial bug in PR #1652.

Refs [STCOR-985](https://folio-org.atlassian.net/browse/STCOR-985)