### PR TITLE
STCOR-1055 adopt FFetch's rotation logic in FXHR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Export AuthenticatedError component. Refs STCOR-1047.
 * Add case for `users-keycloak`'s 404 status to rotate keys on failure. STCOR-1054.
 * Test-logic only belongs in tests, Refs STCOR-1050.
+* Adopt FFetch's rotation logic in FXHR for consistency. Refs STCOR-1055.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -1,10 +1,5 @@
-import { getTokenExpiry } from '../../loginServices';
 import { rotateAndReplay } from './rotateAndReplay';
 import { isFolioApiRequest } from './token-util';
-import {
-  RTR_ERROR_EVENT,
-} from './constants';
-import { RTRError } from './Errors';
 
 export default (deps) => {
   return class FXHRClass extends XMLHttpRequest {
@@ -20,30 +15,37 @@ export default (deps) => {
       super.open(method, url);
     }
 
-    send = async (payload) => {
-      const { logger } = this.FFetchContext;
-      this.FFetchContext.logger?.log('rtr', 'capture XHR send');
-      if (this.shouldEnsureToken) {
-        try {
-          const expiry = await getTokenExpiry();
-          if (expiry?.atExpires < Date.now()) {
-            await rotateAndReplay(
-              this.FFetchContext.nativeFetch,
-              { ...this.FFetchContext.rotationConfig, logger: this.FFetchContext.logger, shouldRotate: async () => Promise.resolve(true) },
-            );
-          }
-          super.send(payload);
-        } catch (err) {
-          if (err instanceof RTRError) {
-            console.error('RTR failure while attempting XHR', err); // eslint-disable-line no-console
-            window.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: err }));
-          }
-          throw err;
-        }
+    /**
+     * Capture failure-to-launch errors that are the result of calling send()
+     * with an expired AT and attempt to re-launch. Pass all other errors up
+     * to the superclass.
+     * @param {ProgressEvent} e https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
+     */
+    onerror = (e) => {
+      // if no data was loaded, this is a FOLIO API request, and we have not
+      // already restarted, one possibility is that the AT was expired. Rotate
+      // and try again.
+      if (e.loaded === 0 && this.shouldEnsureToken && !this.didRestart) {
+        this.FFetchContext.logger?.log('rtr', 'XHR rotateAndReplay');
+        rotateAndReplay(
+          this.FFetchContext.nativeFetch,
+          { ...this.FFetchContext.rotationConfig, logger: this.FFetchContext.logger, shouldRotate: async () => true },
+        )
+          .then(() => {
+            this.didRestart = true;
+            this.send(this.payload);
+          });
       } else {
-        logger.log('rtr', 'request passed through, sending XHR...');
-        super.send(payload);
+        super.onerror(e);
       }
+    }
+
+    send = (payload) => {
+      // cache in case we need to conduct RTR and restart
+      this.payload = payload;
+
+      this.FFetchContext.logger?.log('rtr', 'capture XHR send');
+      super.send(payload);
     };
   };
 };

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -1,6 +1,4 @@
-// import { rtr } from './token-util';
 import { rotateAndReplay } from './rotateAndReplay';
-import { getTokenExpiry } from '../../loginServices';
 import FXHR from './FXHR';
 
 jest.mock('./token-util', () => ({
@@ -10,12 +8,6 @@ jest.mock('./token-util', () => ({
 jest.mock('./rotateAndReplay', () => ({
   ...(jest.requireActual('./rotateAndReplay')),
   rotateAndReplay: jest.fn(() => Promise.resolve()),
-}));
-
-jest.mock('../../loginServices', () => ({
-  ...(jest.requireActual('../../loginServices')),
-  setTokenExpiry: jest.fn(() => Promise.resolve()),
-  getTokenExpiry: jest.fn(() => Promise.resolve())
 }));
 
 const openSpy = jest.spyOn(XMLHttpRequest.prototype, 'open').mockImplementation();
@@ -29,7 +21,7 @@ describe('FXHR', () => {
   let testXHR;
   beforeEach(() => {
     jest.clearAllMocks();
-    FakeXHR = FXHR({ tokenExpiration: { atExpires: Date.now(), rtExpires: Date.now() + 5000 }, logger: { log: () => { } }, okapi: { url: 'okapiUrl' } });
+    FakeXHR = FXHR({ logger: { log: () => { } }, okapi: { url: 'okapiUrl' } });
     testXHR = new FakeXHR();
   });
 
@@ -59,11 +51,6 @@ describe('FXHR', () => {
   });
 
   it('Does not rotate if token is valid', () => {
-    getTokenExpiry.mockResolvedValue({
-      atExpires: Date.now() + (10 * 60 * 1000),
-      rtExpires: Date.now() + (10 * 60 * 1000),
-    });
-
     testXHR.addEventListener('abort', mockHandler);
     testXHR.open('POST', 'okapiUrl');
     testXHR.send(new ArrayBuffer(8));
@@ -72,17 +59,16 @@ describe('FXHR', () => {
     expect(rotateAndReplay).not.toHaveBeenCalled();
   });
 
-  it('Rotates if token is expired', async () => {
-    getTokenExpiry.mockResolvedValue({
-      atExpires: Date.now() - (10 * 60 * 1000),
-      rtExpires: Date.now() + (10 * 60 * 1000),
-    });
+  it('onerror rotates and calls send when an error is received before any data is loaded', () => {
     console.log({ rotateAndReplay });
     testXHR.addEventListener('abort', mockHandler);
     testXHR.open('POST', 'okapiUrl');
-    await testXHR.send(new ArrayBuffer(8));
+    testXHR.send(new ArrayBuffer(8));
+    testXHR.onerror({ loaded: 0 });
     expect(openSpy.mock.calls).toHaveLength(1);
     expect(aelSpy.mock.calls).toHaveLength(1);
     expect(rotateAndReplay).toHaveBeenCalled();
+    // logging shows send() is called twice, but sendSpy only counts one call.
+    // I don't understand that.
   });
 });


### PR DESCRIPTION
Use similar patterns in these similar classes, i.e. attempt to make a request, trap unsuccessful responses, rotate, and replay. We abandoned checking the (unreliable) AT expiration data in FFetch in PR #1710; here we do the same for FXHR, capturing `error` events and inspecting them to divine the reason for the failure.

There is not a lot to go on in an XHR request; all we can really see is how much data has been transfered and how much data we expect to transfer. Here, we interpret "no data sent" as "I bet we couldn't send data because we didn't have a valid token" so we rotate and try again. We only try rotation once. Errors received after a second attempt or after any data has been transfered are passed straight up to the superclass.

This PR also resolves a minor wart on the earlier implementation, replacing the async/await based-logic with a Promise-based implementation. Because `send()` and `onerror()` are void, we cannot leverage `await`. Instead, we just have to do our work inside an un-returned promise chain.

NB: I couldn't figure out how to write a test that could validate `send()` being called twice (the original invocation, plus the replayed one after the error is trapped). Logging bears out that it works correctly. Why doesn't the spy work?

Refs [STCOR-1055](https://folio-org.atlassian.net/browse/STCOR-1055)