### PR TITLE
STCOR-1048 correctly handle unreliable AT metadata during RTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 11.1.2 IN PROGRESS
 
 * Export AuthenticatedError component. Refs STCOR-1047.
+* Recover from AT cookie deletion during RTR. Refs STCOR-1048.
 
 ## 11.1.0 IN PROGRESS
 

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -27,7 +27,6 @@
 
 import { RTR_LOCK_KEY, rotateAndReplay } from './rotateAndReplay';
 
-import { getTokenExpiry } from '../../loginServices';
 import {
   isFolioApiRequest,
 } from './token-util';

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -141,20 +141,6 @@ export class FFetch {
       }
     },
 
-    // isValidToken
-    // return true if a valid token is available
-    isValidToken: async () => {
-      try {
-        const expiry = await getTokenExpiry();
-        this.logger.log('rtr', `isValidToken ? ${expiry?.atExpires} > ${Date.now()} ? ${expiry?.atExpires > Date.now()}`);
-        return expiry?.atExpires > Date.now();
-      } catch (err) {
-        // swallow the error
-        this.logger.log('rtrv', { err });
-      }
-      return false;
-    },
-
     // onSuccess
     // rotation succeeded: call the success-callback
     onSuccess: async (newTokens) => {

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -161,11 +161,8 @@ export class FFetch {
    * ffetch (FOLIO-fetch) provides an RTR-wrapper around fetch requests for
    * FOLIO API requests. It pauses fetching while rotation is in-flight, and
    * if a response is not successful (!response.ok), it invokes RTR. RTR will
-   * inspect the response, rotate if necessary, then replay and return the
-   * original request, or it
-   *
-   * see if the failure was due to authentication (in which case it'll rotate
-   * and replay the request).
+   * inspect the response, rotate if necessary, then replay the request and
+   * return its response.
    *
    * @param {object} resource a fetchable resource
    * @param {object} options fetch options
@@ -173,51 +170,35 @@ export class FFetch {
    */
   ffetch = async (resource, options = {}) => {
     if (isFolioApiRequest(resource, this.okapi.url)) {
-      try {
-        let response;
-        // a fetch() resource can be either a string (which can be copied)
-        // or a Request object (which can only be consumed once, and needs
-        // to be cloned before it is used the first time in case this fetch
-        // triggers rotation and it needs to be replayed.
-        const reusableResource = resource instanceof Request ? resource.clone() : resource;
+      let response;
+      // a fetch() resource can be either a string (which can be copied)
+      // or a Request object (which can only be consumed once, and needs
+      // to be cloned before it is used the first time in case this fetch
+      // triggers rotation and it needs to be replayed.
+      const reusableResource = resource instanceof Request ? resource.clone() : resource;
 
-        // readers/writer lock pattern: don't fetch while rotation is in-progress
-        // https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request
-        // with a fallback for old (er, incomplete?) envs that don't support
-        // navigator.locks (👋 jsdom)
-        if (navigator?.locks?.request) {
-          response = await navigator.locks.request(RTR_LOCK_KEY, { mode: 'shared' }, async () => {
-            const fr = await this.nativeFetch.apply(globalThis, [resource, options && { ...options, ...OKAPI_FETCH_OPTIONS }]);
-            return fr;
-          });
-        } else {
-          response = await this.nativeFetch.apply(globalThis, [resource, options && { ...options, ...OKAPI_FETCH_OPTIONS }]);
-        }
-
-        if (!response?.ok) {
-          response = await rotateAndReplay(
-            this.nativeFetch,
-            { ...this.rotationConfig, logger: this.logger },
-            { response, resource: reusableResource, options }
-          );
-        }
-
-        return response;
-      } catch (err) {
-        // we can end up here for three reasons:
-        // 1. the original request itself failed
-        // 2. rotation failed
-        // 3. rotation was unnecessary and it rejected with the original reponse
-        //
-        // For #3, we just want to return that response, allowing it to bubble
-        // to the original caller to deal with as they choose. For the others,
-        // this is a legit error so we re-throw it rather than returning it.
-        if (err.response) {
-          return err.response;
-        }
-
-        throw err;
+      // readers/writer lock pattern: don't fetch while rotation is in-progress
+      // https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request
+      // with a fallback for old (er, incomplete?) envs that don't support
+      // navigator.locks (👋 jsdom)
+      if (navigator?.locks?.request) {
+        response = await navigator.locks.request(RTR_LOCK_KEY, { mode: 'shared' }, async () => {
+          const fr = await this.nativeFetch.apply(globalThis, [resource, options && { ...options, ...OKAPI_FETCH_OPTIONS }]);
+          return fr;
+        });
+      } else {
+        response = await this.nativeFetch.apply(globalThis, [resource, options && { ...options, ...OKAPI_FETCH_OPTIONS }]);
       }
+
+      if (!response?.ok) {
+        response = await rotateAndReplay(
+          this.nativeFetch,
+          { ...this.rotationConfig, logger: this.logger },
+          { response, resource: reusableResource, options }
+        );
+      }
+
+      return response;
     }
 
     // default: pass requests through to the network

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -171,20 +171,6 @@ describe('FFetch behavior and rotation helpers', () => {
       await expect(ff.rotationConfig.rotate()).rejects.toThrow('Rotation failure!');
     });
 
-    it('isValidToken returns true when token expiry is in future and false otherwise', async () => {
-      const { getTokenExpiry } = require('../../loginServices');
-      const ff = new FFetch({ logger: { log: jest.fn() }, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
-
-      getTokenExpiry.mockResolvedValueOnce({ atExpires: Date.now() + 10000 });
-      await expect(ff.rotationConfig.isValidToken()).resolves.toBe(true);
-
-      getTokenExpiry.mockResolvedValueOnce({ atExpires: Date.now() - 10000 });
-      await expect(ff.rotationConfig.isValidToken()).resolves.toBe(false);
-
-      getTokenExpiry.mockRejectedValueOnce(new Error('no storage'));
-      await expect(ff.rotationConfig.isValidToken()).resolves.toBe(false);
-    });
-
     it('replaceXMLHttpRequest sets global.XMLHttpRequest and preserves the original', () => {
       const dummy = function OldXhr() { };
       global.XMLHttpRequest = dummy;

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -28,7 +28,7 @@ describe('FFetch behavior and rotation helpers', () => {
         request: async (...av) => {
           if (av.length === 3) return av[2]();
           if (av.length === 2) return av[1]();
-          throw new Error('Cannot call navigator.locks.request without a function to execute!')
+          throw new Error('Cannot call navigator.locks.request without a function to execute!');
         },
       };
     }
@@ -212,7 +212,7 @@ describe('FFetch behavior and rotation helpers', () => {
 
     it('rotationConfig.onFailure dispatches an RTR error event', async () => {
       const ff = new FFetch({ logger: {}, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
-      const spy = jest.spyOn(window, 'dispatchEvent');
+      const spy = jest.spyOn(globalThis, 'dispatchEvent');
 
       await ff.rotationConfig.onFailure(new Error('boom'));
 

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -81,7 +81,7 @@ describe('FFetch behavior and rotation helpers', () => {
 
       // the fetch will fail, then rotation will reject with the same response
       mockFetch.mockResolvedValueOnce(failResp);
-      rotateAndReplay.mockRejectedValueOnce({ response: failResp });
+      rotateAndReplay.mockResolvedValueOnce(failResp);
 
       const ff = new FFetch({ logger: console, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
       ff.replaceFetch();

--- a/src/components/Root/rotateAndReplay.js
+++ b/src/components/Root/rotateAndReplay.js
@@ -6,34 +6,48 @@ export const RTR_LOCK_KEY = '@folio/stripes-core::RTR_LOCK_KEY';
 
 /**
  * rotateAndReplay
- * rotateAndReplay is called when a response has a 4xx code and if it looks
- * like an authentication problem, rotate the tokens, replay the original
- * request, and resolve with that response. If rotation does not happen (there
- * are many possible reasons, detailed below), reject with the original response.
- * If there are any errors related to rotation itself, report them via a callback
- * and then reject with the original response.
  *
- * 1. inspect the response and the config to determine if rotation is needed.
+ * IN SUMMARY
+ *
+ * rotateAndReplay is called when a request in FFetch returns a non-ok response.
+ * Here, we inspect the request-options and response in detail and if it looks
+ * like the problem was an expired (and therefore absent) AT cookie, rotate the
+ * tokens and then replay the original request, returning the new response. If
+ * the initial inspection fails (maybe we got a 404, which is a problem of
+ * course but not an RTR problem), reject with the original response so it can
+ * bubble back to the caller. If rotation itself fails, report the failure via
+ * the config callback and then reject with the original response (if
+ * available) or the rotation error.
+ *
+ * IN DETAIL
+ *
+ * 1. 🧐 inspect the response and the config to determine if rotation is needed.
  *    reject if any of the following are true:
  *    * we have a response but its code is not one we handle
  *    * the original request was configured with an `ignoreRtr` option
  *    * the config's shouldRotate() function returned false
- * 2. get an exclusive, browser-level lock, to avoid multiple tabs/windows
+ * 2. 🔒 get an exclusive, browser-level lock, to avoid multiple tabs/windows
  *    attempting to rotate simultaneously. the lock takes an async function
- *    and releases when the promise settles. within that promise, rotate.
+ *    and releases when the promise settles. within the lock's promise, rotate.
  *    if the rotation succeeds, replay the request and return the response.
  *
- * Inside the lock, the rotation process looks like this:
- * 1. Check storage to see if the token is still expired. When several requests
- *    fire together and then fail together, they'll queue up due to the browser
- *    lock. Once the first promise resolves, we can use its tokens for the
- *    remaining queued requests. This means that failed requests become
- *    single-threaded since they're all stuck here, waiting for the lock. Alas.
- * 2. Race a rejecting promise against the rotation request. We don't want
+ * Inside the lock's promise, rotation looks like this:
+ * 1. 👀 Inspect storage to see if the token is still expired. When several
+ *    requests fire together and then fail together, they'll queue up to enter
+ *    the lock and then proceed through it single-file. Although several
+ *    requests may be queued, only the first one in the queue needs to perform
+ *    rotation; the others can short-circuit straight to replay. Note, however,
+ *    that deleting the AT cookie without updating the expiration-data in
+ *    storage will lead to this check returning a stale response. In that
+ *    situation, even the first request through the lock will also trigger the
+ *    short-circuit to replay, but the replay will fail with a 401. Thus we
+ *    check the replay's status here, and if it indicates an authentication
+ *    failure we eject from the short-circuit and continue with rotation.
+ * 2. 🔄 Race a rejecting promise against the rotation request. We don't want
  *    to wait forever!
- * 3. Storage callback: update the token-expiration data in storage (so the
+ * 3. 💾 Storage callback: update the token-expiration data in storage (so the
  *    next queued request can retrieve it in Step 1).
- * 4. Replay the original request and return its response.
+ * 4. 🔂 Replay the original request and return its response.
  *
  * @param {*} fetchfx fetch function to execute
  * @param {*} config rotation configuration
@@ -44,6 +58,10 @@ export const RTR_LOCK_KEY = '@folio/stripes-core::RTR_LOCK_KEY';
  */
 export const rotateAndReplay = async (fetchfx, config, error) => {
   config.logger.log('rtr', 'queueRotateReplay...', config);
+
+  // rotation config
+  const shouldRotate = config.shouldRotate ?? (() => Promise.resolve(false));
+  const statusCodes = config.statusCodes || [401];
 
   /**
    * replayRequest
@@ -66,7 +84,7 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
 
   /**
    * rotateTokens
-   * 1. getTokens: maybe another request has already rotated
+   * 1. inspect: maybe another request has already rotated
    * 2. rotate: race the rotation request with a rejecting timeout
    * 3. callback: store updated token details
    * 4. replay: replay the original request
@@ -77,15 +95,22 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
     config.logger.log('rtr', 'locked ...');
     try {
       //
-      // 1. if rotation completed elsewhere, we don't need to rotate!
-      // maybe another tab rotated, maybe it happened while awaiting the lock.
+      // 1. 👀 If rotation completed elsewhere, we don't need to rotate!
+      // Maybe another tab rotated, maybe it happened while awaiting the lock.
+      // If this short-circuit-to-replay fails, however, that means our
+      // assumption that rotation completed elsewhere was wrong and we need to
+      // proceed with rotation.
       if (await config.isValidToken()) {
         config.logger.log('rtr', 'reusing token supplied by another request');
-        return replayRequest();
+        const replayResponse = await replayRequest();
+        if (!statusCodes.includes(replayResponse.status)) {
+          return replayResponse;
+        }
+        config.logger.log('rtr', 'replay failed; forcing rotate ...');
       }
 
       //
-      // 2. rotate: race the rotation-request with a timeout; default 30s
+      // 2. 🔄 rotate: race the rotation-request with a timeout; default 30s
       let rejectId = null;
       const refreshTimeout = new Promise((_res, rej) => {
         const timeout = config.refreshTimeout || ms('30s');
@@ -103,15 +128,15 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
       config.logger.log('rtr', '<=== rotated!');
 
       //
-      // 3. callback
+      // 3. 💾 callback: save new token-expiration value
       await config.onSuccess(t);
       config.logger.log('rtr', 'stored updated expiry ...');
 
       //
-      // 4. replay the original request
+      // 4. 🔂 replay the original request
       return replayRequest();
     } catch (err) {
-      // Ruhroh, Raggy, rotation railed!
+      // 💥 Ruhroh, Raggy, rotation railed!
       // Report the failure via the provided callback. Reject with the original
       // response if available, allowing it to bubble to the caller. Otherwise,
       // rethrow, i.e. reject with the object we just caught.
@@ -124,12 +149,7 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
     }
   };
 
-  // rotation config
-  const shouldRotate = config.shouldRotate ?? (() => Promise.resolve(false));
-  const statusCodes = config.statusCodes || [401];
-
-
-  // shouldRotate() forces rotation when it returns true. If false,
+  // 🧐 shouldRotate() forces rotation when it returns true. If false,
   // investigate the error response, allowing the error to bubble back to
   // the caller when:
   // 1. the response does not indicate an authn failure
@@ -142,7 +162,7 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
     }
   }
 
-  // lock, then rotate
+  // 🔒 lock, then rotate
   // default lock-mode is exclusive, preventing others from entering the lock
   // until this lock resolves (writer/readers pattern)
   if (navigator?.locks?.request) {

--- a/src/components/Root/rotateAndReplay.js
+++ b/src/components/Root/rotateAndReplay.js
@@ -77,7 +77,7 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
     }
 
     // XHR does not have a request to replay
-    return null;
+    return undefined;
   };
 
   /**

--- a/src/components/Root/rotateAndReplay.js
+++ b/src/components/Root/rotateAndReplay.js
@@ -91,11 +91,12 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
     try {
       //
       // 1. 👀 If rotation completed elsewhere, we don't need to rotate!
-      // Replay the request and inspect the response. If it's good, we're good.
-      // If it looks like an authentication failure, however, proceed to rotate.
+      // Replay the request and inspect the response for success. If it's ok,
+      // we're done and can return that response. If it's not 2xx/ok, rotate
+      // and then replay again.
       config.logger.log('rtr', 'reusing token supplied by another request');
       const replayResponse = await replayRequest();
-      if (replayResponse && !statusCodes.includes(replayResponse?.status)) {
+      if (replayResponse?.ok) {
         return replayResponse;
       }
       config.logger.log('rtr', 'replay failed; forcing rotate ...');
@@ -140,16 +141,17 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
     }
   };
 
-  // 🧐 shouldRotate() forces rotation when it returns true. If false,
-  // investigate the error response, allowing the error to bubble back to
-  // the caller when:
-  // 1. the response does not indicate an authn failure
+  // 🧐 shouldRotate() forces rotation when it returns true.
+  // here, we check the converse: what are reasons we should NOT rotate?
+  // 1. the response status does not indicate an authn failure
   // 2. the original request had an `rtrIgnore` option
+  // if rotation is not necessary, give the response right back and let it
+  // bubble back to its origin
   if (!await shouldRotate(error?.response)) {
     if ((error?.response && !statusCodes.includes(error.response.status)) ||
       error?.options?.rtrIgnore
     ) {
-      throw error;
+      return error.response;
     }
   }
 

--- a/src/components/Root/rotateAndReplay.js
+++ b/src/components/Root/rotateAndReplay.js
@@ -32,21 +32,19 @@ export const RTR_LOCK_KEY = '@folio/stripes-core::RTR_LOCK_KEY';
  *    if the rotation succeeds, replay the request and return the response.
  *
  * Inside the lock's promise, rotation looks like this:
- * 1. 👀 Inspect storage to see if the token is still expired. When several
- *    requests fire together and then fail together, they'll queue up to enter
- *    the lock and then proceed through it single-file. Although several
- *    requests may be queued, only the first one in the queue needs to perform
- *    rotation; the others can short-circuit straight to replay. Note, however,
- *    that deleting the AT cookie without updating the expiration-data in
- *    storage will lead to this check returning a stale response. In that
- *    situation, even the first request through the lock will also trigger the
- *    short-circuit to replay, but the replay will fail with a 401. Thus we
- *    check the replay's status here, and if it indicates an authentication
- *    failure we eject from the short-circuit and continue with rotation.
+ * 1. 👀 Immediately attempt to replay the request and observe the response.
+ *    Multiple requests may fail simultaneously across multiple tabs, and all
+ *    of them will be queued up to go through this lock single-file. In fact,
+ *    only the first request needs to rotate. Once that first request travels
+ *    through, performs rotation, and is replayed, the remaining requests in
+ *    the queue can short-circuit the process, abandoning the queue and
+ *    returning the replayed response without rotation. This means the first
+ *    request through the queue suffers a performance penalty (an extra failed
+ *    replay), but subsequent requests sail through more quickly. Feels like an
+ *    okay tradeoff.
  * 2. 🔄 Race a rejecting promise against the rotation request. We don't want
  *    to wait forever!
- * 3. 💾 Storage callback: update the token-expiration data in storage (so the
- *    next queued request can retrieve it in Step 1).
+ * 3. 💾 Storage callback: update the token-expiration data in storage.
  * 4. 🔂 Replay the original request and return its response.
  *
  * @param {*} fetchfx fetch function to execute
@@ -66,9 +64,8 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
   /**
    * replayRequest
    * replay the error'ed request, if there is one. unlike FFetch which traps
-   * and replays failed requests, FXHR simply checks for a valid token and
-   * rotates if it does not have one. (Its send() method is void, so we don't
-   * have an error-response to inspect.)
+   * and replays failed requests, FXHR checks for a valid token and invokes
+   * rotation if it does not have one prior to calling `super.send()`.
    *
    * @returns Promise
    */
@@ -78,8 +75,6 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
       const response = await fetchfx.apply(globalThis, [error.resource, config.options(error.options)]);
       return response;
     }
-
-    return Promise.resolve();
   };
 
   /**
@@ -96,18 +91,14 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
     try {
       //
       // 1. 👀 If rotation completed elsewhere, we don't need to rotate!
-      // Maybe another tab rotated, maybe it happened while awaiting the lock.
-      // If this short-circuit-to-replay fails, however, that means our
-      // assumption that rotation completed elsewhere was wrong and we need to
-      // proceed with rotation.
-      if (await config.isValidToken()) {
-        config.logger.log('rtr', 'reusing token supplied by another request');
-        const replayResponse = await replayRequest();
-        if (!statusCodes.includes(replayResponse.status)) {
-          return replayResponse;
-        }
-        config.logger.log('rtr', 'replay failed; forcing rotate ...');
+      // Replay the request and inspect the response. If it's good, we're good.
+      // If it looks like an authentication failure, however, proceed to rotate.
+      config.logger.log('rtr', 'reusing token supplied by another request');
+      const replayResponse = await replayRequest();
+      if (replayResponse && !statusCodes.includes(replayResponse?.status)) {
+        return replayResponse;
       }
+      config.logger.log('rtr', 'replay failed; forcing rotate ...');
 
       //
       // 2. 🔄 rotate: race the rotation-request with a timeout; default 30s
@@ -142,7 +133,7 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
       // rethrow, i.e. reject with the object we just caught.
       config.logger.log('rtr', 'RTR error!', err);
       await config.onFailure(err);
-      if (error.response) {
+      if (error?.response) {
         throw error;
       }
       throw err;

--- a/src/components/Root/rotateAndReplay.js
+++ b/src/components/Root/rotateAndReplay.js
@@ -75,6 +75,9 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
       const response = await fetchfx.apply(globalThis, [error.resource, config.options(error.options)]);
       return response;
     }
+
+    // XHR does not have a request to replay
+    return null;
   };
 
   /**

--- a/src/components/Root/rotateAndReplay.test.js
+++ b/src/components/Root/rotateAndReplay.test.js
@@ -11,7 +11,7 @@ describe('rotateAndReplay', () => {
         request: async (...av) => {
           if (av.length === 3) return av[2]();
           if (av.length === 2) return av[1]();
-          throw new Error('Cannot call navigator.locks.request without a function to execute!')
+          throw new Error('Cannot call navigator.locks.request without a function to execute!');
         },
       };
     }
@@ -32,7 +32,7 @@ describe('rotateAndReplay', () => {
   describe('with an error response', () => {
     describe('resolves', () => {
       test('short-circuits to replay when token is already valid', async () => {
-        const expected = { ok: true, body: 'replayed-response' }
+        const expected = { ok: true, body: 'replayed-response' };
         const fetchfx = jest.fn().mockResolvedValue(expected);
         const config = {
           logger: makeLogger(),

--- a/src/components/Root/rotateAndReplay.test.js
+++ b/src/components/Root/rotateAndReplay.test.js
@@ -29,7 +29,6 @@ describe('rotateAndReplay', () => {
         const fetchfx = jest.fn().mockResolvedValue('replayed-response');
         const config = {
           logger: makeLogger(),
-          isValidToken: jest.fn().mockResolvedValue(true),
           rotate: jest.fn(),
           onSuccess: jest.fn(),
           onFailure: jest.fn(),
@@ -44,18 +43,17 @@ describe('rotateAndReplay', () => {
         const res = await rotateAndReplay(fetchfx, config, error);
         expect(res).toBe('replayed-response');
         expect(fetchfx).toHaveBeenCalledWith('/foo', { some: 'opt' });
-        expect(config.isValidToken).toHaveBeenCalled();
         expect(config.rotate).not.toHaveBeenCalled();
         expect(config.onSuccess).not.toHaveBeenCalled();
         expect(config.onFailure).not.toHaveBeenCalled();
       });
 
       test('`config.shouldRotate()` forces rotation then replays and returns the new response', async () => {
-        const fetchfx = jest.fn().mockResolvedValue('after-rotate-response');
+        const fetchfx = jest.fn().mockResolvedValueOnce({ status: 401 })
+          .mockResolvedValueOnce('after-rotate-response');
         const rotateResult = { token: 'abc' };
         const config = {
           logger: makeLogger(),
-          isValidToken: jest.fn().mockResolvedValue(false),
           rotate: jest.fn().mockResolvedValue(rotateResult),
           onSuccess: jest.fn().mockResolvedValue(undefined),
           onFailure: jest.fn().mockResolvedValue(undefined),
@@ -73,11 +71,12 @@ describe('rotateAndReplay', () => {
       });
 
       test('matched default error code causes rotation then replays and returns the new response', async () => {
-        const fetchfx = jest.fn().mockResolvedValue('after-rotate-response');
+        const fetchfx = jest.fn().mockResolvedValueOnce({ status: 401 })
+          .mockResolvedValueOnce('after-rotate-response');
+
         const rotateResult = { token: 'abc' };
         const config = {
           logger: makeLogger(),
-          isValidToken: jest.fn().mockResolvedValue(false),
           rotate: jest.fn().mockResolvedValue(rotateResult),
           onSuccess: jest.fn().mockResolvedValue(undefined),
           onFailure: jest.fn().mockResolvedValue(undefined),
@@ -94,11 +93,12 @@ describe('rotateAndReplay', () => {
       });
 
       test('matched custom error code causes rotation then replays and returns the new response', async () => {
-        const fetchfx = jest.fn().mockResolvedValue('after-rotate-response');
+        const fetchfx = jest.fn().mockResolvedValueOnce({ status: 666 })
+          .mockResolvedValueOnce('after-rotate-response');
+
         const rotateResult = { token: 'abc' };
         const config = {
           logger: makeLogger(),
-          isValidToken: jest.fn().mockResolvedValue(false),
           rotate: jest.fn().mockResolvedValue(rotateResult),
           onSuccess: jest.fn().mockResolvedValue(undefined),
           onFailure: jest.fn().mockResolvedValue(undefined),
@@ -118,11 +118,10 @@ describe('rotateAndReplay', () => {
 
     describe('rejects', () => {
       test('calls onFailure and rejects with the original error when rotation fails', async () => {
-        const fetchfx = jest.fn();
+        const fetchfx = jest.fn().mockResolvedValueOnce({ status: 401 });
         const rotateErr = new Error('rotate failed');
         const config = {
           logger: makeLogger(),
-          isValidToken: jest.fn().mockResolvedValue(false),
           rotate: jest.fn().mockRejectedValue(rotateErr),
           onSuccess: jest.fn().mockResolvedValue(undefined),
           onFailure: jest.fn().mockResolvedValue(undefined),
@@ -134,7 +133,7 @@ describe('rotateAndReplay', () => {
 
         await expect(rotateAndReplay(fetchfx, config, originalError)).rejects.toBe(originalError);
         expect(config.onFailure).toHaveBeenCalled();
-        expect(fetchfx).not.toHaveBeenCalled();
+        expect(fetchfx).toHaveBeenCalledWith(originalError.resource, originalError.options);
       });
 
       test('with the original reponse if the response status does not match', async () => {
@@ -164,12 +163,11 @@ describe('rotateAndReplay', () => {
   describe('without an error response (XHR)', () => {
     // effectively, this is just a test of whether `shouldRotate` forces
     // rotation when no error response is present, e.g. in an XHR
-    test('shouldRotate forces rotation then returns undefined', async () => {
+    test.only('shouldRotate forces rotation then returns undefined', async () => {
       const fetchfx = jest.fn().mockResolvedValue('after-rotate-response');
       const rotateResult = { token: 'abc' };
       const config = {
         logger: makeLogger(),
-        isValidToken: jest.fn().mockResolvedValue(false),
         rotate: jest.fn().mockResolvedValue(rotateResult),
         onSuccess: jest.fn().mockResolvedValue(undefined),
         onFailure: jest.fn().mockResolvedValue(undefined),
@@ -189,7 +187,6 @@ describe('rotateAndReplay', () => {
     const rotateResult = { token: 'nav' };
     const config = {
       logger: makeLogger(),
-      isValidToken: jest.fn().mockResolvedValue(false),
       rotate: jest.fn().mockResolvedValue(rotateResult),
       onSuccess: jest.fn().mockResolvedValue(undefined),
       onFailure: jest.fn().mockResolvedValue(undefined),

--- a/src/components/Root/rotateAndReplay.test.js
+++ b/src/components/Root/rotateAndReplay.test.js
@@ -26,7 +26,8 @@ describe('rotateAndReplay', () => {
   describe('with an error response', () => {
     describe('resolves', () => {
       test('short-circuits to replay when token is already valid', async () => {
-        const fetchfx = jest.fn().mockResolvedValue('replayed-response');
+        const expected = { ok: true, body: 'replayed-response' }
+        const fetchfx = jest.fn().mockResolvedValue(expected);
         const config = {
           logger: makeLogger(),
           rotate: jest.fn(),
@@ -41,7 +42,7 @@ describe('rotateAndReplay', () => {
         const error = { resource: '/foo', options: { some: 'opt' } };
 
         const res = await rotateAndReplay(fetchfx, config, error);
-        expect(res).toBe('replayed-response');
+        expect(res).toBe(expected);
         expect(fetchfx).toHaveBeenCalledWith('/foo', { some: 'opt' });
         expect(config.rotate).not.toHaveBeenCalled();
         expect(config.onSuccess).not.toHaveBeenCalled();
@@ -114,10 +115,32 @@ describe('rotateAndReplay', () => {
         expect(config.onSuccess).toHaveBeenCalledWith(rotateResult);
         expect(fetchfx).toHaveBeenCalledWith('/bar', { foo: 'bar' });
       });
+
+      test('with the original reponse if the response status does not match', async () => {
+        const fetchfx = jest.fn();
+        const config = {
+          logger: makeLogger(),
+          options: jest.fn((opts) => opts),
+        };
+
+        const err = { response: { status: 403 }, options: {} };
+        await expect(rotateAndReplay(fetchfx, config, err)).resolves.toBe(err.response);
+      });
+
+      test('with the original reseponse if the request\'s rtrIgnore option is true', async () => {
+        const fetchfx = jest.fn();
+        const config = {
+          logger: makeLogger(),
+          options: jest.fn((opts) => opts),
+        };
+
+        const err = { response: { status: 404 }, options: { rtrIgnore: true } };
+        await expect(rotateAndReplay(fetchfx, config, err)).resolves.toBe(err.response);
+      });
     });
 
     describe('rejects', () => {
-      test('calls onFailure and rejects with the original error when rotation fails', async () => {
+      test('when rotation fails, calls onFailure and rejects with the original error when rotation fails', async () => {
         const fetchfx = jest.fn().mockResolvedValueOnce({ status: 401 });
         const rotateErr = new Error('rotate failed');
         const config = {
@@ -135,35 +158,13 @@ describe('rotateAndReplay', () => {
         expect(config.onFailure).toHaveBeenCalled();
         expect(fetchfx).toHaveBeenCalledWith(originalError.resource, originalError.options);
       });
-
-      test('with the original reponse if the response status does not match', async () => {
-        const fetchfx = jest.fn();
-        const config = {
-          logger: makeLogger(),
-          options: jest.fn((opts) => opts),
-        };
-
-        const err = { response: { status: 403 }, options: {} };
-        await expect(rotateAndReplay(fetchfx, config, err)).rejects.toBe(err);
-      });
-
-      test('with the original reseponse if the request\'s rtrIgnore option is true', async () => {
-        const fetchfx = jest.fn();
-        const config = {
-          logger: makeLogger(),
-          options: jest.fn((opts) => opts),
-        };
-
-        const err = { response: { status: 404 }, options: { rtrIgnore: true } };
-        await expect(rotateAndReplay(fetchfx, config, err)).rejects.toBe(err);
-      });
     });
   });
 
   describe('without an error response (XHR)', () => {
     // effectively, this is just a test of whether `shouldRotate` forces
     // rotation when no error response is present, e.g. in an XHR
-    test.only('shouldRotate forces rotation then returns undefined', async () => {
+    test('shouldRotate forces rotation then returns undefined', async () => {
       const fetchfx = jest.fn().mockResolvedValue('after-rotate-response');
       const rotateResult = { token: 'abc' };
       const config = {


### PR DESCRIPTION
## Summary 

If the AT cookie and its corresponding expiration data in the session object in local storage get out of sync (e.g. somebody deletes cookies), Stripes will be in an inconsistent state: its AT is missing, but its session data indicates that a valid AT is present. This PR addresses that inconsistency, allowing RTR to recover and proceed with rotation. 

## Approach

Favor simplicity over cleverness: we know the token's metadata can be unreliable, so we don't rely on it. If a cookie was deleted prior to expiration but metadata in storage is never updated, there's nothing we can do to detect that. In that situation, the previous algorithm worked like this: all requests through the queue would check storage, find it valid, replay, and return the response without inspecting for success, allowing 401s to bubble to their origin (whoops). This PR simplifies and corrects the logic: all requests through the queue attempt replay and all responses are inspected. The first one will fail, rotate, and replay. Subsequent requests replay and (assuming they are successful) short-circuit.

This means the first request in the queue pays a performance penalty (an extra failed replay attempt) but every other request in the queue goes through more efficiently (no async storage check). It also simplifies the logic because we don't spend any effort trying to figure out "Do we think this request is likely to succeed because we have an unverifiable belief that our token is valid?" We just make requests and deal with the consequences.

This PR also addresses a wart with the earlier implementation regarding the handling of non-ok responses that entered the rotation queue but were determined not to have failed due to a missing AT (e.g. a 404, 403, etc). Now, if rotation is determined to be unnecessary, `rotateAndReplay()` returns the response instead of throwing it. Not rotating is not an exceptional condition, it's just ... not rotating. Back in `FFetch`, we would check for this and return the response from the `catch` clause. By not throwing this non-error, `FFetch` can be simplified too, omitting the now-unnecessary `catch` that would do nothing except rethrowing.

Refs [STCOR-1048](https://folio-org.atlassian.net/browse/STCOR-1048)