### PR TITLE
STCOR-1058 rotate given a 422 from /authn/logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Test-logic only belongs in tests, Refs STCOR-1050.
 * Add case for `users-keycloak`'s 404 status to rotate keys on failure. STCOR-1054.
 * Recover from AT cookie deletion during RTR. Refs STCOR-1048.
+* Add case for `authn/logout`'s 422 status to rotate keys on failure. STCOR-1058.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -38,7 +38,7 @@ import {
 } from './constants';
 import FXHR from './FXHR';
 
-const OKAPI_FETCH_OPTIONS = {
+const FOLIO_FETCH_OPTIONS = {
   credentials: 'include',
   mode: 'cors',
 };
@@ -89,7 +89,7 @@ export class FFetch {
     // function that receives the original request options and returns the
     // options-object that will be used on the replayed request.
     options: (options = {}) => {
-      return { ...options, ...OKAPI_FETCH_OPTIONS };
+      return { ...options, ...FOLIO_FETCH_OPTIONS };
     },
 
     // shouldRotate
@@ -105,7 +105,8 @@ export class FFetch {
         return (
           (response.status === 400 && text.startsWith('Token missing, access requires permission')) ||
           (response.status === 404 && response.url?.includes('/users-keycloak/_self')) ||
-          (response.status === 404 && response.url?.includes('/bl-users/_self'))
+          (response.status === 404 && response.url?.includes('/bl-users/_self')) ||
+          (response.status === 422 && response.url?.includes('/authn/logout'))
         );
       }
 
@@ -184,7 +185,7 @@ export class FFetch {
       // readers/writer lock pattern: don't fetch while rotation is in-progress
       // https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request
       response = await navigator.locks.request(RTR_LOCK_KEY, { mode: 'shared' }, async () => {
-        const fr = await this.nativeFetch.apply(globalThis, [resource, options && { ...options, ...OKAPI_FETCH_OPTIONS }]);
+        const fr = await this.nativeFetch.apply(globalThis, [resource, options && { ...options, ...FOLIO_FETCH_OPTIONS }]);
         return fr;
       });
 

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -132,22 +132,60 @@ describe('FFetch behavior and rotation helpers', () => {
 
   describe('rotationConfig helpers', () => {
     describe('shouldRotate', () => {
-      it('without a response, returns false', async () => {
-        const ff = new FFetch({ logger: {}, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
-        const shouldRotate = await ff.rotationConfig.shouldRotate();
-        expect(shouldRotate).toBe(false);
+      describe('returns true', () => {
+        it('given a 400 with okapi\'s special error text, returns true', async () => {
+          const res = new Response('Token missing, access requires permission', { status: 400 })
+          const ff = new FFetch({ logger: {}, okapi: { url: '/users-keycloak/_self', tenant: 't' }, onRotate: jest.fn() });
+          const shouldRotate = await ff.rotationConfig.shouldRotate(res);
+          expect(shouldRotate).toBe(true);
+        });
+
+        it('given a 404 at /users-keycloak/_self', async () => {
+          const res = new Response('whateva', { status: 404, url: '/users-keycloak/_self' });
+          const ff = new FFetch({ logger: {}, okapi: { url: '/bl-users/_self', tenant: 't' }, onRotate: jest.fn() });
+          const shouldRotate = await ff.rotationConfig.shouldRotate(res);
+          expect(shouldRotate).toBe(true);
+        });
+
+        it('given a 404 at /bl-users/_self', async () => {
+          const res = new Response('whateva', { status: 404, url: '/bl-users/_self' });
+          const ff = new FFetch({ logger: {}, okapi: { url: '/bl-users/_self', tenant: 't' }, onRotate: jest.fn() });
+          const shouldRotate = await ff.rotationConfig.shouldRotate(res);
+          expect(shouldRotate).toBe(true);
+        });
+
+        it('given a 422 at /authn/logout', async () => {
+          const res = new Response('whateva', { status: 422, url: '/authn/logout' });
+          const ff = new FFetch({ logger: {}, okapi: { url: '/bl-users/_self', tenant: 't' }, onRotate: jest.fn() });
+          const shouldRotate = await ff.rotationConfig.shouldRotate(res);
+          expect(shouldRotate).toBe(true);
+        });
       });
 
-      it('given a 400 with okapi\'s special error text, returns true', async () => {
-        const ff = new FFetch({ logger: {}, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
-        const shouldRotate = await ff.rotationConfig.shouldRotate(new Response('Token missing, access requires permission', { status: 400 }));
-        expect(shouldRotate).toBe(true);
-      });
+      describe('returns false', () => {
+        it('without a response to investigate', async () => {
+          const ff = new FFetch({ logger: {}, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
+          const shouldRotate = await ff.rotationConfig.shouldRotate();
+          expect(shouldRotate).toBe(false);
+        });
 
-      it('given a 400 with generic text, returns false', async () => {
-        const ff = new FFetch({ logger: {}, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
-        const shouldRotate = await ff.rotationConfig.shouldRotate(new Response('Nobody here but us chickens', { status: 400 }));
-        expect(shouldRotate).toBe(false);
+        it('given a 400 without okapi\'s specific text', async () => {
+          const ff = new FFetch({ logger: {}, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
+          const shouldRotate = await ff.rotationConfig.shouldRotate(new Response('Nobody here but us chickens', { status: 400 }));
+          expect(shouldRotate).toBe(false);
+        });
+
+        it('given a 404 somewhere other than /users-keycloak/_self or /bl-users/_self', async () => {
+          const ff = new FFetch({ logger: {}, okapi: { url: '/somewhere/safe', tenant: 't' }, onRotate: jest.fn() });
+          const shouldRotate = await ff.rotationConfig.shouldRotate(new Response('Nobody here but us chickens', { status: 404 }));
+          expect(shouldRotate).toBe(false);
+        });
+
+        it('given a 422 somewhere other than /authn/logout', async () => {
+          const ff = new FFetch({ logger: {}, okapi: { url: '/somewhere/safe', tenant: 't' }, onRotate: jest.fn() });
+          const shouldRotate = await ff.rotationConfig.shouldRotate(new Response('Nobody here but us chickens', { status: 404 }));
+          expect(shouldRotate).toBe(false);
+        });
       });
     });
 

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -183,7 +183,7 @@ describe('FFetch behavior and rotation helpers', () => {
 
         it('given a 422 somewhere other than /authn/logout', async () => {
           const ff = new FFetch({ logger: {}, okapi: { url: '/somewhere/safe', tenant: 't' }, onRotate: jest.fn() });
-          const shouldRotate = await ff.rotationConfig.shouldRotate(new Response('Nobody here but us chickens', { status: 404 }));
+          const shouldRotate = await ff.rotationConfig.shouldRotate(new Response('Nobody here but us chickens', { status: 422 }));
           expect(shouldRotate).toBe(false);
         });
       });


### PR DESCRIPTION
Rotate-and-replay upon receiving a 422 from `/authn/logout`. Typically, endpoints return a 401 when they require a token but do not receive one. Some, however, return non-standard responses that we still need to handle.

Refs [STCOR-1058](https://folio-org.atlassian.net/browse/STCOR-1058)