### PR TITLE
STCOR-1054 - Add an additional exception case for rotation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 11.1.2 IN PROGRESS
 
 * Export AuthenticatedError component. Refs STCOR-1047.
+* Add case for `users-keycloak`'s 404 status to rotate keys on failure. STCOR-1054.
 
 ## 11.1.0 IN PROGRESS
 

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -95,14 +95,18 @@ export class FFetch {
 
     // shouldRotate
     // alternative to status code inspection when a response is present:
-    // deal with Okapi's non-standard 400 response for missing/invalid tokens
+    // deal with Okapi's non-standard 400 response for missing/invalid tokens,
+    // as well as /users-keycloak's 404 response for missing token
     // by cloning the response and inspecting the body text.
     // optional; defaults to a function that resolves to false, i.e. do not force rotation
     shouldRotate: async (response) => {
       if (response) {
         const cr = response.clone();
         const text = await cr.text();
-        return response.status === 400 && text.startsWith('Token missing, access requires permission');
+        return (
+          (response.status === 400 && text.startsWith('Token missing, access requires permission')) ||
+          (response.status === 404 && response.url?.includes('/users-keycloak/'))
+        );
       }
 
       return false;

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -105,7 +105,8 @@ export class FFetch {
         const text = await cr.text();
         return (
           (response.status === 400 && text.startsWith('Token missing, access requires permission')) ||
-          (response.status === 404 && response.url?.includes('/users-keycloak/'))
+          (response.status === 404 && response.url?.includes('/users-keycloak/_self')) ||
+          (response.status === 404 && response.url?.includes('/bl-users/_self'))
         );
       }
 


### PR DESCRIPTION
## [STCOR-1054](https://folio-org.atlassian.net/browse/STCOR-1054)

This PR adds a new `shouldRotate` case with /users-keycloak/ response of 404.
The non-typical (subj?) response from this module - and lack of our necessary handling (refresh!!) - can end up being the [Bubba Wallace](https://www.nascar.com/news-media/2026/04/26/cup-series-big-one-strikes-talladega-spring-bubba-wallace-involved/) - of a slew of potential abrupt logout cases. This can occur any time a page is refreshed (any action causing refresh) or when a new tab is opened.

The placement of the logic here is definitely up for discussion, but the case itself is fairly straightforward - and a similar patch could likely be applied to *ahem - that OTHER rtr implementation...