### PR TITLE
STCOR-805 supply `modules` on Stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Take `tenant` from URL for multi-tenant setup in `getLoginTenant`. Make `makeCall` method async to avoid displaying an error message when loading the password reset page. Refs STCOR-1000.
 * Use async/await consistently in all `loginServices.js` functions. Refs STCOR-1004.
 * Provide `<Suspense>` boundaries around modules and plugins. Refs STCOR-635.
+* Supply `modules` property on `Stripes`. Refs STCOR-805.
 
 ## [11.0.0](https://github.com/folio-org/stripes-core/tree/v11.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v10.2.0...v11.0.0)

--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -52,7 +52,7 @@ const AppRoutes = ({ modules, stripes }) => {
       path={module.route}
       key={module.route}
       render={props => {
-        const data = { displayName, name };
+        const data = { displayName, name, module: module.module };
 
         // allow SELECT_MODULE handlers to intervene
         const handlerComponents = getEventHandlers(events.SELECT_MODULE, moduleStripes, modules.handler, data);

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -185,6 +185,7 @@ class Root extends Component {
         perms: currentPerms,
       },
       connect(X) { return X; },
+      modules: this.props.modules,
     });
 
     return (


### PR DESCRIPTION
Supply `modules` to Stripes when initializing it, and for each module supply a module's `name` attribute from its `package.json` file in the `data` argument passed to an event handler.

`modules` is an object grouped by `type` typically shaped like
```
   app: [{ module: '@folio/users' }, { module: '@folio/checkin' }],
   settings: [{ module: '@folio/users' }, { module: '@folio/checkin' }],
   plugin: [ ... ],
   handler: [ ... ],
```
but it could also have a key like
```
  servicepointsConsumer: [{ module: '@folio/checkin' }]
```
that stripes-core does not know or care about. A handler-module like ui-servicepoints could leverage that key in a `SELECT_MODULE` handler to see if a value in the `stripes.modules.servicepointsConsumer` array matches the value from `data.module` (the incoming module). This allows modules to use their `actsAs` types to interact independently of any particular knowledge of those types in stripes-core. Note that in the example above, ui-checkin publishes a type and ui-servicepoints consumes that type, and stripes-core is utterly uninvolved.

Refs [STCOR-805](https://folio-org.atlassian.net/browse/STCOR-805)