### PR TITLE
STRIPES-901 - validate for conflicting peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "regenerator-runtime": "^0.13.10",
     "rtl-detect": "^1.0.2",
     "rxjs": "^6.6.3",
+    "semver": "^7.7.2",
     "use-deep-compare": "^1.1.0"
   },
   "peerDependencies": {

--- a/src/components/EntitlementLoader.js
+++ b/src/components/EntitlementLoader.js
@@ -6,6 +6,7 @@ import { useStripes } from '../StripesContext';
 import { useCallout } from '../CalloutContext';
 import { ModulesContext, useModules, modulesInitialState } from '../ModulesContext';
 import { loadEntitlement } from './loadEntitlement';
+import { validateRemoteDependencies } from './remoteDependencyValidation';
 
 // class for carrying formatted callout error messages.
 class RemoteModuleLoadingError extends Error {
@@ -212,11 +213,14 @@ const EntitlementLoader = ({ children }) => {
         }
 
         let cachedModules = modulesInitialState;
+        const validatedRemotes = remotes || [];
         const remotesWithLoadedAssets = [];
         const loadFailures = [];
 
         // if the signal is aborted, avoid all subsequent fetches, state updates...
         if (!signal.aborted) {
+          validateRemoteDependencies(validatedRemotes, signal);
+
           // load module assets (translations, icons)...
           const assetResults = await loadAllModuleAssets(stripes, remotes);
           assetResults.forEach((r, i) => {

--- a/src/components/EntitlementLoader.js
+++ b/src/components/EntitlementLoader.js
@@ -213,13 +213,12 @@ const EntitlementLoader = ({ children }) => {
         }
 
         let cachedModules = modulesInitialState;
-        const validatedRemotes = remotes || [];
         const remotesWithLoadedAssets = [];
         const loadFailures = [];
 
         // if the signal is aborted, avoid all subsequent fetches, state updates...
         if (!signal.aborted) {
-          validateRemoteDependencies(validatedRemotes, signal);
+          validateRemoteDependencies(signal, remotes);
 
           // load module assets (translations, icons)...
           const assetResults = await loadAllModuleAssets(stripes, remotes);

--- a/src/components/EntitlementLoader.js
+++ b/src/components/EntitlementLoader.js
@@ -6,7 +6,7 @@ import { useStripes } from '../StripesContext';
 import { useCallout } from '../CalloutContext';
 import { ModulesContext, useModules, modulesInitialState } from '../ModulesContext';
 import { loadEntitlement } from './loadEntitlement';
-import { validateRemoteDependencies } from './remoteDependencyValidation';
+import { logRemoteDependencyViolations } from './remoteDependencyValidation';
 
 // class for carrying formatted callout error messages.
 class RemoteModuleLoadingError extends Error {
@@ -218,7 +218,7 @@ const EntitlementLoader = ({ children }) => {
 
         // if the signal is aborted, avoid all subsequent fetches, state updates...
         if (!signal.aborted) {
-          validateRemoteDependencies(signal, remotes);
+          logRemoteDependencyViolations(signal, remotes);
 
           // load module assets (translations, icons)...
           const assetResults = await loadAllModuleAssets(stripes, remotes);

--- a/src/components/EntitlementLoader.test.js
+++ b/src/components/EntitlementLoader.test.js
@@ -230,6 +230,34 @@ describe('EntitlementLoader', () => {
         });
       }
     });
+
+    it('handles failures loading module assets (logs and sends callout)', async () => {
+      const discoveryUrl = 'http://localhost:8000/entitlement';
+      okapi.discoveryUrl = discoveryUrl;
+
+      // Override the describe-level fetch queue so this test gets exactly one success + one failure.
+      global.fetch = jest.fn();
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(translations)
+      }).mockResolvedValueOnce({ ok: false });
+
+      const mockCallout = { sendCallout: jest.fn() };
+      const calloutCtx = require('../CalloutContext');
+      const useCalloutSpy = jest.spyOn(calloutCtx, 'useCallout').mockReturnValue(mockCallout);
+
+      render(<TestHarness testStripes={{ ...mockStripes, okapi: { discoveryUrl } }} />);
+
+      await waitFor(() => {
+        expect(mockStripes.logger.log).toHaveBeenCalledWith(
+          'core',
+          expect.stringContaining('Error loading remote module assets')
+        );
+        expect(mockCallout.sendCallout).toHaveBeenCalled();
+      });
+
+      useCalloutSpy.mockRestore();
+    });
   });
 
   describe('when discoveryUrl is not configured', () => {

--- a/src/components/EntitlementLoader.test.js
+++ b/src/components/EntitlementLoader.test.js
@@ -6,10 +6,14 @@ import EntitlementLoader, { preloadModules, loadModuleAssets } from './Entitleme
 import { StripesContext } from '../StripesContext';
 import { ModulesContext, useModules, modulesInitialState as mockModuleInitialState } from '../ModulesContext';
 import { loadEntitlement } from './loadEntitlement';
+import { validateRemoteDependencies } from './remoteDependencyValidation';
 
 jest.mock('stripes-config');
 jest.mock('./loadEntitlement', () => ({
   loadEntitlement: jest.fn()
+}));
+jest.mock('./remoteDependencyValidation', () => ({
+  validateRemoteDependencies: jest.fn(() => Promise.resolve()),
 }));
 
 const mockLoadRemote = jest.fn(() => Promise.resolve({ default: {} }));
@@ -184,6 +188,7 @@ describe('EntitlementLoader', () => {
 
       await waitFor(() => {
         expect(loadEntitlement).toHaveBeenCalledWith(discoveryUrl, new AbortController().signal);
+        expect(validateRemoteDependencies).toHaveBeenCalled();
       });
     });
 

--- a/src/components/EntitlementLoader.test.js
+++ b/src/components/EntitlementLoader.test.js
@@ -6,14 +6,14 @@ import EntitlementLoader, { preloadModules, loadModuleAssets } from './Entitleme
 import { StripesContext } from '../StripesContext';
 import { ModulesContext, useModules, modulesInitialState as mockModuleInitialState } from '../ModulesContext';
 import { loadEntitlement } from './loadEntitlement';
-import { validateRemoteDependencies } from './remoteDependencyValidation';
+import { logRemoteDependencyViolations } from './remoteDependencyValidation';
 
 jest.mock('stripes-config');
 jest.mock('./loadEntitlement', () => ({
   loadEntitlement: jest.fn()
 }));
 jest.mock('./remoteDependencyValidation', () => ({
-  validateRemoteDependencies: jest.fn(() => Promise.resolve()),
+  logRemoteDependencyViolations: jest.fn(() => Promise.resolve()),
 }));
 
 const mockLoadRemote = jest.fn(() => Promise.resolve({ default: {} }));
@@ -188,7 +188,7 @@ describe('EntitlementLoader', () => {
 
       await waitFor(() => {
         expect(loadEntitlement).toHaveBeenCalledWith(discoveryUrl, new AbortController().signal);
-        expect(validateRemoteDependencies).toHaveBeenCalled();
+        expect(logRemoteDependencyViolations).toHaveBeenCalled();
       });
     });
 

--- a/src/components/remoteDependencyValidation.js
+++ b/src/components/remoteDependencyValidation.js
@@ -52,15 +52,16 @@ const validateManifestDependency = (remoteName, dependency) => {
 };
 
 /**
- * Validate remote modules for dependency compatibility against the host.
+ * Check remote modules for dependency compatibility against the host.
  * Fetches each remote's `mf-manifest.json` and checks shared dependency version ranges.
- * Any incompatibilities (required ranges from host that do not satisfy the remote's version) are collected and logged as a warning.
+ * Any incompatibilities (required ranges from host that do not satisfy the remote's version)
+ * are collected and logged as a warning.
  *
  * @param {AbortSignal} [signal] - AbortSignal to cancel network requests.
  * @param {Array<Object>} [remotes=[]] - Array of remote objects; each should include at least `name` and `assetPath`.
  * @returns {Promise<void>} Resolves when validation completes or is aborted.
  */
-export const validateRemoteDependencies = async (signal, remotes = []) => {
+export const logRemoteDependencyViolations = async (signal, remotes = []) => {
   if (signal?.aborted || !Array.isArray(remotes) || !remotes.length) {
     return;
   }

--- a/src/components/remoteDependencyValidation.js
+++ b/src/components/remoteDependencyValidation.js
@@ -1,15 +1,41 @@
 import satisfies from 'semver/functions/satisfies';
 
+/**
+ * Check whether the provided error is an AbortError.
+ * @param {any} error - The error object to inspect.
+ * @returns {boolean} True if the error is an AbortError, otherwise false.
+ */
 const isAbortError = (error) => error?.name === 'AbortError';
 
+/**
+ * Construct a message for failures fetching the remote's mf-manifest file.
+ * @param {string} remoteName - The name of the remote module.
+ * @param {string} manifestUrl - The URL of the mf-manifest that failed to fetch.
+ * @param {number|string} status - HTTP status or error code returned by the fetch.
+ * @returns {string} Human-readable error message.
+ */
 export const formatManifestFetchFailure = (remoteName, manifestUrl, status) => {
   return `[${remoteName}] failed to fetch manifest '${manifestUrl}' (${status})`;
 };
 
+/**
+ * Construct a message for dependency version mismatches.
+ * @param {string} remoteName - The name of the remote module.
+ * @param {string} pkgName - The package name that has a version mismatch.
+ * @param {string} version - The version used to build the remote.
+ * @param {string} requiredVersion - The host's provided version range.
+ * @returns {string} Human-readable mismatch message.
+ */
 export const formatDependencyMismatch = (remoteName, pkgName, version, requiredVersion) => {
   return `[${remoteName}] '${pkgName}' version '${version}' does not satisfy host's required version: '${requiredVersion}'`;
 };
 
+/**
+ * Validate a single shared dependency entry from a remote manifest.
+ * @param {string} remoteName - The name of the remote module the dependency belongs to.
+ * @param {Object} dependency - Dependency descriptor from the manifest (may include `name`/`id`, `version`, and `requiredVersion`).
+ * @returns {string|null} A formatted failure message if validation fails, otherwise null.
+ */
 const validateManifestDependency = (remoteName, dependency) => {
   const pkgName = dependency?.name || dependency?.id || 'unknown-package';
   const { version, requiredVersion } = dependency || {};
@@ -25,7 +51,16 @@ const validateManifestDependency = (remoteName, dependency) => {
   return null;
 };
 
-export const validateRemoteDependencies = async (remotes = [], signal) => {
+/**
+ * Validate remote modules for dependency compatibility against the host.
+ * Fetches each remote's `mf-manifest.json` and checks shared dependency version ranges.
+ * Any incompatibilities (required ranges from host that do not satisfy the remote's version) are collected and logged as a warning.
+ *
+ * @param {AbortSignal} [signal] - AbortSignal to cancel network requests.
+ * @param {Array<Object>} [remotes=[]] - Array of remote objects; each should include at least `name` and `assetPath`.
+ * @returns {Promise<void>} Resolves when validation completes or is aborted.
+ */
+export const validateRemoteDependencies = async (signal, remotes = []) => {
   if (signal?.aborted || !Array.isArray(remotes) || !remotes.length) {
     return;
   }
@@ -67,6 +102,6 @@ export const validateRemoteDependencies = async (remotes = [], signal) => {
   }
 
   // eslint-disable-next-line no-console
-  console.warn(`Remote dependency validation failed:\n${failures.map(f => `- ${f}`).join('\n')}`);
+  console.warn(`Remote dependency validation failed:\n${failures.map(f => '- ' + f).join('\n')}`);
 };
 

--- a/src/components/remoteDependencyValidation.js
+++ b/src/components/remoteDependencyValidation.js
@@ -11,7 +11,7 @@ const validateManifestDependency = (remoteName, dependency) => {
   }
 
   if (!satisfies(version, requiredVersion, { includePrerelease: true })) {
-    return `[${remoteName}] '${pkgName}' version '${version}' does not satisfy requiredVersion '${requiredVersion}'`;
+    return `[${remoteName}] '${pkgName}' version '${version}' does not satisfy host's required version: '${requiredVersion}'`;
   }
 
   return null;

--- a/src/components/remoteDependencyValidation.js
+++ b/src/components/remoteDependencyValidation.js
@@ -2,6 +2,14 @@ import satisfies from 'semver/functions/satisfies';
 
 const isAbortError = (error) => error?.name === 'AbortError';
 
+export const formatManifestFetchFailure = (remoteName, manifestUrl, status) => {
+  return `[${remoteName}] failed to fetch manifest '${manifestUrl}' (${status})`;
+};
+
+export const formatDependencyMismatch = (remoteName, pkgName, version, requiredVersion) => {
+  return `[${remoteName}] '${pkgName}' version '${version}' does not satisfy host's required version: '${requiredVersion}'`;
+};
+
 const validateManifestDependency = (remoteName, dependency) => {
   const pkgName = dependency?.name || dependency?.id || 'unknown-package';
   const { version, requiredVersion } = dependency || {};
@@ -11,7 +19,7 @@ const validateManifestDependency = (remoteName, dependency) => {
   }
 
   if (!satisfies(version, requiredVersion, { includePrerelease: true })) {
-    return `[${remoteName}] '${pkgName}' version '${version}' does not satisfy host's required version: '${requiredVersion}'`;
+    return formatDependencyMismatch(remoteName, pkgName, version, requiredVersion);
   }
 
   return null;
@@ -32,7 +40,7 @@ export const validateRemoteDependencies = async (remotes = [], signal) => {
       const response = await fetch(manifestUrl, { signal });
 
       if (!response.ok) {
-        failures.push(`[${remoteName}] failed to fetch manifest '${manifestUrl}' (${response.status})`);
+        failures.push(formatManifestFetchFailure(remoteName, manifestUrl, response.status));
         return;
       }
 

--- a/src/components/remoteDependencyValidation.js
+++ b/src/components/remoteDependencyValidation.js
@@ -1,0 +1,64 @@
+import satisfies from 'semver/functions/satisfies';
+
+const isAbortError = (error) => error?.name === 'AbortError';
+
+const validateManifestDependency = (remoteName, dependency) => {
+  const pkgName = dependency?.name || dependency?.id || 'unknown-package';
+  const { version, requiredVersion } = dependency || {};
+
+  if (!version || !requiredVersion) {
+    return null;
+  }
+
+  if (!satisfies(version, requiredVersion, { includePrerelease: true })) {
+    return `[${remoteName}] '${pkgName}' version '${version}' does not satisfy requiredVersion '${requiredVersion}'`;
+  }
+
+  return null;
+};
+
+export const validateRemoteDependencies = async (remotes = [], signal) => {
+  if (signal?.aborted || !Array.isArray(remotes) || !remotes.length) {
+    return;
+  }
+
+  const failures = [];
+
+  await Promise.all(remotes.map(async (remote) => {
+    const remoteName = remote?.name || 'unknown-remote';
+
+    try {
+      const manifestUrl = `${remote.assetPath}/mf-manifest.json`;
+      const response = await fetch(manifestUrl, { signal });
+
+      if (!response.ok) {
+        failures.push(`[${remoteName}] failed to fetch manifest '${manifestUrl}' (${response.status})`);
+        return;
+      }
+
+      const manifest = await response.json();
+      const sharedDependencies = Array.isArray(manifest?.shared) ? manifest.shared : [];
+
+      sharedDependencies.forEach((dependency) => {
+        const validationFailure = validateManifestDependency(remoteName, dependency);
+        if (validationFailure) {
+          failures.push(validationFailure);
+        }
+      });
+    } catch (error) {
+      if (isAbortError(error) || signal?.aborted) {
+        return;
+      }
+
+      failures.push(`[${remoteName}] ${error?.message || error}`);
+    }
+  }));
+
+  if (signal?.aborted || !failures.length) {
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.warn(`Remote dependency validation failed:\n${failures.map(f => `- ${f}`).join('\n')}`);
+};
+

--- a/src/components/remoteDependencyValidation.test.js
+++ b/src/components/remoteDependencyValidation.test.js
@@ -1,4 +1,4 @@
-import { validateRemoteDependencies } from './remoteDependencyValidation';
+import { validateRemoteDependencies, formatManifestFetchFailure, formatDependencyMismatch } from './remoteDependencyValidation';
 
 describe('remoteDependencyValidation', () => {
   let consoleWarnSpy;
@@ -44,7 +44,7 @@ describe('remoteDependencyValidation', () => {
       await expect(validateRemoteDependencies([
         { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
       ])).resolves.toBeUndefined();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("version '18.3.1' does not satisfy requiredVersion '^19.0.0'"));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'react', '18.3.1', '^19.0.0')));
     });
 
     it('warns when manifest cannot be fetched', async () => {
@@ -56,7 +56,7 @@ describe('remoteDependencyValidation', () => {
       await expect(validateRemoteDependencies([
         { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
       ])).resolves.toBeUndefined();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("failed to fetch manifest 'http://localhost:3000/mf-manifest.json' (404)"));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatManifestFetchFailure('folio_bulk_edit', 'http://localhost:3000/mf-manifest.json', 404)));
     });
 
     it('returns without error when aborted', async () => {

--- a/src/components/remoteDependencyValidation.test.js
+++ b/src/components/remoteDependencyValidation.test.js
@@ -3,6 +3,8 @@ import { validateRemoteDependencies, formatManifestFetchFailure, formatDependenc
 describe('remoteDependencyValidation', () => {
   let consoleWarnSpy;
 
+  const defaultRemote = { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' };
+
   beforeEach(() => {
     global.fetch = jest.fn();
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { });
@@ -14,6 +16,15 @@ describe('remoteDependencyValidation', () => {
   });
 
   describe('validateRemoteDependencies', () => {
+    it('returns without error when remotes are missing, empty, or not an array', async () => {
+      await expect(validateRemoteDependencies()).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies([])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies({ name: 'not-an-array' })).resolves.toBeUndefined();
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
     it('passes when all shared dependencies are semver-compatible', async () => {
       global.fetch.mockResolvedValueOnce({
         ok: true,
@@ -25,9 +36,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies([
-        { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
-      ])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -41,10 +50,63 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies([
-        { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
-      ])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'react', '18.3.1', '^19.0.0')));
+    });
+
+    it('uses dependency id as fallback package name in mismatch warnings', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          shared: [
+            { id: 'react-dom', version: '18.3.1', requiredVersion: '^19.0.0' },
+          ],
+        }),
+      });
+
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'react-dom', '18.3.1', '^19.0.0')));
+    });
+
+    it('uses unknown-package fallback when dependency has no name or id', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          shared: [
+            { version: '18.3.1', requiredVersion: '^19.0.0' },
+          ],
+        }),
+      });
+
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'unknown-package', '18.3.1', '^19.0.0')));
+    });
+
+    it('ignores dependencies missing version or requiredVersion', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          shared: [
+            { name: 'react', requiredVersion: '^18.0.0' },
+            { name: 'react-dom', version: '18.3.1' },
+          ],
+        }),
+      });
+
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('treats non-array manifest shared field as empty', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          shared: { react: '18.3.1' },
+        }),
+      });
+
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('warns when manifest cannot be fetched', async () => {
@@ -53,19 +115,78 @@ describe('remoteDependencyValidation', () => {
         status: 404,
       });
 
-      await expect(validateRemoteDependencies([
-        { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
-      ])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatManifestFetchFailure('folio_bulk_edit', 'http://localhost:3000/mf-manifest.json', 404)));
+    });
+
+    it('uses unknown-remote fallback in fetch failure warnings', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(validateRemoteDependencies([{ assetPath: 'http://localhost:3000' }])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatManifestFetchFailure('unknown-remote', 'http://localhost:3000/mf-manifest.json', 500)));
+    });
+
+    it('warns with thrown error message when manifest request throws non-abort error', async () => {
+      global.fetch.mockRejectedValueOnce(new Error('network exploded'));
+
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[folio_bulk_edit] network exploded'));
+    });
+
+    it('returns without warning when fetch throws AbortError', async () => {
+      global.fetch.mockRejectedValueOnce({ name: 'AbortError', message: 'aborted' });
+
+      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn if signal is aborted before warning stage', async () => {
+      const signal = { aborted: false };
+
+      global.fetch.mockImplementationOnce(() => {
+        signal.aborted = true;
+        return Promise.resolve({ ok: false, status: 404 });
+      });
+
+      await expect(validateRemoteDependencies([defaultRemote], signal)).resolves.toBeUndefined();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('returns without error when aborted', async () => {
       const signal = { aborted: true };
 
-      await expect(validateRemoteDependencies([
-        { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
-      ], signal)).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies([defaultRemote], signal)).resolves.toBeUndefined();
       expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('aggregates multiple failures into a single warning message', async () => {
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            shared: [
+              { name: 'react', version: '18.3.1', requiredVersion: '^19.0.0' },
+            ],
+          }),
+        });
+
+      await expect(validateRemoteDependencies([
+        { name: 'remote_a', assetPath: 'http://localhost:3000' },
+        { name: 'remote_b', assetPath: 'http://localhost:3001' },
+      ])).resolves.toBeUndefined();
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      const warning = consoleWarnSpy.mock.calls[0][0];
+      expect(warning).toContain('Remote dependency validation failed:');
+      expect(warning).toContain(`- ${formatManifestFetchFailure('remote_a', 'http://localhost:3000/mf-manifest.json', 404)}`);
+      expect(warning).toContain(`- ${formatDependencyMismatch('remote_b', 'react', '18.3.1', '^19.0.0')}`);
     });
   });
 });

--- a/src/components/remoteDependencyValidation.test.js
+++ b/src/components/remoteDependencyValidation.test.js
@@ -18,8 +18,8 @@ describe('remoteDependencyValidation', () => {
   describe('validateRemoteDependencies', () => {
     it('returns without error when remotes are missing, empty, or not an array', async () => {
       await expect(validateRemoteDependencies()).resolves.toBeUndefined();
-      await expect(validateRemoteDependencies([])).resolves.toBeUndefined();
-      await expect(validateRemoteDependencies({ name: 'not-an-array' })).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, { name: 'not-an-array' })).resolves.toBeUndefined();
 
       expect(global.fetch).not.toHaveBeenCalled();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
@@ -36,7 +36,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -50,7 +50,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'react', '18.3.1', '^19.0.0')));
     });
 
@@ -64,7 +64,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'react-dom', '18.3.1', '^19.0.0')));
     });
 
@@ -78,7 +78,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'unknown-package', '18.3.1', '^19.0.0')));
     });
 
@@ -93,7 +93,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -105,7 +105,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -115,7 +115,7 @@ describe('remoteDependencyValidation', () => {
         status: 404,
       });
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatManifestFetchFailure('folio_bulk_edit', 'http://localhost:3000/mf-manifest.json', 404)));
     });
 
@@ -125,21 +125,21 @@ describe('remoteDependencyValidation', () => {
         status: 500,
       });
 
-      await expect(validateRemoteDependencies([{ assetPath: 'http://localhost:3000' }])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [{ assetPath: 'http://localhost:3000' }])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatManifestFetchFailure('unknown-remote', 'http://localhost:3000/mf-manifest.json', 500)));
     });
 
     it('warns with thrown error message when manifest request throws non-abort error', async () => {
       global.fetch.mockRejectedValueOnce(new Error('network exploded'));
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[folio_bulk_edit] network exploded'));
     });
 
     it('returns without warning when fetch throws AbortError', async () => {
       global.fetch.mockRejectedValueOnce({ name: 'AbortError', message: 'aborted' });
 
-      await expect(validateRemoteDependencies([defaultRemote])).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -151,14 +151,14 @@ describe('remoteDependencyValidation', () => {
         return Promise.resolve({ ok: false, status: 404 });
       });
 
-      await expect(validateRemoteDependencies([defaultRemote], signal)).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(signal, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('returns without error when aborted', async () => {
       const signal = { aborted: true };
 
-      await expect(validateRemoteDependencies([defaultRemote], signal)).resolves.toBeUndefined();
+      await expect(validateRemoteDependencies(signal, [defaultRemote])).resolves.toBeUndefined();
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
@@ -177,7 +177,7 @@ describe('remoteDependencyValidation', () => {
           }),
         });
 
-      await expect(validateRemoteDependencies([
+      await expect(validateRemoteDependencies(undefined, [
         { name: 'remote_a', assetPath: 'http://localhost:3000' },
         { name: 'remote_b', assetPath: 'http://localhost:3001' },
       ])).resolves.toBeUndefined();

--- a/src/components/remoteDependencyValidation.test.js
+++ b/src/components/remoteDependencyValidation.test.js
@@ -1,4 +1,4 @@
-import { validateRemoteDependencies, formatManifestFetchFailure, formatDependencyMismatch } from './remoteDependencyValidation';
+import { logRemoteDependencyViolations, formatManifestFetchFailure, formatDependencyMismatch } from './remoteDependencyValidation';
 
 describe('remoteDependencyValidation', () => {
   let consoleWarnSpy;
@@ -15,11 +15,11 @@ describe('remoteDependencyValidation', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  describe('validateRemoteDependencies', () => {
+  describe('logRemoteDependencyViolations', () => {
     it('returns without error when remotes are missing, empty, or not an array', async () => {
-      await expect(validateRemoteDependencies()).resolves.toBeUndefined();
-      await expect(validateRemoteDependencies(undefined, [])).resolves.toBeUndefined();
-      await expect(validateRemoteDependencies(undefined, { name: 'not-an-array' })).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations()).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, { name: 'not-an-array' })).resolves.toBeUndefined();
 
       expect(global.fetch).not.toHaveBeenCalled();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
@@ -36,7 +36,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -50,7 +50,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'react', '18.3.1', '^19.0.0')));
     });
 
@@ -64,7 +64,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'react-dom', '18.3.1', '^19.0.0')));
     });
 
@@ -78,7 +78,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatDependencyMismatch('folio_bulk_edit', 'unknown-package', '18.3.1', '^19.0.0')));
     });
 
@@ -93,7 +93,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -105,7 +105,7 @@ describe('remoteDependencyValidation', () => {
         }),
       });
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -115,7 +115,7 @@ describe('remoteDependencyValidation', () => {
         status: 404,
       });
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatManifestFetchFailure('folio_bulk_edit', 'http://localhost:3000/mf-manifest.json', 404)));
     });
 
@@ -125,21 +125,21 @@ describe('remoteDependencyValidation', () => {
         status: 500,
       });
 
-      await expect(validateRemoteDependencies(undefined, [{ assetPath: 'http://localhost:3000' }])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [{ assetPath: 'http://localhost:3000' }])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining(formatManifestFetchFailure('unknown-remote', 'http://localhost:3000/mf-manifest.json', 500)));
     });
 
     it('warns with thrown error message when manifest request throws non-abort error', async () => {
       global.fetch.mockRejectedValueOnce(new Error('network exploded'));
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[folio_bulk_edit] network exploded'));
     });
 
     it('returns without warning when fetch throws AbortError', async () => {
       global.fetch.mockRejectedValueOnce({ name: 'AbortError', message: 'aborted' });
 
-      await expect(validateRemoteDependencies(undefined, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(undefined, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
@@ -151,14 +151,14 @@ describe('remoteDependencyValidation', () => {
         return Promise.resolve({ ok: false, status: 404 });
       });
 
-      await expect(validateRemoteDependencies(signal, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(signal, [defaultRemote])).resolves.toBeUndefined();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('returns without error when aborted', async () => {
       const signal = { aborted: true };
 
-      await expect(validateRemoteDependencies(signal, [defaultRemote])).resolves.toBeUndefined();
+      await expect(logRemoteDependencyViolations(signal, [defaultRemote])).resolves.toBeUndefined();
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
@@ -177,7 +177,7 @@ describe('remoteDependencyValidation', () => {
           }),
         });
 
-      await expect(validateRemoteDependencies(undefined, [
+      await expect(logRemoteDependencyViolations(undefined, [
         { name: 'remote_a', assetPath: 'http://localhost:3000' },
         { name: 'remote_b', assetPath: 'http://localhost:3001' },
       ])).resolves.toBeUndefined();

--- a/src/components/remoteDependencyValidation.test.js
+++ b/src/components/remoteDependencyValidation.test.js
@@ -1,0 +1,71 @@
+import { validateRemoteDependencies } from './remoteDependencyValidation';
+
+describe('remoteDependencyValidation', () => {
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('validateRemoteDependencies', () => {
+    it('passes when all shared dependencies are semver-compatible', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          shared: [
+            { name: 'react', version: '18.3.1', requiredVersion: '~18.3' },
+            { name: 'react-router-dom', version: '5.3.4', requiredVersion: '^5.2.0' },
+          ],
+        }),
+      });
+
+      await expect(validateRemoteDependencies([
+        { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
+      ])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns when a dependency version does not satisfy requiredVersion', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          shared: [
+            { name: 'react', version: '18.3.1', requiredVersion: '^19.0.0' },
+          ],
+        }),
+      });
+
+      await expect(validateRemoteDependencies([
+        { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
+      ])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("version '18.3.1' does not satisfy requiredVersion '^19.0.0'"));
+    });
+
+    it('warns when manifest cannot be fetched', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      await expect(validateRemoteDependencies([
+        { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
+      ])).resolves.toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("failed to fetch manifest 'http://localhost:3000/mf-manifest.json' (404)"));
+    });
+
+    it('returns without error when aborted', async () => {
+      const signal = { aborted: true };
+
+      await expect(validateRemoteDependencies([
+        { name: 'folio_bulk_edit', assetPath: 'http://localhost:3000' },
+      ], signal)).resolves.toBeUndefined();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12999,6 +12999,11 @@ semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
+semver@^7.7.2:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
 send@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"


### PR DESCRIPTION
## [STRIPES-901](https://folio-org.atlassian.net/browse/STRIPES-901)

Currently, we strip out shared singleton dependencies from ui-module builds with the [`import: false` configuration in `stripes-webpack`](https://github.com/folio-org/stripes-webpack/blob/main/module-federation-config.js#L53) so that there's no chance they'll be loaded in the bundle.
They're all mapped (forced) to use the host app's loaded dependency, so they don't make the request for a conflicting version (as they would if `import: false` were not used. Without that request, Module-federation's built-in dependency check/warn won't fire - and so we have to implement our own via this very PR!

Despite being missing from the bundled code, the version that the ui-module was built with is maintained within its generated `mf-manifest.json` file. The code here loads that file for each remote, inspects the JSON and checks for compatibility on the versions of shared dependencies. If an incompatibility is detected, a warning is emitted in the console.

 This check does *not block the rest of the modules from loading, nor does a module failing the check.
 
 This PR does include the addition of the `semver` library to `stripes-core`.
 
The console warning:
<img width="802" height="64" alt="image" src="https://github.com/user-attachments/assets/a20fc323-19bd-4544-8318-f1d25dd4a64a" />

Example `mf-manifest.json` from compatible `react` dep:
```
  "shared": [
    {
      "id": "folio_users:react",
      "name": "react",
      "version": "18.3.1", // version ui-module is built with...
      "singleton": true,
      "requiredVersion": "~18.3",  // @folio/stripes-core's version...
      "assets": {
        "js": {
          "async": [],
          "sync": []
        },
        "css": {
          "async": [],
          "sync": []
        }
      },
      "fallback": ""
    },
```

Offending app `mf-manifest.json`:
```
  "shared": [
    {
      "id": "folio_minimal_r_19:react",
      "name": "react",
      "version": "19.2.4",  // version ui-module is built with...
      "singleton": true,
      "requiredVersion": "~18.3",  // @folio/stripes-core's version...
      "assets": {
        "js": {
          "async": [],
          "sync": []
        },
        "css": {
          "async": [],
          "sync": []
        }
      },
      "fallback": ""
    }
  ],
```
