### PR TITLE
STCOR-1059 short-circuit from RTR given { rtrIgnore: true }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Test-logic only belongs in tests, Refs STCOR-1050.
 * Add case for `users-keycloak`'s 404 status to rotate keys on failure. STCOR-1054.
 * Recover from AT cookie deletion during RTR. Refs STCOR-1048.
+* Completely avoid rotation-related work given a request with `options.rtrIgnore`. Refs STCOR-1059.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -188,6 +188,10 @@ export class FFetch {
         return fr;
       });
 
+      if (options?.rtrIgnore) {
+        return response;
+      }
+
       if (!response?.ok) {
         response = await rotateAndReplay(
           this.nativeFetch,

--- a/src/components/Root/FFetch.test.js
+++ b/src/components/Root/FFetch.test.js
@@ -63,6 +63,22 @@ describe('FFetch behavior and rotation helpers', () => {
     expect(res).toBe(expected);
   });
 
+  it('ignores rotation in requests with options containing "rtrIgnore: true "', async () => {
+    const { rotateAndReplay } = require('./rotateAndReplay');
+    const failResp = { ok: false, status: 401, body: 'ruhroh, "the island of missing trees" was, um, missing' };
+
+    mockFetch.mockResolvedValueOnce(failResp);
+    rotateAndReplay.mockResolvedValueOnce(failResp);
+
+    const ff = new FFetch({ logger: console, okapi: { url: okapiUrl, tenant: 't' }, onRotate: jest.fn() });
+    ff.replaceFetch();
+
+    const res = await globalThis.fetch(`${okapiUrl}/as/the/token/turns`, { rtrIgnore: true });
+    expect(res).toBe(failResp);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(rotateAndReplay).not.toHaveBeenCalled();
+  });
+
   it('uses navigator.locks.request when available', async () => {
     // provide LockManager
     const lockCb = jest.fn((key, opts, cb) => cb());

--- a/src/components/Root/rotateAndReplay.js
+++ b/src/components/Root/rotateAndReplay.js
@@ -144,22 +144,15 @@ export const rotateAndReplay = async (fetchfx, config, error) => {
     }
   };
 
-  // 🧐 shouldRotate() forces rotation when it returns true.
-  // here, we check the converse: what are reasons we should NOT rotate?
-  // 1. the response status does not indicate an authn failure
-  // 2. the original request had an `rtrIgnore` option
-  // if rotation is not necessary, give the response right back and let it
-  // bubble back to its origin
-  if (!await shouldRotate(error?.response)) {
-    if ((error?.response && !statusCodes.includes(error.response.status)) ||
-      error?.options?.rtrIgnore
-    ) {
-      return error.response;
-    }
+  // 🧐 are we certain we need to rotate? check these two conditions:
+  // 1. shouldRotate() asked for rotation
+  // 2. the response status indicates we need rotation
+  if (await shouldRotate(error?.response) || statusCodes.includes(error?.response?.status)) {
+    // 🔒 lock, then rotate
+    // default lock-mode is exclusive, preventing others from entering the lock
+    // until this lock resolves (writer/readers pattern)
+    return navigator.locks.request(RTR_LOCK_KEY, rotateTokens);
   }
 
-  // 🔒 lock, then rotate
-  // default lock-mode is exclusive, preventing others from entering the lock
-  // until this lock resolves (writer/readers pattern)
-  return navigator.locks.request(RTR_LOCK_KEY, rotateTokens);
+  return error?.response;
 };


### PR DESCRIPTION
When a request's `options` argument contains `rtrIgnore: true`, short-circuit ASAP. This is more efficient and simpler. Previously, we checked this option inside `rotateAndReplay()`, which made the should-we-rotate? logic there difficult to follow.

Refs [STCOR-1059](https://folio-org.atlassian.net/browse/STCOR-1059)