### PR TITLE
STCOR-1067 followup: pass dynamic post-logout-redirect URI

### DIFF
--- a/src/components/Logout/useLogoutMutation.js
+++ b/src/components/Logout/useLogoutMutation.js
@@ -163,7 +163,7 @@ export const useLogoutMutation = (timers) => {
         if (localStorage.getItem(SESSION_NAME)) {
           console.error('logout failure; session storage was active but the logout API request failed', err); // eslint-disable-line no-console
           const { clientId } = getLoginTenant(okapi, config);
-          const logoutUrl = `${okapi.authnUrl}/realms/${tenant}/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:3000/logout?reason=${reason}&client_id=${clientId}`;
+          const logoutUrl = `${okapi.authnUrl}/realms/${tenant}/protocol/openid-connect/logout?post_logout_redirect_uri=${globalThis.location.origin}/logout?reason=${reason}&client_id=${clientId}`;
           throw new SessionSyncError(logoutUrl);
         }
       } finally {


### PR DESCRIPTION
Whoops, don't hard-code the post-logout redirect URI passed to Keycloak. The correct value is the current hostname. Somehow, I missed this in the original PR, #1737.

Refs [STCOR-1067](https://folio-org.atlassian.net/browse/STCOR-1067)