### PR TITLE
STCOR-1062 do not call clone() on URL instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Completely avoid rotation-related work given a request with `options.rtrIgnore`. Refs STCOR-1059.
 * Add case for `authn/logout`'s 422 status to rotate keys on failure. STCOR-1058.
 * Clone requests before replaying them, allowing multiple replays. Refs STCOR-1060.
+* ^^^ yes, but do not call `clone()` on `URL` instances inside requests. Refs STCOR-1062.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -180,7 +180,7 @@ export class FFetch {
       // or a Request object (which can only be consumed once, and needs
       // to be cloned before it is used the first time in case this fetch
       // triggers rotation and it needs to be replayed.
-      const reusableResource = resource instanceof Request || resource instanceof URL ? resource.clone() : resource;
+      const reusableResource = resource instanceof Request ? resource.clone() : resource;
 
       // readers/writer lock pattern: don't fetch while rotation is in-progress
       // https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request


### PR DESCRIPTION
Whoops, `URL` does not implement `clone()`. Sorry sorry sorry.

Refs [STCOR-1062](https://folio-org.atlassian.net/browse/STCOR-1062), [UIEH-1491](https://folio-org.atlassian.net/browse/UIEH-1491)