### PR TITLE
STCOR-986 handle OTP in StrictMode

### DIFF
--- a/src/components/OIDCLanding.error.test.js
+++ b/src/components/OIDCLanding.error.test.js
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+
+import OIDCLanding from './OIDCLanding';
+import useExchangeCode from './useExchangeCode';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    search: 'session_state=dead-beef&code=c0ffee'
+  }),
+  Redirect: () => <>Redirect</>,
+}));
+
+jest.mock('react-redux', () => ({
+  useStore: () => { },
+}));
+
+jest.mock('../StripesContext', () => ({
+  useStripes: () => ({
+    okapi: { url: 'https://whaterver' },
+    config: { tenantOptions: { diku: { name: 'diku', clientId: 'diku-application' } } },
+  }),
+}));
+
+jest.mock('./OrganizationLogo', () => (() => <div>OrganizationLogo</div>));
+
+jest.mock('../loginServices', () => ({
+  ...(jest.requireActual('../loginServices')),
+  setTokenExpiry: jest.fn(() => Promise.resolve()),
+  // sorry eslint; we just gotta mock what the code already does
+  // eslint-disable-next-line prefer-promise-reject-errors
+  requestUserWithPerms: () => Promise.reject('requestUserWithPerms-error'),
+  getOIDCRedirectUri: () => '',
+  getLoginTenant: () => 't',
+}));
+
+jest.mock('./useExchangeCode');
+
+describe('OIDCLanding', () => {
+  it('displays an error on token exchange failure', async () => {
+    const error = 'token-exchange-error';
+    const mockUseExchangeCode = useExchangeCode;
+    mockUseExchangeCode.mockReturnValue({
+      data: null,
+      isloading: false,
+      error,
+    });
+
+    render(<OIDCLanding />);
+
+    await waitFor(() => {
+      screen.getByText(error);
+    });
+  });
+
+  it('displays an error on session init failure', async () => {
+    const mockUseExchangeCode = useExchangeCode;
+    mockUseExchangeCode.mockReturnValue({
+      data: { some: 'string' },
+      isloading: false,
+      error: null,
+    });
+
+    render(<OIDCLanding />);
+    await waitFor(() => {
+      screen.getByText('requestUserWithPerms-error');
+    });
+  });
+});

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -1,20 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
-import queryString from 'query-string';
-import { useStore } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 import {
-  Button,
-  Col,
   Headline,
   Loading,
-  Row,
 } from '@folio/stripes-components';
 
-import OrganizationLogo from './OrganizationLogo';
 import {
-  getOIDCRedirectUri,
   requestUserWithPerms,
   setTokenExpiry,
   storeLogoutTenant,
@@ -22,6 +14,9 @@ import {
 import { useStripes } from '../StripesContext';
 
 import css from './Front.css';
+
+import useExchangeCode from './useExchangeCode';
+import OIDCLandingError from './OIDCLandingError';
 
 /**
  * OIDCLanding: un-authenticated route handler for /oidc-landing.
@@ -35,127 +30,50 @@ import css from './Front.css';
  * @see RootWithIntl
  */
 const OIDCLanding = () => {
-  const location = useLocation();
-  const store = useStore();
-  const { okapi } = useStripes();
-  const [oidcError, setOIDCError] = useState();
+  const intl = useIntl();
+  const { okapi, store } = useStripes();
+  const [userFetchError, setUserFetchError] = useState();
 
-  /**
-   * Exchange the otp for AT/RT cookies, then retrieve the user.
-   *
-   * See https://ebscoinddev.atlassian.net/wiki/spaces/TEUR/pages/12419306/mod-login-keycloak#mod-login-keycloak-APIs
-   * for additional details. May not be necessary for SAML-specific pages
-   * to exist since the workflow is the same for SSO. We can just inspect
-   * the response for SSO-y values or SAML-y values and act accordingly.
-   */
+  const { data: tokenData, isLoading, error: tokenError } = useExchangeCode();
+
   useEffect(() => {
-    const getParams = () => {
-      const search = location.search;
-      if (!search) return undefined;
-      return queryString.parse(search) || {};
-    };
-
-    /**
-     * retrieve the OTP
-     * @returns {string}
-     */
-    const getOtp = () => {
-      return getParams()?.code;
-    };
-
-    const otp = getOtp();
-
-    const redirectUri = getOIDCRedirectUri(okapi.tenant, okapi.clientId);
-
-    if (otp) {
-      fetch(`${okapi.url}/authn/token?code=${otp}&redirect-uri=${redirectUri}`, {
-        credentials: 'include',
-        headers: { 'X-Okapi-tenant': okapi.tenant, 'Content-Type': 'application/json' },
-        mode: 'cors',
+    if (tokenData) {
+      setTokenExpiry({
+        atExpires: tokenData.accessTokenExpiration ? new Date(tokenData.accessTokenExpiration).getTime() : Date.now() + (60 * 1000),
+        rtExpires: tokenData.refreshTokenExpiration ? new Date(tokenData.refreshTokenExpiration).getTime() : Date.now() + (2 * 60 * 1000),
       })
-        .then((resp) => {
-          if (resp.ok) {
-            return resp.json()
-              .then((json) => {
-                return setTokenExpiry({
-                  atExpires: json.accessTokenExpiration ? new Date(json.accessTokenExpiration) : Date.now() + (60 * 1000),
-                  rtExpires: json.refreshTokenExpiration ? new Date(json.refreshTokenExpiration) : Date.now() + (2 * 60 * 1000),
-                });
-              })
-              .then(() => {
-                return requestUserWithPerms(okapi.url, store, okapi.tenant);
-              })
-              .then(() => {
-                // for login itself we're storing selected tenant and clientId in the url
-                // but we still need to store tenantId in localStorage for logout purposes
-                // `logout` function in loginServices.js provides details about this.
-                storeLogoutTenant(okapi.tenant);
-              });
-          } else {
-            return resp.json().then((error) => {
-              throw error;
-            });
-          }
+        .then(() => {
+          return storeLogoutTenant(okapi.tenant);
+        })
+        .then(() => {
+          return requestUserWithPerms(okapi.url, store, okapi.tenant);
         })
         .catch(e => {
-          // eslint-disable-next-line no-console
-          console.error('@@ Oh, snap, OTP exchange failed!', e);
-          setOIDCError(e);
+          setUserFetchError(e);
         });
     }
-    // we only want to run this effect once, on load.
-    // keycloak authentication will redirect here and the other deps will be constant:
-    // location.search: the query string; this will never change
-    // okapi.tenant, okapi.url: these are defined in stripes.config.js
-    // store: the redux store
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [tokenData]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  /**
-   * formatOIDCError
-   * Return formatted OIDC error message, or null
-   * @returns
-   */
-  const formatOIDCError = () => {
-    if (Array.isArray(oidcError?.errors)) {
-      return (
-        <Row center="xs">
-          <Col xs={12}>
-            <Headline>{oidcError.errors[0]?.message}</Headline>
-          </Col>
-        </Row>
-      );
-    }
+  // token exchange failure
+  if (tokenError) {
+    return <OIDCLandingError error={tokenError} />;
+  }
 
-    return null;
-  };
-
-  if (oidcError) {
-    return (
-      <main data-test-saml-error>
-        <Row center="xs">
-          <Col xs={12}>
-            <OrganizationLogo />
-          </Col>
-        </Row>
-        <Row center="xs">
-          <Col xs={12}>
-            <Headline size="large"><FormattedMessage id="stripes-core.errors.oidc" /></Headline>
-          </Col>
-        </Row>
-        {formatOIDCError()}
-        <Row center="xs">
-          <Col xs={12}>
-            <Button to="/"><FormattedMessage id="stripes-core.rtr.idleSession.logInAgain" /></Button>
-          </Col>
-        </Row>
-      </main>
-    );
+  // session-init failure
+  if (userFetchError) {
+    return <OIDCLandingError error={userFetchError} />;
   }
 
   return (
     <div data-test-saml-success>
       <div className={css.frontWrap}>
-        <Loading size="xlarge" />
+        <div>
+          <Loading size="xlarge" />
+        </div>
+        <Headline size="xx-large">
+          {isLoading && intl.formatMessage({ id: 'stripes-core.oidc.validatingAuthenticationToken' })}
+          {tokenData && intl.formatMessage({ id: 'stripes-core.oidc.initializingSession' })}
+        </Headline>
       </div>
     </div>
   );

--- a/src/components/OIDCLandingError.js
+++ b/src/components/OIDCLandingError.js
@@ -1,0 +1,52 @@
+import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
+
+import {
+  Button,
+  Col,
+  Headline,
+  Row,
+} from '@folio/stripes-components';
+
+import OrganizationLogo from './OrganizationLogo';
+
+const OIDCLandingError = ({ error }) => {
+  const message = error?.errors?.[0]?.message || error;
+
+  return (
+    <main data-test-saml-error>
+      <Row center="xs">
+        <Col xs={12}>
+          <OrganizationLogo />
+        </Col>
+      </Row>
+      <Row center="xs">
+        <Col xs={12}>
+          <Headline size="large"><FormattedMessage id="stripes-core.errors.oidc" /></Headline>
+        </Col>
+      </Row>
+      <Row center="xs">
+        <Col xs={12}>
+          <Headline>{message}</Headline>
+        </Col>
+      </Row>
+      <Row center="xs">
+        <Col xs={12}>
+          <Button to="/"><FormattedMessage id="stripes-core.rtr.idleSession.logInAgain" /></Button>
+        </Col>
+      </Row>
+    </main>
+  );
+};
+
+OIDCLandingError.propTypes = {
+  error: PropTypes.oneOfType([
+    PropTypes.shape({
+      errors: PropTypes.arrayOf(PropTypes.shape({
+        message: PropTypes.string
+      }))
+    }),
+    PropTypes.string])
+};
+export default OIDCLandingError;
+

--- a/src/components/OIDCLandingError.test.js
+++ b/src/components/OIDCLandingError.test.js
@@ -1,0 +1,25 @@
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import OIDCLandingError from './OIDCLandingError';
+
+jest.mock('./OrganizationLogo', () => () => 'Logo');
+
+describe('OIDCLandingError', () => {
+  it('handles expected error shape', () => {
+    const error = {
+      errors: [
+        {
+          message: "To gain a standard for the appreciation of others' work"
+        }
+      ]
+
+    };
+    render(<OIDCLandingError error={error} />);
+    expect(screen.getByText(error.errors[0].message)).toBeInTheDocument();
+  });
+
+  it('handles unexpected error shape', () => {
+    const error = 'And the criticism of your own';
+    render(<OIDCLandingError error={error} />);
+    expect(screen.getByText(error, { exact: false })).toBeInTheDocument();
+  });
+});

--- a/src/components/useExchangeCode.js
+++ b/src/components/useExchangeCode.js
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useQuery } from 'react-query';
+import { useIntl } from 'react-intl';
+
+import useOkapiKy from '../useOkapiKy';
+import {
+  getLoginTenant,
+} from '../loginServices';
+import { useStripes } from '../StripesContext';
+
+const useExchangeCode = () => {
+  const stripes = useStripes();
+  const ky = useOkapiKy();
+  const intl = useIntl();
+
+  const [error, setError] = useState();
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const code = urlParams.get('code');
+  const { tenant, clientId } = getLoginTenant(stripes.okapi, stripes.config);
+
+  const { isFetching, data } = useQuery(
+    ['@folio/stripes-core', 'authn/token'],
+    () => {
+      if (code) {
+        return ky('authn/token', {
+          searchParams: {
+            code,
+            'redirect-uri': `${window.location.protocol}//${window.location.host}/oidc-landing?tenant=${tenant}&client_id=${clientId}`,
+          }
+        })
+          .json();
+      }
+
+      throw new Error(intl.formatMessage({ id: 'stripes-core.oidc.otp.missingCode' }));
+    },
+    {
+      retry: false,
+      onError: (e) => {
+        // pull error message from an API response if present,
+        // or directly from the Error object thrown during fetch
+        if (e?.response?.json) {
+          e.response.json()
+            .then(json => {
+              setError(json);
+            });
+        } else {
+          setError({ errors: [{ message: e.message }] });
+        }
+      }
+
+    }
+  );
+
+  return ({
+    data,
+    isLoading: isFetching,
+    error,
+  });
+};
+
+export default useExchangeCode;

--- a/src/components/useExchangeCode.test.js
+++ b/src/components/useExchangeCode.test.js
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import { createMemoryHistory } from 'history';
+
+import Harness from '../../test/jest/helpers/harness';
+import useOkapiKy from '../useOkapiKy';
+import OIDCLanding from './OIDCLanding';
+
+jest.mock('./OrganizationLogo', () => (() => <div>OrganizationLogo</div>));
+
+jest.mock('../useOkapiKy');
+
+describe('useExchangeCode', () => {
+  it('errors when code is missing from window.location.search', async () => {
+    const stripes = {
+      config: {},
+      hasPerm: jest.fn(),
+      okapi: {},
+    };
+    const history = createMemoryHistory();
+
+    render(<Harness history={history} stripes={stripes}><OIDCLanding /></Harness>);
+    await waitFor(() => {
+      screen.findByText('stripes-core.errors.oidc');
+    });
+  });
+
+  it('extracts errors from the authn/token reponse', async () => {
+    window.location.pathname = '/some-path';
+    window.location.search = '?code=code';
+
+    const message = 'I am nobody; who are you?';
+    const error = {
+      response: {
+        json: () => Promise.resolve({ errors: [{ message }] })
+      }
+    };
+
+    const stripes = {
+      config: {},
+      hasPerm: jest.fn(),
+      okapi: {},
+    };
+    const history = createMemoryHistory();
+    const mockUseOkapiKy = useOkapiKy;
+    mockUseOkapiKy.mockReturnValue(() => ({
+      json: () => { throw error; }
+    }));
+
+    render(<Harness history={history} stripes={stripes}><OIDCLanding /></Harness>);
+    await waitFor(() => {
+      screen.getByText(message);
+    });
+  });
+});

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -172,6 +172,9 @@
   "rtr.idleSession.keepWorking": "Keep working",
   "rtr.idleSession.sessionExpiredSoSad": "Your session expired due to inactivity.",
   "rtr.idleSession.logInAgain": "Log in again",
-  "rtr.fixedLengthSession.timeRemaining": "Your session will end soon! Time remaining:"
+  "rtr.fixedLengthSession.timeRemaining": "Your session will end soon! Time remaining:",
 
+  "oidc.validatingAuthenticationToken": "Validating authentication token...",
+  "oidc.initializingSession": "Initializing session...",
+  "oidc.otp.missingCode": "The query parameter 'code' is missing."
 }


### PR DESCRIPTION
## Summary 

Refactor the OIDC landing page to avoid making the OTP exchange request via `fetch()` in an effect, which failed in `<StrictMode>`.

## Details

OTP exchange has to happen exactly once (a repeat request causes the token and related sessions to be invalidated), which caused the original implementation to fail under `<StrictMode>` where effects always run twice.

Here, the OTP exchange is removed to a hook, resolving the double-effect glitch, and is also migrated to react-query for consistency. The remaining session-initialization remains in an effect. Bonus: the loading-spinner is now accompanied by a status message, relaying the current state: exchanging the token, or initializing the session.

Replaces PR #1652 / PR #1656

Refs [STCOR-986](https://folio-org.atlassian.net/browse/STCOR-987)