### PR TITLE
STCOR-1072 supply mod-settings permissions for others' settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Inspect local expiry information prior to initial request, avoiding 401's in rtr flow. Refs STCOR-1069.
 * Rotate preventively prior to logout. Refs STCOR-1068.
 * Reliably handle unsynchronized FOLIO/Keycloak sessions. Refs STCOR-1067.
+* Supply `mod-settings` permissios for managing others' settings. Refs STCOR-1072.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Inspect local expiry information prior to initial request, avoiding 401's in rtr flow. Refs STCOR-1069.
 * Rotate preventively prior to logout. Refs STCOR-1068.
 * Reliably handle unsynchronized FOLIO/Keycloak sessions. Refs STCOR-1067.
-* Supply `mod-settings` permissios for managing others' settings. Refs STCOR-1072.
+* Supply `mod-settings` permissions for managing others' settings. Refs STCOR-1072.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/package.json
+++ b/package.json
@@ -52,6 +52,16 @@
         "visible": false
       },
       {
+        "permissionName": "mod-settings.users.read.stripes-core.prefs.manage",
+        "displayName": "UI: read another user's central preferences, such as order of links in the main navigation.",
+        "visible": false
+      },
+      {
+        "permissionName": "mod-settings.users.write.stripes-core.prefs.manage",
+        "displayName": "UI: update another user's central preferences, such as order of links in the main navigation.",
+        "visible": false
+      },
+      {
         "permissionName": "mod-settings.global.read.stripes-core.prefs.manage",
         "displayName": "UI: read the tenant's preferences",
         "visible": false


### PR DESCRIPTION
Supply the `mod-settings` permissions necessary for one user to manage settings on behalf of another. Okapi-based systems handle this via autovivification; not so in Eureka-based systems. Oh, hi JAPH.

CC: @mreno-EBSCO, @craigmcnally 

Refs [STCOR-1072](https://folio-org.atlassian.net/browse/STCOR-1072)