### PR TITLE
STCOR-976: Implement async modules loading infrastructure and update related components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Remove `RTR_IS_ROTATING` from local storage before dispatching the `RTR_SUCCESS_EVENT` to correctly determine the `RTR_IS_ROTATING` state in the `rotationHandler` function. Refs STCOR-983.
 * Correctly implement tenant-selection ringdown during application init. Refs STCOR-985.
 * Conform `@apollo/client` init to the v4 API to suppress warnings. Refs STCOR-992.
+* Implement async `modules` loading infrastructure and update related components. Refs STCOR-976.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/ModulesContext.js
+++ b/src/ModulesContext.js
@@ -1,7 +1,12 @@
 import React, { useContext } from 'react';
-import { modules } from 'stripes-config';
 
-export const ModulesContext = React.createContext(modules);
+export const modulesInitialState = {
+  app: [],
+  handler: [],
+  plugin: [],
+  settings: [],
+};
+
+export const ModulesContext = React.createContext(modulesInitialState);
 export default ModulesContext;
 export const useModules = () => useContext(ModulesContext);
-export { modules as originalModules };

--- a/src/Pluggable.js
+++ b/src/Pluggable.js
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { modules } from 'stripes-config';
+import { useModules } from './ModulesContext';
 import { withStripes } from './StripesContext';
 import { ModuleHierarchyProvider } from './components';
 
 const Pluggable = (props) => {
+  const modules = useModules();
   const plugins = modules.plugin || [];
   const cachedPlugins = useMemo(() => {
     const cached = [];
@@ -44,7 +45,8 @@ const Pluggable = (props) => {
     ));
   }
 
-  if (!props.children) return null;
+  // Display null when no plugins are available to avoid rendering BadRequestScreen
+  if (!props.children || !plugins.length) return null;
   if (props.children.length) {
     // eslint-disable-next-line no-console
     console.error(`<Pluggable type="${props.type}"> has ${props.children.length} children, can only return one`);

--- a/src/components/HandlerManager/HandlerManager.js
+++ b/src/components/HandlerManager/HandlerManager.js
@@ -19,18 +19,39 @@ class HandlerManager extends React.Component {
 
   constructor(props) {
     super(props);
-    const { event, stripes, modules, data } = props;
+    this.state = {
+      components: [],
+    };
+  }
 
-    this.components = getEventHandlers(event, stripes, modules.handler, data);
+  componentDidMount() {
+    this.updateComponents();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { modules } = this.props;
+
+    if (prevProps.modules !== modules) {
+      this.updateComponents();
+    }
+  }
+
+  updateComponents() {
+    const { event, stripes, modules, data } = this.props;
+
+    const components = getEventHandlers(event, stripes, modules.handler, data);
+    this.setState({ components });
   }
 
   render() {
     const { stripes, data, props } = this.props;
-    return (this.components.map(Component => (
+    const { components } = this.state;
+
+    return components.map(Component => (
       <ModuleHierarchyProvider key={Component.name} module={Component.module.module}>
         <Component stripes={stripes} actAs="handler" data={data} {...props} />
       </ModuleHierarchyProvider>
-    )));
+    ));
   }
 }
 

--- a/src/components/HandlerManager/HandlerManager.test.js
+++ b/src/components/HandlerManager/HandlerManager.test.js
@@ -1,0 +1,73 @@
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+
+import HandlerManager from './HandlerManager';
+
+import { getEventHandlers } from '../../handlerService';
+
+jest.mock('../../handlerService', () => ({
+  getEventHandlers: jest.fn(),
+}));
+
+let mockModulesProp = {};
+
+jest.mock('../Modules', () => ({
+  withModules: (Comp) => (props) => <Comp {...props} modules={mockModulesProp} />,
+}));
+
+jest.mock('../ModuleHierarchy', () => ({
+  ModuleHierarchyProvider: ({ children }) => <>{children}</>,
+}));
+
+const createMockHandlerComponent = (handlerName) => {
+  const HandlerComponent = ({ data }) => (
+    <div data-testid={`handler-${handlerName}`}>{data?.label || handlerName}</div>
+  );
+  HandlerComponent.module = { module: { module: handlerName } };
+  return HandlerComponent;
+};
+
+const getComponent = (props = {}) => <HandlerManager stripes={{}} {...props} />;
+const renderComponent = (props = {}) => render(getComponent(props));
+
+describe('HandlerManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockModulesProp = { handler: [] };
+  });
+
+  it('renders handlers on mount (componentDidMount -> updateComponents)', () => {
+    const FirstHandlerComponent = createMockHandlerComponent('First');
+    getEventHandlers.mockReturnValue([FirstHandlerComponent]);
+    mockModulesProp = { handler: [{}, {}] };
+
+    renderComponent({
+      event: 'create',
+    });
+
+    expect(getEventHandlers).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('handler-First')).toBeInTheDocument();
+  });
+
+  it('updates rendered handlers when modules prop changes (componentDidUpdate)', () => {
+    const FirstHandlerComponent = createMockHandlerComponent('First');
+    const SecondHandlerComponent = createMockHandlerComponent('Second');
+    const props = { event: 'update' };
+
+    getEventHandlers.mockReturnValueOnce([FirstHandlerComponent]);
+    mockModulesProp = { handler: [{}] };
+
+    const { rerender } = renderComponent(props);
+
+    expect(screen.getByTestId('handler-First')).toBeInTheDocument();
+    expect(getEventHandlers).toHaveBeenCalledTimes(1);
+
+    getEventHandlers.mockReturnValueOnce([FirstHandlerComponent, SecondHandlerComponent]);
+    mockModulesProp = { handler: [{}, {}, {}] };
+
+    rerender(getComponent(props));
+
+    expect(screen.getByTestId('handler-First')).toBeInTheDocument();
+    expect(screen.getByTestId('handler-Second')).toBeInTheDocument();
+    expect(getEventHandlers).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/LastVisited/withLastVisited.js
+++ b/src/components/LastVisited/withLastVisited.js
@@ -21,14 +21,8 @@ function withLastVisited(WrappedComponent) {
 
     constructor(props) {
       super();
-
-      const { modules, history } = props;
-
-      this.moduleList = modules.app.concat({
-        route: '/settings',
-        module: '@folio/x_settings',
-      });
-
+      const { history } = props;
+      this.moduleList = [];
       this.cachePreviousUrl = this.cachePreviousUrl.bind(this);
       this.lastVisited = {};
       this.previous = {};
@@ -40,6 +34,29 @@ function withLastVisited(WrappedComponent) {
         this.previous[name] = this.lastVisited[name];
         this.lastVisited[name] = `${location.pathname}${location.search}`;
         this.currentName = name;
+      });
+    }
+
+    componentDidMount() {
+      this.updateAppList();
+    }
+
+    componentDidUpdate(prevProps) {
+      const { modules } = this.props;
+
+      if (prevProps.modules !== modules) {
+        this.updateAppList();
+      }
+    }
+
+    updateAppList() {
+      const { modules } = this.props;
+
+      if (!modules.app?.length) return;
+
+      this.moduleList = modules.app.concat({
+        route: '/settings',
+        module: '@folio/x_settings',
       });
     }
 

--- a/src/components/LastVisited/withLastVisited.test.js
+++ b/src/components/LastVisited/withLastVisited.test.js
@@ -1,0 +1,90 @@
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import withLastVisited from './withLastVisited';
+import LastVisitedContext from './LastVisitedContext';
+
+let mockModulesData = {};
+let listeners = [];
+
+const mockHistory = {
+  listen: (fn) => {
+    listeners.push(fn);
+    return () => { listeners = listeners.filter(l => l !== fn); };
+  }
+};
+
+jest.mock('react-router', () => ({
+  withRouter: (Comp) => (props) => {
+    return <Comp {...props} history={mockHistory} />;
+  }
+}));
+
+jest.mock('../Modules', () => ({
+  withModules: (Comp) => (props) => <Comp {...props} modules={mockModulesData} />,
+}));
+
+const Component = ({ onRender }) => (
+  <LastVisitedContext.Consumer>
+    {({ lastVisited, cachePreviousUrl }) => {
+      onRender({ lastVisited, cachePreviousUrl });
+      return null;
+    }}
+  </LastVisitedContext.Consumer>
+);
+
+const Wrapped = withLastVisited(Component);
+
+const getComponent = (props = {}) => <Wrapped {...props} />;
+const renderComponent = (props = {}) => render(getComponent(props));
+
+describe('withLastVisited', () => {
+  beforeEach(() => {
+    listeners = [];
+    mockModulesData = { app: [] };
+  });
+
+  it('updates lastVisited during componentDidMount via history.listen', () => {
+    mockModulesData = {
+      app: [
+        { route: '/users', module: '@folio/users' },
+      ]
+    };
+
+    const renders = [];
+    const handleRender = (ctx) => { renders.push(ctx); };
+
+    renderComponent({ onRender: handleRender });
+
+    // Simulate navigation events that history.listen would provide.
+    listeners.forEach(l => l({ pathname: '/users', search: '' }));
+    listeners.forEach(l => l({ pathname: '/users/view/1', search: '?layer=edit' }));
+
+    const lastCtx = renders.at(-1);
+    expect(lastCtx.lastVisited.users).toBe('/users/view/1?layer=edit');
+  });
+
+  it('updates module list in componentDidUpdate and preserves previous lastVisited via cachePreviousUrl', () => {
+    mockModulesData = { app: [{ route: '/inventory', module: '@folio/inventory' }] };
+    const renders = [];
+    const handleRender = (ctx) => { renders.push(ctx); };
+
+    const { rerender } = renderComponent({ onRender: handleRender });
+
+    listeners.forEach(l => l({ pathname: '/inventory', search: '' }));
+    listeners.forEach(l => l({ pathname: '/inventory/view/uuid', search: '' }));
+
+    // trigger cachePreviousUrl to store previous location
+    const latest = renders.at(-1);
+    latest.cachePreviousUrl();
+
+    mockModulesData = { app: [{ route: '/inventory', module: '@folio/inventory' }, { route: '/orders', module: '@folio/orders' }] };
+    rerender(getComponent({ onRender: handleRender }));
+
+    listeners.forEach(l => l({ pathname: '/orders', search: '' }));
+
+    const finalCtx = renders.at(-1);
+
+    expect(finalCtx.lastVisited.inventory).toBe('/inventory');
+    expect(finalCtx.lastVisited.orders).toBe('/orders');
+  });
+});

--- a/src/components/MainNav/AppList/components/ResizeContainer/ResizeContainer.test.js
+++ b/src/components/MainNav/AppList/components/ResizeContainer/ResizeContainer.test.js
@@ -1,0 +1,253 @@
+import { createRef, forwardRef } from 'react';
+
+import { render, act } from '@folio/jest-config-stripes/testing-library/react';
+
+import ResizeContainer from './ResizeContainer';
+
+const makeItems = (n) => Array.from({ length: n }, (_, i) => ({ id: String(i + 1) }));
+
+const FIXED_ITEM_WIDTH = 120;
+const WRAPPER_WIDTH = 500;
+
+const Component = forwardRef(({
+  items,
+  currentAppId,
+  hideAllWidth,
+  offset,
+  className,
+}, ref) => (
+  <div
+    data-testid="outer"
+    style={{ width: WRAPPER_WIDTH }}
+  >
+    <ResizeContainer
+      ref={ref}
+      items={items}
+      currentAppId={currentAppId}
+      hideAllWidth={hideAllWidth}
+      offset={offset}
+      className={className}
+    >
+      {({ hiddenItems, itemWidths, ready }) => (
+        <div
+          data-testid="payload"
+          data-hidden-items={hiddenItems.join(',')}
+          data-ready={ready}
+        >
+          {items.map(item => (
+            <span key={item.id}>
+              <button
+                id={`app-list-item-${item.id}`}
+                type="button"
+              >
+                Item {item.id} ({itemWidths[item.id] || 0})
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </ResizeContainer>
+  </div>
+));
+
+const getComponent = (props = {}) => <Component {...props} />;
+const renderComponent = (props = {}) => render(getComponent(props));
+
+let originalOffsetWidth;
+let originalClientWidth;
+
+describe('ResizeContainer (Jest)', () => {
+  beforeEach(() => {
+    originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+    originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get() { return FIXED_ITEM_WIDTH; } });
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get() { return WRAPPER_WIDTH; } });
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (originalOffsetWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
+    }
+    if (originalClientWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+    }
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('sets ready after initialization when items exist', () => {
+    const items = makeItems(3);
+
+    const { getByTestId } = renderComponent({
+      items,
+      offset: 0,
+      hideAllWidth: 0,
+    });
+    const payload = getByTestId('payload');
+
+    expect(payload.getAttribute('data-ready')).toBe('true');
+  });
+
+  it('does not set ready when there are no initial items', () => {
+    const { getByTestId } = renderComponent({
+      items: [],
+      offset: 0,
+      hideAllWidth: 0,
+    });
+
+    const payload = getByTestId('payload');
+
+    expect(payload.getAttribute('data-ready')).toBe('false');
+  });
+
+  it('hides items that exceed wrapper width accounting for offset', () => {
+    const items = makeItems(10);
+    const offset = 50;
+
+    const { getByTestId } = renderComponent({
+      items,
+      offset,
+      hideAllWidth: 0,
+    });
+
+    const payload = getByTestId('payload');
+    const hidden = payload.getAttribute('data-hidden-items').split(',').filter(Boolean);
+
+    // capacity calculation: accumulate widths until width + item + offset would exceed wrapper
+    let acc = 0;
+    const hiddenCalc = [];
+
+    items.forEach(it => {
+      const fits = (FIXED_ITEM_WIDTH + acc + offset) <= WRAPPER_WIDTH;
+
+      if (!fits) {
+        hiddenCalc.push(it.id);
+      } else {
+        acc += FIXED_ITEM_WIDTH;
+      }
+    });
+
+    expect(hidden).toEqual(hiddenCalc);
+  });
+
+  it('hides all items when window.innerWidth <= hideAllWidth', () => {
+    const original = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 300 });
+    const items = makeItems(4);
+
+    const { getByTestId } = renderComponent({
+      items,
+      hideAllWidth: 400,
+      offset: 0,
+    });
+
+    const payload = getByTestId('payload');
+    const hidden = payload.getAttribute('data-hidden-items').split(',').filter(Boolean);
+
+    expect(hidden).toEqual(items.map(i => i.id));
+
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: original });
+  });
+
+  it('re-caches widths only when item ids set changes', () => {
+    const items1 = makeItems(3);
+    const ref = createRef();
+
+    const { rerender } = renderComponent({
+      ref,
+      items: items1,
+      hideAllWidth: 0,
+      offset: 0,
+    });
+
+    // Spy after initial mount so we only count subsequent calls
+    const cacheSpy = jest.spyOn(ref.current, 'cacheWidthsOfItems');
+    const itemsSameIds = items1.map(i => ({ id: i.id, foo: 'bar' }));
+
+    rerender(getComponent({
+      ref,
+      items: itemsSameIds,
+      hideAllWidth: 0,
+      offset: 0,
+    }));
+
+    expect(cacheSpy).not.toHaveBeenCalled();
+
+    const itemsNew = [...itemsSameIds, { id: '999' }];
+
+    rerender(getComponent({
+      ref,
+      items: itemsNew,
+      hideAllWidth: 0,
+      offset: 0,
+    }));
+
+    expect(cacheSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates hidden items when currentAppId changes', () => {
+    const items = makeItems(4);
+    const ref = createRef();
+
+    const { rerender } = renderComponent({
+      ref,
+      items,
+      currentAppId: '1',
+      hideAllWidth: 0,
+      offset: 0,
+    });
+
+    const updateSpy = jest.spyOn(ref.current, 'updateHiddenItems');
+
+    rerender(getComponent({
+      ref,
+      items,
+      currentAppId: '2',
+      hideAllWidth: 0,
+      offset: 0,
+    }));
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces resize events and calls updateHiddenItems once', () => {
+    const items = makeItems(5);
+    const ref = createRef();
+
+    renderComponent({
+      ref,
+      items,
+      hideAllWidth: 0,
+      offset: 0,
+    });
+
+    const updateSpy = jest.spyOn(ref.current, 'updateHiddenItems');
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    act(() => { jest.advanceTimersByTime(150); });
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes itemWidths for each item id', () => {
+    const items = makeItems(2);
+
+    const { getByText } = renderComponent({
+      items,
+      hideAllWidth: 0,
+      offset: 0,
+    });
+
+    items.forEach(i => {
+      expect(getByText(new RegExp(`Item ${i.id} \\(${FIXED_ITEM_WIDTH}\\)`))).toBeTruthy();
+    });
+  });
+});

--- a/src/components/ModuleTranslator/ModuleTranslator.js
+++ b/src/components/ModuleTranslator/ModuleTranslator.js
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 
-import { ModulesContext, originalModules } from '../../ModulesContext';
+import { getModules } from '../../entitlementService';
+import {
+  ModulesContext,
+  modulesInitialState,
+} from '../../ModulesContext';
 
 class ModuleTranslator extends React.Component {
   static propTypes = {
@@ -14,11 +18,22 @@ class ModuleTranslator extends React.Component {
     super(props);
 
     this.state = {
-      modules: this.translateModules(),
+      modules: modulesInitialState,
     };
   }
 
-  translateModules = () => {
+  async componentDidMount() {
+    try {
+      const moduleData = await getModules();
+      const modules = this.translateModules(moduleData);
+
+      this.setState({ modules });
+    } catch (error) {
+      console.error('Failed to load modules:', error); // eslint-disable-line
+    }
+  }
+
+  translateModules = (originalModules) => {
     return {
       app: (originalModules.app || []).map(this.translateModule),
       plugin: (originalModules.plugin || []).map(this.translateModule),

--- a/src/components/ModuleTranslator/ModuleTranslator.test.js
+++ b/src/components/ModuleTranslator/ModuleTranslator.test.js
@@ -1,0 +1,76 @@
+import { IntlProvider } from 'react-intl';
+
+import { render, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+
+import ModuleTranslator from './ModuleTranslator';
+import { ModulesContext } from '../../ModulesContext';
+import { getModules } from '../../entitlementService';
+
+jest.mock('../../entitlementService', () => ({
+  getModules: jest.fn(),
+}));
+
+const defaultMessages = {
+  'app.label': 'App Label',
+  'plugin.label': 'Plugin Label',
+  'settings.label': 'Settings Label',
+  'handler.label': 'Handler Label',
+};
+const renderWithIntl = ({
+  ui,
+  messages = defaultMessages,
+} = {}) => render(
+  <ModuleTranslator>
+    <ModulesContext.Consumer>
+      {({ app, plugin, settings, handler }) => (
+        <IntlProvider
+          locale="en"
+          messages={messages}
+        >
+          {ui || (
+            <div>
+              <div data-testid="app-name">{app[0]?.displayName}</div>
+              <div data-testid="plugin-name">{plugin[0]?.displayName}</div>
+              <div data-testid="settings-name">{settings[0]?.displayName}</div>
+              <div data-testid="handler-name">{handler[0]?.displayName}</div>
+            </div>
+          )}
+        </IntlProvider>
+      )}
+    </ModulesContext.Consumer>
+  </ModuleTranslator>
+);
+
+describe('ModuleTranslator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('assigns displayName from formatMessage call', async () => {
+    getModules.mockResolvedValueOnce({
+      app: [{ id: 'a1', displayName: 'app.label' }],
+      plugin: [{ id: 'p1', displayName: 'plugin.label' }],
+      settings: [{ id: 's1', displayName: 'settings.label' }],
+      handler: [{ id: 'h1', displayName: 'handler.label' }],
+    });
+
+    const { getByTestId } = renderWithIntl();
+
+    await waitFor(() => {
+      expect(getByTestId('app-name').textContent).toBe('app.label');
+      expect(getByTestId('plugin-name').textContent).toBe('plugin.label');
+      expect(getByTestId('settings-name').textContent).toBe('settings.label');
+      expect(getByTestId('handler-name').textContent).toBe('handler.label');
+    });
+  });
+
+  it('leaves displayName undefined when original module has no displayName field', async () => {
+    getModules.mockResolvedValueOnce({ app: [{ id: 'a1' }] });
+
+    const { getByTestId } = renderWithIntl();
+
+    await waitFor(() => {
+      expect(getByTestId('app-name').textContent).toBe('');
+    });
+  });
+});

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -26,7 +26,6 @@ import { configureRtr } from './token-util';
 
 import './Root.css';
 
-import { withModules } from '../Modules';
 import { FFetch } from './FFetch';
 
 if (!metadata) {
@@ -38,14 +37,13 @@ class Root extends Component {
   constructor(...args) {
     super(...args);
 
-    const { modules, history, okapi, store } = this.props;
+    const { okapi, store } = this.props;
 
     this.reducers = { ...initialReducers };
     this.epics = {};
     this.withOkapi = okapi.withoutOkapi !== true;
 
-    const appModule = getCurrentModule(modules, history.location);
-    this.queryResourceStateKey = (appModule) ? getQueryResourceKey(appModule) : null;
+    this.queryResourceStateKey = null;
     this.defaultRichTextElements = {
       b: (chunks) => <b>{chunks}</b>,
       i: (chunks) => <i>{chunks}</i>,
@@ -84,10 +82,26 @@ class Root extends Component {
     const locale = this.props.config.locale ?? 'en-US';
     // TODO: remove this after we load locale and translations at start from a public endpoint
     loadTranslations(store, locale, defaultTranslations);
+    this.updateQueryResourceStateKey();
   }
 
   shouldComponentUpdate(nextProps) {
-    return !this.withOkapi || nextProps.okapiReady || nextProps.serverDown;
+    const { modules } = this.props;
+    return nextProps.modules !== modules || !this.withOkapi || nextProps.okapiReady || nextProps.serverDown;
+  }
+
+  componentDidUpdate(prevProps) {
+    const { modules } = this.props;
+
+    if (prevProps.modules !== modules) {
+      this.updateQueryResourceStateKey();
+    }
+  }
+
+  updateQueryResourceStateKey = () => {
+    const { modules, history } = this.props;
+    const appModule = getCurrentModule(modules, history.location);
+    this.queryResourceStateKey = appModule ? getQueryResourceKey(appModule) : null;
   }
 
   addReducer = (key, reducer) => {
@@ -276,4 +290,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(withModules(Root));
+export default connect(mapStateToProps)(Root);

--- a/src/components/Root/Root.test.js
+++ b/src/components/Root/Root.test.js
@@ -1,0 +1,166 @@
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+
+import Root from './Root';
+
+jest.mock('../../loginServices', () => ({
+  loadTranslations: jest.fn(),
+  checkOkapiSession: jest.fn(),
+}));
+
+jest.mock('./token-util', () => ({ configureRtr: jest.fn().mockReturnValue({ rtr: true }) }));
+jest.mock('../SystemSkeleton', () => () => <div data-testid="system-skeleton">SystemSkeleton</div>);
+jest.mock('../../createApolloClient', () => jest.fn().mockReturnValue({}));
+jest.mock('../../createReactQueryClient', () => jest.fn().mockReturnValue({}));
+jest.mock('@apollo/client', () => ({ ApolloProvider: ({ children }) => <>{children}</> }));
+jest.mock('react-query', () => ({ QueryClientProvider: ({ children }) => <>{children}</> }));
+jest.mock('@folio/stripes-components', () => ({ ErrorBoundary: ({ children }) => <>{children}</> }));
+
+let latestContextFns = {};
+
+jest.mock('../../RootWithIntl', () => {
+  const { ConnectContext } = require('@folio/stripes-connect');
+  return ({ stripes }) => (
+    <ConnectContext.Consumer>
+      {(val) => {
+        latestContextFns = val; // capture addReducer/addEpic
+        return (
+          <div
+            data-testid="root-with-intl"
+            data-locale={stripes.locale}
+          >
+            RootWithIntl
+          </div>
+        );
+      }}
+    </ConnectContext.Consumer>
+  );
+});
+
+const makeStore = (stateOverrides = {}) => {
+  const state = {
+    okapi: {
+      bindings: {},
+      currency: 'USD',
+      currentPerms: {},
+      currentUser: {},
+      discovery: {},
+      isAuthenticated: false,
+      locale: 'en-US',
+      okapiReady: false,
+      plugins: {},
+      serverDown: false,
+      timezone: 'UTC',
+      token: undefined,
+      translations: { ready: true },
+      ...stateOverrides.okapi,
+    },
+    discovery: stateOverrides.discovery || { isFinished: true },
+    ...stateOverrides,
+  };
+
+  return {
+    getState: () => state,
+    dispatch: jest.fn(),
+    subscribe: jest.fn(),
+    replaceReducer: jest.fn(),
+  };
+};
+
+const getRootComponent = (props = {}) => (
+  <Root
+    store={makeStore()}
+    logger={{}}
+    epics={{ add: jest.fn() }}
+    config={{ locale: 'en-US', rtr: { enabled: true } }}
+    okapi={{ url: 'http://okapi', tenant: 'diku', withoutOkapi: false }}
+    actionNames={[]}
+    disableAuth
+    defaultTranslations={{}}
+    modules={{ app: [] }}
+    history={{ location: { pathname: '/', search: '' } }}
+    {...props}
+  />
+);
+
+const renderRoot = (props = {}) => render(getRootComponent(props));
+
+describe('Root component', () => {
+  it('shows server down message if serverDown state is true', () => {
+    const store = makeStore({ okapi: { serverDown: true } });
+
+    renderRoot({ store });
+
+    expect(screen.getByText(/server is forbidden, unreachable or down/i)).toBeInTheDocument();
+  });
+
+  it('renders SystemSkeleton while translations not loaded', () => {
+    const store = makeStore({ okapi: { translations: undefined } });
+
+    renderRoot({ store });
+
+    expect(screen.getByTestId('system-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('root-with-intl')).toBeNull();
+  });
+
+  it('renders RootWithIntl when translations are present', () => {
+    renderRoot();
+    expect(screen.getByTestId('root-with-intl')).toBeInTheDocument();
+  });
+
+  it('addEpic only adds a new epic once', () => {
+    const mockAdd = jest.fn();
+    const epic = jest.fn();
+
+    renderRoot({
+      epics: { add: mockAdd },
+    });
+
+    expect(latestContextFns.addEpic('epic1', epic)).toBe(true);
+    expect(latestContextFns.addEpic('epic1', epic)).toBe(false);
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates queryResourceStateKey on modules change', () => {
+    window.location.search = '?x=1';
+    const store = makeStore();
+    const initialModules = { app: [], settings: [] };
+
+    const history = {
+      location: { pathname: '/qm', search: '?x=1' },
+    };
+
+    const queryModule = {
+      route: '/qm',
+      queryResource: 'list',
+      module: 'QueryMod',
+    };
+
+    const props = {
+      store,
+      history,
+      modules: initialModules,
+      okapi: {
+        url: '',
+        tenant: 'diku',
+        withoutOkapi: true,
+      },
+    };
+
+    const { rerender } = renderRoot(props);
+
+    rerender(getRootComponent({
+      ...props,
+      modules: {
+        app: [queryModule],
+        settings: [],
+      },
+    }));
+
+    const passedReducer = jest.fn();
+    const result = latestContextFns.addReducer('query_mod_list', passedReducer);
+
+    expect(passedReducer).toHaveBeenCalledWith({ x: '1' }, expect.anything());
+    expect(store.replaceReducer).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+});

--- a/src/components/Root/token-util.test.js
+++ b/src/components/Root/token-util.test.js
@@ -11,7 +11,7 @@ import {
   RTR_IS_ROTATING,
   RTR_MAX_AGE,
 } from './token-util';
-import { 
+import {
   RTR_SUCCESS_EVENT,
   RTR_ERROR_EVENT,
 } from './constants';

--- a/src/entitlementService.js
+++ b/src/entitlementService.js
@@ -1,0 +1,12 @@
+import { modules } from 'stripes-config';
+
+/**
+ * Gets the module configuration data through a Promise interface.
+ *
+ * Currently returns modules from stripes-config wrapped in Promise.
+ * This maintains backward compatibility while providing the Promise-based
+ * interface needed for future dynamic loading.
+ */
+export function getModules() {
+  return new Promise(resolve => setTimeout(() => resolve(modules), 100));
+}

--- a/src/gatherActions.js
+++ b/src/gatherActions.js
@@ -1,6 +1,5 @@
 // Gather actionNames from all registered modules for hot-key mapping
 
-import { modules } from 'stripes-config';
 import stripesComponents from '@folio/stripes-components/package';
 
 function addKeys(moduleName, register, list) {
@@ -13,7 +12,7 @@ function addKeys(moduleName, register, list) {
   }
 }
 
-export default function gatherActions() {
+export default function gatherActions(modules) {
   const allActions = {};
 
   for (const key of Object.keys(modules)) {

--- a/src/gatherActions.test.js
+++ b/src/gatherActions.test.js
@@ -1,16 +1,14 @@
 import gatherActions from './gatherActions';
 
-jest.mock('stripes-config', () => ({
-  modules: {
-    a: { a: { module: 'a', actionNames: ['alice', 'andrew'] } },
-    b: { b: { module: 'b', actionNames: ['bea', 'bea'] } },
-    c: { c: { module: 'c' } },
-  },
-}));
+const modules = {
+  a: { a: { module: 'a', actionNames: ['alice', 'andrew'] } },
+  b: { b: { module: 'b', actionNames: ['bea', 'bea'] } },
+  c: { c: { module: 'c' } },
+};
 
 describe('gatherActions', () => {
   it('gathers actions from modules', () => {
-    const response = gatherActions();
+    const response = gatherActions(modules);
     expect(response).toContain('alice');
     expect(response).toContain('andrew');
     expect(response).toContain('bea');


### PR DESCRIPTION
## Purpose
Make `modules` loading asynchronous to prepare for future dynamic module loading capabilities. Currently, `modules` is imported synchronously from `stripes-config` at build time.

## Description
* The `entitlementService.js` is added. The new service provides Promise-based `getModules()` function. Currently wraps static `stripes-config` modules in Promise.
* The `getModules()` is applied in the `ModuleTranslator` provider to share the modules.
* The `getModules()` is also applied in the `App` component; perhaps, it might be worth wrapping the `App` component in `ModuleTranslator`.
* Updated `ResizeContainer`. Modules now appear asynchronously, so we need to recalculate the width of the nav list items not only on mount, but also when updating modules.
* Removed the `withModules` HOC from the `Root` component, since the provider of modules resides below the `Root`, and desn't provide the requested modules. `modules` is now passed down from the parent `App` component, since `modules` is also necessary there.

## Issues
[STCOR-976](https://folio-org.atlassian.net/browse/STCOR-976)