### PR TITLE
STCOR-1055 FXHR functionality refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Export AuthenticatedError component. Refs STCOR-1047.
 * Add case for `users-keycloak`'s 404 status to rotate keys on failure. STCOR-1054.
 * Test-logic only belongs in tests, Refs STCOR-1050.
+* Adopt FFetch's rotation logic in FXHR for consistency. Refs STCOR-1055.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -1,51 +1,147 @@
 import { rotateAndReplay } from './rotateAndReplay';
 import { isFolioApiRequest } from './token-util';
+import {
+  RTR_ERROR_EVENT,
+} from './constants';
+import { RTRError } from './Errors';
 
 export default (deps) => {
   return class FXHRClass extends XMLHttpRequest {
     constructor() {
       super();
       this.shouldEnsureToken = false;
+      this.hasRetriedAuth = false;
+      this.isReplaying = false;
+      this.requestMethod = null;
+      this.requestUrl = null;
+      this.requestOpenArgs = null;
+      this.requestPayload = null;
+      this.requestHeaders = [];
+      this.requestWithCredentials = false;
+      this.userOnReadyStateChange = null;
       this.FFetchContext = deps;
+
+      // Always route readystatechange through the wrapper so auth failures can
+      // be handled before consumer callbacks are invoked.
+      super.onreadystatechange = this.handleInternalReadyStateChange;
     }
 
-    open = (method, url) => {
+    open = (method, url, ...rest) => {
       this.FFetchContext.logger?.log('rtr', 'capture XHR.open');
       this.shouldEnsureToken = isFolioApiRequest(url, this.FFetchContext.okapi.url);
-      super.open(method, url);
+      this.requestMethod = method;
+      this.requestUrl = url;
+      this.requestOpenArgs = [method, url, ...rest];
+      this.requestHeaders = [];
+      this.requestWithCredentials = false;
+      this.hasRetriedAuth = false;
+      super.open(method, url, ...rest);
     }
 
-    /**
-     * Capture failure-to-launch errors that are the result of calling send()
-     * with an expired AT and attempt to re-launch. Pass all other errors up
-     * to the superclass.
-     * @param {ProgressEvent} e https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
-     */
-    onerror = (e) => {
-      // if no data was loaded, this is a FOLIO API request, and we have not
-      // already restarted, one possibility is that the AT was expired. Rotate
-      // and try again.
-      if (e.loaded === 0 && this.shouldEnsureToken && !this.didRestart) {
-        this.FFetchContext.logger?.log('rtr', 'XHR rotateAndReplay');
-        rotateAndReplay(
+    setRequestHeader = (header, value) => {
+      this.requestHeaders.push([header, value]);
+      super.setRequestHeader(header, value);
+    }
+
+    isAuthFailureResponse = () => {
+      if (this.status === 401) {
+        return true;
+      }
+
+      if (this.status === 400 && typeof this.responseText === 'string') {
+        return this.responseText.startsWith('Token missing, access requires permission');
+      }
+
+      return false;
+    }
+
+    replayRequest = () => {
+      if (!this.requestOpenArgs) {
+        return false;
+      }
+
+      this.isReplaying = true;
+      super.open(...this.requestOpenArgs);
+      try {
+        this.withCredentials = this.requestWithCredentials;
+      } catch (_err) {
+        // In test harnesses that mock open(), XHR state transitions may not
+        // occur; ignore state errors so replay can continue.
+      }
+      this.requestHeaders.forEach(([header, value]) => {
+        super.setRequestHeader(header, value);
+      });
+      super.send(this.requestPayload);
+
+      return true;
+    }
+
+    handleAuthFailure = async (event) => {
+      this.hasRetriedAuth = true;
+
+      try {
+        await rotateAndReplay(
           this.FFetchContext.nativeFetch,
           { ...this.FFetchContext.rotationConfig, logger: this.FFetchContext.logger, shouldRotate: async () => true },
-        )
-          .then(() => {
-            this.didRestart = true;
-            this.send(this.payload);
-          });
-      } else {
-        super.onerror(e);
+        );
+
+        const replayed = this.replayRequest();
+        if (!replayed) {
+          this.userOnReadyStateChange?.call(this, event);
+        }
+      } catch (err) {
+        if (err instanceof RTRError) {
+          console.error('RTR failure while attempting XHR', err); // eslint-disable-line no-console
+          window.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: err }));
+        }
+
+        // Surface the original failed response to the XHR consumer when
+        // rotation cannot recover the request.
+        this.userOnReadyStateChange?.call(this, event);
       }
     }
 
-    send = (payload) => {
-      // cache in case we need to conduct RTR and restart
-      this.payload = payload;
+    handleInternalReadyStateChange = (event) => {
+      if (this.readyState !== this.DONE) {
+        this.userOnReadyStateChange?.call(this, event);
+        return;
+      }
 
+      if (this.isReplaying) {
+        this.isReplaying = false;
+        this.userOnReadyStateChange?.call(this, event);
+        return;
+      }
+
+      const shouldRetry = this.shouldEnsureToken && !this.hasRetriedAuth && this.isAuthFailureResponse();
+      if (shouldRetry) {
+        this.handleAuthFailure(event);
+        return;
+      }
+
+      this.userOnReadyStateChange?.call(this, event);
+    }
+
+    set onreadystatechange(handler) {
+      this.userOnReadyStateChange = handler;
+    }
+
+    get onreadystatechange() {
+      return this.userOnReadyStateChange;
+    }
+
+    send = (payload) => {
+      const { logger } = this.FFetchContext;
       this.FFetchContext.logger?.log('rtr', 'capture XHR send');
-      super.send(payload);
+      this.requestPayload = payload;
+      this.requestWithCredentials = this.withCredentials;
+
+      if (this.shouldEnsureToken) {
+        super.send(payload);
+      } else {
+        logger.log('rtr', 'request passed through, sending XHR...');
+        super.send(payload);
+      }
     };
   };
 };

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -34,10 +34,10 @@ export default (deps) => {
        * Captured request details used to replay the original XHR after
        * successful token rotation.
        */
-      this.requestOpenArgs = null;
-      this.requestPayload = null;
-      this.requestHeaders = [];
-      this.requestWithCredentials = false;
+      this.originalRequestOpenArgs = null;
+      this.originalRequestPayload = null;
+      this.originalRequestHeaders = [];
+      this.originalRequestWithCredentials = false;
 
       /**
        * Application callback passthrough and shared RTR dependencies.
@@ -79,9 +79,10 @@ export default (deps) => {
     open = (method, url, ...rest) => {
       this.FFetchContext.logger?.log('rtr', 'capture XHR.open');
       this.shouldEnsureToken = isFolioApiRequest(url, this.FFetchContext.okapi.url);
-      this.requestOpenArgs = [method, url, ...rest];
-      this.requestHeaders = [];
-      this.requestWithCredentials = false;
+      this.originalRequestOpenArgs = [method, url, ...rest];
+      this.originalRequestHeaders = [];
+      this.originalRequestPayload = null;
+      this.originalRequestWithCredentials = false;
       this.hasRetriedAuth = false;
       super.open(method, url, ...rest);
     }
@@ -90,7 +91,7 @@ export default (deps) => {
      * Persist outgoing headers so replay can reproduce the original request.
      */
     setRequestHeader = (header, value) => {
-      this.requestHeaders.push([header, value]);
+      this.originalRequestHeaders.push([header, value]);
       super.setRequestHeader(header, value);
     }
 
@@ -113,16 +114,16 @@ export default (deps) => {
      * Reissue the original request one time after rotation succeeds.
      */
     replayRequest = () => {
-      if (!this.requestOpenArgs) {
+      if (!this.originalRequestOpenArgs) {
         return false;
       }
 
-      super.open(...this.requestOpenArgs);
-      this.withCredentials = this.requestWithCredentials;
-      this.requestHeaders.forEach(([header, value]) => {
+      super.open(...this.originalRequestOpenArgs);
+      super.withCredentials = this.originalRequestWithCredentials;
+      this.originalRequestHeaders.forEach(([header, value]) => {
         super.setRequestHeader(header, value);
       });
-      super.send(this.requestPayload);
+      super.send(this.originalRequestPayload);
 
       return true;
     }
@@ -185,8 +186,8 @@ export default (deps) => {
     send = (payload) => {
       const { logger } = this.FFetchContext;
       this.FFetchContext.logger?.log('rtr', 'capture XHR send');
-      this.requestPayload = payload;
-      this.requestWithCredentials = this.withCredentials;
+      this.originalRequestPayload = payload;
+      this.originalRequestWithCredentials = this.withCredentials;
 
       if (!this.shouldEnsureToken) {
         logger.log('rtr', 'request passed through, sending XHR...');

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -134,6 +134,10 @@ export default (deps) => {
       this.hasRetriedAuth = true;
 
       try {
+        /**  rotateAndReplay is implemented to work with fetch requests, including original requests and response in
+        *   its parameters, but this is not applicable to XHR requests, so we do not send the third
+        *   parameter so this function only performs rotation within the lock implementation.
+        */
         await rotateAndReplay(
           this.FFetchContext.nativeFetch,
           { ...this.FFetchContext.rotationConfig, logger: this.FFetchContext.logger, shouldRotate: async () => true },

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -1,10 +1,5 @@
-import { getTokenExpiry } from '../../loginServices';
 import { rotateAndReplay } from './rotateAndReplay';
 import { isFolioApiRequest } from './token-util';
-import {
-  RTR_ERROR_EVENT,
-} from './constants';
-import { RTRError } from './Errors';
 
 export default (deps) => {
   return class FXHRClass extends XMLHttpRequest {
@@ -20,30 +15,37 @@ export default (deps) => {
       super.open(method, url);
     }
 
-    send = async (payload) => {
-      const { logger } = this.FFetchContext;
-      this.FFetchContext.logger?.log('rtr', 'capture XHR send');
-      if (this.shouldEnsureToken) {
-        try {
-          const expiry = await getTokenExpiry();
-          if (expiry?.atExpires < Date.now()) {
-            await rotateAndReplay(
-              this.FFetchContext.nativeFetch,
-              { ...this.FFetchContext.rotationConfig, logger: this.FFetchContext.logger, shouldRotate: async () => Promise.resolve(true) },
-            );
-          }
-          super.send(payload);
-        } catch (err) {
-          if (err instanceof RTRError) {
-            console.error('RTR failure while attempting XHR', err); // eslint-disable-line no-console
-            window.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: err }));
-          }
-          throw err;
-        }
+    /**
+     * Capture failure-to-launch errors that are the result of calling send()
+     * with an expired AT and attempt to re-launch. Pass all other errors up
+     * to the superclass.
+     * @param {ProgressEvent} e https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
+     */
+    onerror = (e) => {
+      // if no data was loaded, this is a FOLIO API request, and we have not
+      // already restarted, one possibility is that the AT was expired. Rotate
+      // and try again.
+      if (e.loaded === 0 && this.shouldEnsureToken && !this.didRestart) {
+        this.FFetchContext.logger?.log('rtr', 'XHR rotateAndReplay');
+        rotateAndReplay(
+          this.FFetchContext.nativeFetch,
+          { ...this.FFetchContext.rotationConfig, logger: this.FFetchContext.logger, shouldRotate: async () => true },
+        )
+          .then(() => {
+            this.didRestart = true;
+            this.send(this.payload);
+          });
       } else {
-        logger.log('rtr', 'request passed through, sending XHR...');
-        super.send(payload);
+        super.onerror(e);
       }
+    }
+
+    send = (payload) => {
+      // cache in case we need to conduct RTR and restart
+      this.payload = payload;
+
+      this.FFetchContext.logger?.log('rtr', 'capture XHR send');
+      super.send(payload);
     };
   };
 };

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -6,31 +6,79 @@ import {
 import { RTRError } from './Errors';
 
 export default (deps) => {
+  /**
+   * FXHRClass
+   * XMLHttpRequest wrapper that mirrors FFetch's reactive RTR behavior.
+   *
+   * For Okapi requests, it captures the outgoing request shape, sends it,
+   * inspects terminal responses for auth failure (401 and Okapi token-missing
+   * 400), rotates tokens once, and then replays the original request. For
+   * non-Okapi requests, it passes through untouched.
+   *
+   * Consumer callbacks remain compatible with native XHR semantics by routing
+   * readystatechange through an internal interceptor and invoking the assigned
+   * callback with XHR-style this binding.
+   */
   return class FXHRClass extends XMLHttpRequest {
     constructor() {
       super();
+
+      /**
+       * Sentinels controlling whether auth-failure handling should run and
+       * whether rotation has already been attempted for the current request.
+       */
       this.shouldEnsureToken = false;
       this.hasRetriedAuth = false;
-      this.isReplaying = false;
-      this.requestMethod = null;
-      this.requestUrl = null;
+
+      /**
+       * Captured request details used to replay the original XHR after
+       * successful token rotation.
+       */
       this.requestOpenArgs = null;
       this.requestPayload = null;
       this.requestHeaders = [];
       this.requestWithCredentials = false;
+
+      /**
+       * Application callback passthrough and shared RTR dependencies.
+       */
       this.userOnReadyStateChange = null;
       this.FFetchContext = deps;
 
-      // Always route readystatechange through the wrapper so auth failures can
-      // be handled before consumer callbacks are invoked.
+      /**
+       * Always route readystatechange through the wrapper so auth failures can
+       * be handled before consumer callbacks are invoked.
+       */
       super.onreadystatechange = this.handleInternalReadyStateChange;
     }
 
+    /**
+     * Preserve user-provided callback while keeping internal interception in place.
+     */
+    set onreadystatechange(handler) {
+      this.userOnReadyStateChange = handler;
+    }
+
+    /**
+     * Expose assigned callback for compatibility with native XHR usage patterns.
+     */
+    get onreadystatechange() {
+      return this.userOnReadyStateChange;
+    }
+
+    /**
+     * Invoke the user callback with native XHR-style this binding.
+     */
+    invokeUserOnReadyStateChange = (event) => {
+      this.userOnReadyStateChange?.call(this, event);
+    }
+
+    /**
+     * Capture request metadata needed for potential replay.
+     */
     open = (method, url, ...rest) => {
       this.FFetchContext.logger?.log('rtr', 'capture XHR.open');
       this.shouldEnsureToken = isFolioApiRequest(url, this.FFetchContext.okapi.url);
-      this.requestMethod = method;
-      this.requestUrl = url;
       this.requestOpenArgs = [method, url, ...rest];
       this.requestHeaders = [];
       this.requestWithCredentials = false;
@@ -38,11 +86,17 @@ export default (deps) => {
       super.open(method, url, ...rest);
     }
 
+    /**
+     * Persist outgoing headers so replay can reproduce the original request.
+     */
     setRequestHeader = (header, value) => {
       this.requestHeaders.push([header, value]);
       super.setRequestHeader(header, value);
     }
 
+    /**
+     * Match auth failures handled by fetch wrapper: 401 and Okapi token-missing 400.
+     */
     isAuthFailureResponse = () => {
       if (this.status === 401) {
         return true;
@@ -55,19 +109,16 @@ export default (deps) => {
       return false;
     }
 
+    /**
+     * Reissue the original request one time after rotation succeeds.
+     */
     replayRequest = () => {
       if (!this.requestOpenArgs) {
         return false;
       }
 
-      this.isReplaying = true;
       super.open(...this.requestOpenArgs);
-      try {
-        this.withCredentials = this.requestWithCredentials;
-      } catch (_err) {
-        // In test harnesses that mock open(), XHR state transitions may not
-        // occur; ignore state errors so replay can continue.
-      }
+      this.withCredentials = this.requestWithCredentials;
       this.requestHeaders.forEach(([header, value]) => {
         super.setRequestHeader(header, value);
       });
@@ -76,6 +127,9 @@ export default (deps) => {
       return true;
     }
 
+    /**
+     * Rotate tokens on auth failure, then replay or surface the original failure.
+     */
     handleAuthFailure = async (event) => {
       this.hasRetriedAuth = true;
 
@@ -87,7 +141,7 @@ export default (deps) => {
 
         const replayed = this.replayRequest();
         if (!replayed) {
-          this.userOnReadyStateChange?.call(this, event);
+          this.invokeUserOnReadyStateChange(event);
         }
       } catch (err) {
         if (err instanceof RTRError) {
@@ -95,21 +149,20 @@ export default (deps) => {
           window.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: err }));
         }
 
-        // Surface the original failed response to the XHR consumer when
-        // rotation cannot recover the request.
-        this.userOnReadyStateChange?.call(this, event);
+        /**
+         * Surface the original failed response to the XHR consumer when
+         * rotation cannot recover the request.
+         */
+        this.invokeUserOnReadyStateChange(event);
       }
     }
 
+    /**
+     * Intercept DONE responses, trigger RTR when needed, then forward callbacks.
+     */
     handleInternalReadyStateChange = (event) => {
       if (this.readyState !== this.DONE) {
-        this.userOnReadyStateChange?.call(this, event);
-        return;
-      }
-
-      if (this.isReplaying) {
-        this.isReplaying = false;
-        this.userOnReadyStateChange?.call(this, event);
+        this.invokeUserOnReadyStateChange(event);
         return;
       }
 
@@ -119,29 +172,23 @@ export default (deps) => {
         return;
       }
 
-      this.userOnReadyStateChange?.call(this, event);
+      this.invokeUserOnReadyStateChange(event);
     }
 
-    set onreadystatechange(handler) {
-      this.userOnReadyStateChange = handler;
-    }
-
-    get onreadystatechange() {
-      return this.userOnReadyStateChange;
-    }
-
+    /**
+     * Capture replay inputs before first send, then pass through to native XHR.
+     */
     send = (payload) => {
       const { logger } = this.FFetchContext;
       this.FFetchContext.logger?.log('rtr', 'capture XHR send');
       this.requestPayload = payload;
       this.requestWithCredentials = this.withCredentials;
 
-      if (this.shouldEnsureToken) {
-        super.send(payload);
-      } else {
+      if (!this.shouldEnsureToken) {
         logger.log('rtr', 'request passed through, sending XHR...');
-        super.send(payload);
       }
+
+      super.send(payload);
     };
   };
 };

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -70,7 +70,7 @@ export default (deps) => {
      * Invoke the user callback with native XHR-style this binding.
      */
     invokeUserOnReadyStateChange = (event) => {
-      this.userOnReadyStateChange?.call(this, event);
+      this.userOnReadyStateChange?.(this, event);
     }
 
     /**

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -1,4 +1,6 @@
 import { rotateAndReplay } from './rotateAndReplay';
+import { RTR_ERROR_EVENT } from './constants';
+import { RTRError } from './Errors';
 import FXHR from './FXHR';
 
 jest.mock('./token-util', () => ({
@@ -16,13 +18,26 @@ const aelSpy = jest.spyOn(XMLHttpRequest.prototype, 'addEventListener').mockImpl
 
 const mockHandler = jest.fn(() => { });
 
+const setXhrState = (xhr, { readyState, status, responseText = '' }) => {
+  Object.defineProperty(xhr, 'readyState', { configurable: true, value: readyState });
+  Object.defineProperty(xhr, 'status', { configurable: true, value: status });
+  Object.defineProperty(xhr, 'responseText', { configurable: true, value: responseText });
+};
+
 describe('FXHR', () => {
   let FakeXHR;
   let testXHR;
+  let dispatchSpy;
+
   beforeEach(() => {
     jest.clearAllMocks();
     FakeXHR = FXHR({ logger: { log: () => { } }, okapi: { url: 'okapiUrl' } });
     testXHR = new FakeXHR();
+    dispatchSpy = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    dispatchSpy.mockRestore();
   });
 
   it('instantiates without error', () => {
@@ -50,25 +65,109 @@ describe('FXHR', () => {
     expect(aelSpy.mock.calls).toHaveLength(1);
   });
 
-  it('Does not rotate if token is valid', () => {
+  it('does not rotate for successful requests', () => {
     testXHR.addEventListener('abort', mockHandler);
-    testXHR.open('POST', 'okapiUrl');
+    testXHR.open('POST', 'okapiUrl/files');
+    testXHR.onreadystatechange = mockHandler;
     testXHR.send(new ArrayBuffer(8));
+
+    setXhrState(testXHR, { readyState: 4, status: 200, responseText: '{"ok":true}' });
+    testXHR.handleInternalReadyStateChange({});
+
     expect(openSpy.mock.calls).toHaveLength(1);
     expect(aelSpy.mock.calls).toHaveLength(1);
     expect(rotateAndReplay).not.toHaveBeenCalled();
+    expect(mockHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('onerror rotates and calls send when an error is received before any data is loaded', () => {
-    console.log({ rotateAndReplay });
-    testXHR.addEventListener('abort', mockHandler);
-    testXHR.open('POST', 'okapiUrl');
+  it('invokes onreadystatechange with xhr instance as callback context', () => {
+    const contextHandler = jest.fn(function onReadyStateChange() {
+      expect(this).toBe(testXHR);
+    });
+
+    testXHR.open('POST', 'okapiUrl/files');
+    testXHR.onreadystatechange = contextHandler;
     testXHR.send(new ArrayBuffer(8));
-    testXHR.onerror({ loaded: 0 });
-    expect(openSpy.mock.calls).toHaveLength(1);
-    expect(aelSpy.mock.calls).toHaveLength(1);
-    expect(rotateAndReplay).toHaveBeenCalled();
-    // logging shows send() is called twice, but sendSpy only counts one call.
-    // I don't understand that.
+
+    setXhrState(testXHR, { readyState: 4, status: 200, responseText: '{"ok":true}' });
+    testXHR.handleInternalReadyStateChange({});
+
+    expect(contextHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('intercepts first 401 done state, rotates, then replays once', async () => {
+    testXHR.open('POST', 'okapiUrl/files');
+    testXHR.withCredentials = true;
+    testXHR.onreadystatechange = mockHandler;
+
+    const payload = new ArrayBuffer(8);
+    testXHR.send(payload);
+
+    setXhrState(testXHR, { readyState: 4, status: 401, responseText: '{"errors":[]}' });
+    testXHR.handleInternalReadyStateChange({});
+
+    await Promise.resolve();
+
+    expect(rotateAndReplay).toHaveBeenCalledTimes(1);
+    expect(mockHandler).not.toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledTimes(2);
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+
+    setXhrState(testXHR, { readyState: 4, status: 200, responseText: '{"id":"ok"}' });
+    testXHR.handleInternalReadyStateChange({});
+
+    expect(mockHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats okapi token-missing 400 as auth failure and rotates', async () => {
+    testXHR.open('POST', 'okapiUrl/files');
+    testXHR.onreadystatechange = mockHandler;
+    testXHR.send(new ArrayBuffer(8));
+
+    setXhrState(testXHR, {
+      readyState: 4,
+      status: 400,
+      responseText: 'Token missing, access requires permission foo',
+    });
+    testXHR.handleInternalReadyStateChange({});
+
+    await Promise.resolve();
+
+    expect(rotateAndReplay).toHaveBeenCalledTimes(1);
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  it('does not rotate twice when replayed request is still unauthorized', async () => {
+    testXHR.open('POST', 'okapiUrl/files');
+    testXHR.onreadystatechange = mockHandler;
+    testXHR.send(new ArrayBuffer(8));
+
+    setXhrState(testXHR, { readyState: 4, status: 401, responseText: '{}' });
+    testXHR.handleInternalReadyStateChange({});
+
+    await Promise.resolve();
+
+    setXhrState(testXHR, { readyState: 4, status: 401, responseText: '{}' });
+    testXHR.handleInternalReadyStateChange({});
+
+    expect(rotateAndReplay).toHaveBeenCalledTimes(1);
+    expect(mockHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches RTR_ERROR_EVENT and surfaces original failure when rotation fails', async () => {
+    rotateAndReplay.mockRejectedValueOnce(new RTRError('Rotation failure!'));
+
+    testXHR.open('POST', 'okapiUrl/files');
+    testXHR.onreadystatechange = mockHandler;
+    testXHR.send(new ArrayBuffer(8));
+
+    setXhrState(testXHR, { readyState: 4, status: 401, responseText: '{}' });
+    testXHR.handleInternalReadyStateChange({});
+
+    await Promise.resolve();
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy.mock.calls[0][0].type).toBe(RTR_ERROR_EVENT);
+    expect(mockHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -1,6 +1,4 @@
-// import { rtr } from './token-util';
 import { rotateAndReplay } from './rotateAndReplay';
-import { getTokenExpiry } from '../../loginServices';
 import FXHR from './FXHR';
 
 jest.mock('./token-util', () => ({
@@ -10,12 +8,6 @@ jest.mock('./token-util', () => ({
 jest.mock('./rotateAndReplay', () => ({
   ...(jest.requireActual('./rotateAndReplay')),
   rotateAndReplay: jest.fn(() => Promise.resolve()),
-}));
-
-jest.mock('../../loginServices', () => ({
-  ...(jest.requireActual('../../loginServices')),
-  setTokenExpiry: jest.fn(() => Promise.resolve()),
-  getTokenExpiry: jest.fn(() => Promise.resolve())
 }));
 
 const openSpy = jest.spyOn(XMLHttpRequest.prototype, 'open').mockImplementation();
@@ -29,7 +21,7 @@ describe('FXHR', () => {
   let testXHR;
   beforeEach(() => {
     jest.clearAllMocks();
-    FakeXHR = FXHR({ tokenExpiration: { atExpires: Date.now(), rtExpires: Date.now() + 5000 }, logger: { log: () => { } }, okapi: { url: 'okapiUrl' } });
+    FakeXHR = FXHR({ logger: { log: () => { } }, okapi: { url: 'okapiUrl' } });
     testXHR = new FakeXHR();
   });
 
@@ -59,11 +51,6 @@ describe('FXHR', () => {
   });
 
   it('Does not rotate if token is valid', () => {
-    getTokenExpiry.mockResolvedValue({
-      atExpires: Date.now() + (10 * 60 * 1000),
-      rtExpires: Date.now() + (10 * 60 * 1000),
-    });
-
     testXHR.addEventListener('abort', mockHandler);
     testXHR.open('POST', 'okapiUrl');
     testXHR.send(new ArrayBuffer(8));
@@ -72,17 +59,16 @@ describe('FXHR', () => {
     expect(rotateAndReplay).not.toHaveBeenCalled();
   });
 
-  it('Rotates if token is expired', async () => {
-    getTokenExpiry.mockResolvedValue({
-      atExpires: Date.now() - (10 * 60 * 1000),
-      rtExpires: Date.now() + (10 * 60 * 1000),
-    });
+  it('onerror rotates and calls send when an error is received before any data is loaded', () => {
     console.log({ rotateAndReplay });
     testXHR.addEventListener('abort', mockHandler);
     testXHR.open('POST', 'okapiUrl');
-    await testXHR.send(new ArrayBuffer(8));
+    testXHR.send(new ArrayBuffer(8));
+    testXHR.onerror({ loaded: 0 });
     expect(openSpy.mock.calls).toHaveLength(1);
     expect(aelSpy.mock.calls).toHaveLength(1);
     expect(rotateAndReplay).toHaveBeenCalled();
+    // logging shows send() is called twice, but sendSpy only counts one call.
+    // I don't understand that.
   });
 });


### PR DESCRIPTION
This new breed of rtr calls for a version of `FXHR` that will work - ideally with similar flow to FFetch's rotation. The nature of XHR is way different from `fetch` - it doesn't have any real response and relies mostly on event handlers to provide any feedback to the caller.

We tried implementing with `onerror` (PR #1714) - but onerror is for transport-level failures (network problems) not auth problems. It says 'well, you got a response, so this isn't that, no handler call for you!'.

This solution works like this:

Add an internal event handler for `onreadystatechange` that we run prior to any user-provided handlers - so we keep the auth failures from bubbling up to the UI. If rotation/retry fails, we'll pass those errors along.

since `open` is an initializer function, we store parameters passed (withCredentials, etc) in order to attempt a replay of `open` and `send` functions for after rotation completes.

Since XHR doesn't have the `response`  like `fetch`, we adapt in the following ways: 
 - implement similar logic to `ffetch`'s `shouldRotate` - checking the ready state status for `400`'s `401`'s.
 - send no 3rd parameter (the original request, response etc) to `rotateAndReplay()` so that necessary token rotation still leverages the centralized locking mechanism.

An example of XHR usage can be found at https://github.com/folio-org/ui-data-import/blob/master/src/components/UploadingJobsDisplay/UploadingJobsDisplay.js#L288-L338

Refs [STCOR-1055](https://folio-org.atlassian.net/browse/STCOR-1055)
