### PR TITLE
STCOR-1002 handle Error input in OIDCLandingError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Clone requests before replaying them, allowing multiple replays. Refs STCOR-1060.
 * ^^^ yes, but do not call `clone()` on `URL` instances inside requests. Refs STCOR-1062.
 * Adopt FFetch's rotation logic flow in FXHR for consistency. Refs STCOR-1055.
+* Show messages from `Error` objects in OIDCLandingError. Refs STCOR-1002.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/OIDCLandingError.js
+++ b/src/components/OIDCLandingError.js
@@ -10,9 +10,25 @@ import {
 
 import OrganizationLogo from './OrganizationLogo';
 
-const OIDCLandingError = ({ error }) => {
-  const message = error?.errors?.[0]?.message || error;
+export const parseError = (error) => {
+  // do we have JSON from an error API response?
+  if (error?.errors?.[0]?.message) {
+    return error.errors[0].message;
+  }
 
+  // if not, do we have an Error object?
+  if (typeof error?.message === 'string') {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return undefined;
+};
+
+const OIDCLandingError = ({ error }) => {
   return (
     <main data-test-saml-error>
       <Row center="xs">
@@ -27,7 +43,7 @@ const OIDCLandingError = ({ error }) => {
       </Row>
       <Row center="xs">
         <Col xs={12}>
-          <Headline>{message}</Headline>
+          <Headline>{parseError(error)}</Headline>
         </Col>
       </Row>
       <Row center="xs">
@@ -41,12 +57,19 @@ const OIDCLandingError = ({ error }) => {
 
 OIDCLandingError.propTypes = {
   error: PropTypes.oneOfType([
+    // API error response
     PropTypes.shape({
       errors: PropTypes.arrayOf(PropTypes.shape({
         message: PropTypes.string
       }))
     }),
-    PropTypes.string])
+    // some kinda Error object
+    PropTypes.shape({
+      message: PropTypes.string
+    }),
+    // boring ol' string
+    PropTypes.string,
+  ])
 };
 export default OIDCLandingError;
 

--- a/src/components/OIDCLandingError.test.js
+++ b/src/components/OIDCLandingError.test.js
@@ -4,22 +4,46 @@ import OIDCLandingError from './OIDCLandingError';
 jest.mock('./OrganizationLogo', () => () => 'Logo');
 
 describe('OIDCLandingError', () => {
-  it('handles expected error shape', () => {
-    const error = {
-      errors: [
-        {
-          message: "To gain a standard for the appreciation of others' work"
-        }
-      ]
+  describe('displays supplied errors', () => {
+    it('given an API error response in the expected shape', () => {
+      const error = {
+        errors: [
+          {
+            message: "To gain a standard for the appreciation of others' work"
+          }
+        ]
+      };
+      render(<OIDCLandingError error={error} />);
+      expect(screen.getByText(error.errors[0].message)).toBeInTheDocument();
+    });
 
-    };
-    render(<OIDCLandingError error={error} />);
-    expect(screen.getByText(error.errors[0].message)).toBeInTheDocument();
+    it('given a string', () => {
+      const error = 'And the criticism of your own';
+      render(<OIDCLandingError error={error} />);
+      expect(screen.getByText(error, { exact: false })).toBeInTheDocument();
+    });
+
+    it('given an Error object', () => {
+      const error = new Error("to carry the keys of the world's library in your pocket,");
+      render(<OIDCLandingError error={error} />);
+      expect(screen.getByText(error.message, { exact: false })).toBeInTheDocument();
+    });
   });
 
-  it('handles unexpected error shape', () => {
-    const error = 'And the criticism of your own';
-    render(<OIDCLandingError error={error} />);
-    expect(screen.getByText(error, { exact: false })).toBeInTheDocument();
+  describe('displays only the generic message given other input', () => {
+    it('given input in an unsupported/unexpected format', () => {
+      const genericError = 'stripes-core.errors.oidc';
+      const error = ['and feel its resources behind you in whatever task you undertake;'];
+
+      render(<OIDCLandingError error={error} />);
+      expect(screen.queryByText(error[0])).not.toBeInTheDocument();
+      expect(screen.getByText(genericError, { exact: false })).toBeInTheDocument();
+    });
+
+    it('given nothing', () => {
+      const genericError = 'stripes-core.errors.oidc';
+      render(<OIDCLandingError />);
+      expect(screen.getByText(genericError, { exact: false })).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
`error` may contain structured JSON from a failed API response, or a simple string, or an Error object if the API request itself fails. Handle them all. Previously, Error-object props caused a failure because the object was simply supplied as a child in render, which React does not support.

Refs [STCOR-1002](https://folio-org.atlassian.net/browse/STCOR-1002)