### PR TITLE
STCOR-1063 Recalculate navbar apps when container width changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add cleanup logic for FFetch and use it in unmount lifecycle of Root. Refs STCOR-1064.
 * Show messages from `Error` objects in OIDCLandingError. Refs STCOR-1002.
 * Consolidate logout functionality; trap errors during logout so storage is always cleared. Refs STCOR-1061.
+* Recalculate navbar apps when container width changes. Refs STCOR-1063.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/MainNav/AppList/components/ResizeContainer/ResizeContainer.js
+++ b/src/components/MainNav/AppList/components/ResizeContainer/ResizeContainer.js
@@ -38,6 +38,12 @@ class ResizeContainer extends React.Component {
   componentDidMount() {
     this.initialize();
     window.addEventListener('resize', this.onResize, true);
+
+    // Observe size changes of the wrapper itself so we recompute hidden items
+    if (typeof ResizeObserver !== 'undefined' && this.wrapperRef.current) {
+      this.resizeObserver = new ResizeObserver(this.onResize);
+      this.resizeObserver.observe(this.wrapperRef.current);
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -76,6 +82,11 @@ class ResizeContainer extends React.Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.onResize, true);
+
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
   }
 
   cacheWidthsOfItems = () => {
@@ -121,7 +132,7 @@ class ResizeContainer extends React.Component {
 
         // Find items that should be hidden
         items.reduce((acc, { id }) => {
-          const itemWidth = this.cachedItemWidths[id];
+          const itemWidth = this.cachedItemWidths[id] || 0;
           const shouldBeHidden = (itemWidth + acc.accWidth + offset) > wrapperWidth;
           const hidden = shouldBeHidden ? acc.hidden.concat(id) : acc.hidden;
 


### PR DESCRIPTION
The horizontal app list in the main navbar (`ResizeContainer`) decides which app items are visible and which get moved into the overflow menu by measuring the available wrapper width. Previously this recalculation was only triggered by the `window.resize` event, so when the **container's own width changed without the window resizing**.  For example when the "current app" label rendered asynchronously, fonts swapped in, or a sibling element grew - the visible/hidden app split was not updated. As a result, items could overflow the navbar or remain hidden when they would fit.

### Changes
- Added a `ResizeObserver` on the wrapper element in `componentDidMount`, so any size change of the container (not just the window) triggers `updateHiddenItems` via the existing debounced `onResize` handler.
- Guarded the observer with `typeof ResizeObserver !== 'undefined'` so the component continues to work in environments where the API is not available (notably **jsdom** under Jest).
- Properly `disconnect()` the observer in `componentWillUnmount` to prevent leaks and stray callbacks after unmount.
- Added a `|| 0` fallback when reading `this.cachedItemWidths[id]` so a missing measurement (e.g. an item whose DOM node hasn't been measured yet) cannot poison the running width sum into `NaN`, which would silently break the overflow detection for all subsequent items.

Refs: STCOR-1063