### PR TITLE
STCOR-1064 Add cleanup methods to FFetch, use them in Root's unmount.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Clone requests before replaying them, allowing multiple replays. Refs STCOR-1060.
 * ^^^ yes, but do not call `clone()` on `URL` instances inside requests. Refs STCOR-1062.
 * Adopt FFetch's rotation logic flow in FXHR for consistency. Refs STCOR-1055.
+* Add cleanup logic for FFetch and use it in unmount lifecycle of Root. Refs STCOR-1064.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -48,6 +48,7 @@ export class FFetch {
     this.logger = logger;
     this.okapi = okapi;
     this.onRotate = onRotate;
+    this.FXHR = FXHR(this);
   }
 
   destroy = () => {
@@ -70,7 +71,7 @@ export class FFetch {
    */
   replaceXMLHttpRequest = () => {
     this.NativeXHR = globalThis.XMLHttpRequest;
-    globalThis.XMLHttpRequest = FXHR(this);
+    globalThis.XMLHttpRequest = this.FXHR;
   };
 
   restoreFetch = () => {

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -48,6 +48,11 @@ export class FFetch {
     this.logger = logger;
     this.okapi = okapi;
     this.onRotate = onRotate;
+    this.abortController = new AbortController();
+  }
+
+  destroy = (reason) => {
+    this.abortController.abort(reason);
   }
 
   /**
@@ -64,6 +69,16 @@ export class FFetch {
   replaceXMLHttpRequest = () => {
     this.NativeXHR = globalThis.XMLHttpRequest;
     globalThis.XMLHttpRequest = FXHR(this);
+  };
+
+  restoreFetch = () => {
+    globalThis.fetch = this.nativeFetch;
+    this.nativeFetch = null;
+  };
+
+  restoreXMLHttpRequest = () => {
+    globalThis.XMLHttpRequest = this.NativeXHR;
+    this.NativeXHR = null;
   };
 
   /**
@@ -185,7 +200,7 @@ export class FFetch {
       // readers/writer lock pattern: don't fetch while rotation is in-progress
       // https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request
       response = await navigator.locks.request(RTR_LOCK_KEY, { mode: 'shared' }, async () => {
-        const fr = await this.nativeFetch.apply(globalThis, [resource, options && { ...options, ...FOLIO_FETCH_OPTIONS }]);
+        const fr = await this.nativeFetch.apply(globalThis, [resource, options && { signal: this.abortController.signal, ...options, ...FOLIO_FETCH_OPTIONS }]);
         return fr;
       });
 
@@ -193,12 +208,15 @@ export class FFetch {
         return response;
       }
 
-      if (!response?.ok) {
+      if (!response?.ok && this.abortController.signal.aborted !== true) {
         response = await rotateAndReplay(
           this.nativeFetch,
           { ...this.rotationConfig, logger: this.logger },
           { response, resource: reusableResource, options }
         );
+      } else if (this.abortController.signal.aborted === true) {
+        console.log('rtr', 'Fetch aborted by signal before RTR check - is react set to strict mode?', this.abortController.signal.reason);
+        return Promise.resolve();
       }
 
       return response;

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -48,11 +48,14 @@ export class FFetch {
     this.logger = logger;
     this.okapi = okapi;
     this.onRotate = onRotate;
-    this.abortController = new AbortController();
   }
 
-  destroy = (reason) => {
-    this.abortController.abort(reason);
+  destroy = () => {
+    // this.abortController.abort(reason);
+    // unclog any exclusive locks that might be in-flight to avoid RTR deadlocks.
+    this.logger.log('rtr', 'cleaning up after ffetch');
+    this.restoreFetch();
+    this.restoreXMLHttpRequest();
   }
 
   /**
@@ -200,7 +203,7 @@ export class FFetch {
       // readers/writer lock pattern: don't fetch while rotation is in-progress
       // https://developer.mozilla.org/en-US/docs/Web/API/LockManager/request
       response = await navigator.locks.request(RTR_LOCK_KEY, { mode: 'shared' }, async () => {
-        const fr = await this.nativeFetch.apply(globalThis, [resource, options && { signal: this.abortController.signal, ...options, ...FOLIO_FETCH_OPTIONS }]);
+        const fr = await this.nativeFetch.apply(globalThis, [resource, options && { ...options, ...FOLIO_FETCH_OPTIONS }]);
         return fr;
       });
 
@@ -208,15 +211,12 @@ export class FFetch {
         return response;
       }
 
-      if (!response?.ok && this.abortController.signal.aborted !== true) {
+      if (!response?.ok) {
         response = await rotateAndReplay(
           this.nativeFetch,
           { ...this.rotationConfig, logger: this.logger },
           { response, resource: reusableResource, options }
         );
-      } else if (this.abortController.signal.aborted === true) {
-        console.log('rtr', 'Fetch aborted by signal before RTR check - is react set to strict mode?', this.abortController.signal.reason);
-        return Promise.resolve();
       }
 
       return response;

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -51,9 +51,8 @@ export class FFetch {
   }
 
   destroy = () => {
-    // this.abortController.abort(reason);
-    // unclog any exclusive locks that might be in-flight to avoid RTR deadlocks.
-    this.logger.log('rtr', 'cleaning up after ffetch');
+    // restore replaced globals.
+    this.logger?.log?.('rtr', 'cleaning up after ffetch');
     this.restoreFetch();
     this.restoreXMLHttpRequest();
   }
@@ -75,13 +74,17 @@ export class FFetch {
   };
 
   restoreFetch = () => {
-    globalThis.fetch = this.nativeFetch;
-    this.nativeFetch = null;
+    if (globalThis.fetch === this.ffetch) {
+      globalThis.fetch = this.nativeFetch;
+      this.nativeFetch = null;
+    }
   };
 
   restoreXMLHttpRequest = () => {
-    globalThis.XMLHttpRequest = this.NativeXHR;
-    this.NativeXHR = null;
+    if (globalThis.XMLHttpRequest === this.FXHR) {
+      globalThis.XMLHttpRequest = this.NativeXHR;
+      this.NativeXHR = null;
+    }
   };
 
   /**

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -147,6 +147,14 @@ class Root extends Component {
     return !this.withOkapi || nextProps.okapiReady || nextProps.serverDown;
   }
 
+  componentWillUnmount() {
+    // clean up timers and pending requests on unmount
+    this.ffetch.destroy('Root component unmounted, aborting pending requests');
+    this.ffetch.restoreFetch();
+    this.ffetch.restoreXMLHttpRequest();
+    this.ffetch = null;
+  }
+
   updateQueryResourceStateKey = () => {
     const { modules, history } = this.props;
     const appModule = getCurrentModule(modules, history.location);

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -148,11 +148,11 @@ class Root extends Component {
   }
 
   componentWillUnmount() {
-    // clean up timers and pending requests on unmount
-    this.ffetch.destroy('Root component unmounted, aborting pending requests');
-    this.ffetch.restoreFetch();
-    this.ffetch.restoreXMLHttpRequest();
+    // clean up ffetch so that any pending rotation-related work is stopped.
+    this.ffetch.destroy();
     this.ffetch = null;
+    this.sessionTimeoutTimer.clear();
+    this.sessionTimeoutWarningTimer.clear();
   }
 
   updateQueryResourceStateKey = () => {

--- a/src/components/Root/Root.test.js
+++ b/src/components/Root/Root.test.js
@@ -89,7 +89,7 @@ const makeStore = (stateOverrides = {}) => {
 const getRootComponent = (props = {}) => (
   <Root
     store={makeStore()}
-    logger={{}}
+    logger={{ log: jest.fn() }}
     epics={{ add: jest.fn() }}
     config={{ locale: 'en-US', rtr: { enabled: true } }}
     okapi={{ url: 'http://okapi', tenant: 'diku', withoutOkapi: false }}


### PR DESCRIPTION
## [STCOR-1064](https://folio-org.atlassian.net/browse/STCOR-1064)
Having StrictMode turned on will cause the existing RTR implementation to hang in the init process since multiple fetch calls courtesy of `checkOkapiSession` will be made, and `<Root>` will unmount and remount before any rotation even occurs. Speculatively, this is causing the first `exclusive` rotation request to suspend indefinitely, so it never unlocks and the UI is frozen.

The solution - Abort the fetch when `<Root>` unmounts during the strict-mode double-lifecycle. This will kick out the request before rotation gets started so once normal functionality resumes the exclusive lock can be unclogged.