### PR TITLE
STCOR-1076 - Add RTR timeout listeners to FXHR

### DIFF
--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -244,8 +244,10 @@ export default (deps) => {
             globalThis.dispatchEvent(new Event(e.type));
           }, 0);
         };
+
         globalThis.addEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
         globalThis.addEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);
+
         this._removeTimeoutListeners = () => {
           globalThis.removeEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
           globalThis.removeEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -167,12 +167,17 @@ export default (deps) => {
           */
           this._removeTimeoutListeners?.();
 
-          // fire the change with the current 'DONE but error' state.
+          this.rtrAbortReason = err.message || 'RTR failure while attempting XHR';
+
+          // Since the XHR has completed but failed at this point, it will have a readyState of 4,
+          // indicating that the operation is done. We need to invoke the application's listener
+          // so that any state with an active download can be cleared and we can navigate to
+          // the logout page without being blocked by hopeful confirmation modals.
           this.invokeUserOnReadyStateChange(event);
 
           // Abort sets the readystate of the XHR to 0. It will fire a
-          // readystatechange event, but application code may not expect the readystate to be 0 if they're
-          // only set up for completion/post-creation states.
+          // readystatechange event for this, but it's unlikely that applications
+          // will be expecting it.
           super.abort();
 
           // Wait for app updates to settle before dispatching the event so that any navigation blockers
@@ -198,6 +203,11 @@ export default (deps) => {
       if (this.readyState !== this.DONE) {
         this.invokeUserOnReadyStateChange(event);
         return;
+      } else if (this.readyState === 0) {
+        // catch aborted XHRs.
+        if (this.rtrAbortReason) {
+          throw (new RTRError(`XHR aborted: ${this.rtrAbortReason}`))
+        }
       }
 
       // remove our listeners for session timeout events.
@@ -232,6 +242,7 @@ export default (deps) => {
         const abortOnTimeout = (e) => {
           this.FFetchContext.logger?.log('rtr', 'aborting in-flight XHR due to session timeout');
           this._removeTimeoutListeners?.();
+          this.rtrAbortReason = e.type;
 
           // Abort sets the readystate of the XHR to 0. It will fire a
           // readystatechange event, but application code may not expect the readystate to be 0 if they're
@@ -248,6 +259,7 @@ export default (deps) => {
         globalThis.addEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
         globalThis.addEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);
 
+        this.rtrAbortReason = null;
         this._removeTimeoutListeners = () => {
           globalThis.removeEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
           globalThis.removeEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -159,15 +159,29 @@ export default (deps) => {
       } catch (err) {
         if (err instanceof RTRError) {
           console.error('RTR failure while attempting XHR', err); // eslint-disable-line no-console
+
           /* If rotation fails, abort the request. This should
           * allow the application to handle the error / close the request in its own way
           * so that any cancel confirmation modals attached to the operation can be circumvented
           * and our logout navigation can be triggered when the RTR_ERROR_EVENT.
           */
           this._removeTimeoutListeners?.();
+
+          // fire the change with the current 'DONE but error' state.
+          this.invokeUserOnReadyStateChange(event);
+
+          // Abort sets the readystate of the XHR to 0. It will fire a
+          // readystatechange event, but application code may not expect the readystate to be 0 if they're
+          // only set up for completion/post-creation states.
           super.abort();
-          window.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: err }));
+
+          // Wait for app updates to settle before dispatching the event so that any navigation blockers
+          // can be removed before the app navigates to the logout page.
+          setTimeout(() => {
+            globalThis.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: err }));
+          }, 0);
         } else {
+
           /**
          * Surface the original failed response to the XHR consumer when
          * rotation cannot recover the request.
@@ -186,6 +200,7 @@ export default (deps) => {
         return;
       }
 
+      // remove our listeners for session timeout events.
       this._removeTimeoutListeners?.();
 
       const shouldRetry = this.shouldEnsureToken && !this.hasRetriedAuth && this.isAuthFailureResponse();
@@ -201,7 +216,7 @@ export default (deps) => {
      * Capture replay inputs before first send, then pass through to native XHR.
      * For Okapi requests, registers window listeners so the XHR is aborted if a
      * session-terminating timeout event fires while the request is in flight.
-     * This allows the uploading application to receive the abort event, clean up
+     * This allows the uploading application to process the aborted XHR state - (readyState == 0), clean up
      * any navigation guards (e.g. React Router <Prompt>), and let the logout
      * navigation proceed without entering a confirmation-modal loop.
      */
@@ -214,16 +229,26 @@ export default (deps) => {
       if (!this.shouldEnsureToken) {
         logger.log('rtr', 'request passed through, sending XHR...');
       } else {
-        const abortOnTimeout = () => {
+        const abortOnTimeout = (e) => {
           this.FFetchContext.logger?.log('rtr', 'aborting in-flight XHR due to session timeout');
           this._removeTimeoutListeners?.();
+
+          // Abort sets the readystate of the XHR to 0. It will fire a
+          // readystatechange event, but application code may not expect the readystate to be 0 if they're
+          // only set up for completion/post-creation states (1 - 4).
           super.abort();
+
+          // Wait for app updates to settle before dispatching the event so that any state-based
+          // navigation blockers can be removed before the app navigates to the logout page.
+          setTimeout(() => {
+            globalThis.dispatchEvent(new Event(e.type));
+          }, 0);
         };
-        window.addEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
-        window.addEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);
+        globalThis.addEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
+        globalThis.addEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);
         this._removeTimeoutListeners = () => {
-          window.removeEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
-          window.removeEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);
+          globalThis.removeEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
+          globalThis.removeEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);
           this._removeTimeoutListeners = null;
         };
       }

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -2,6 +2,8 @@ import { rotateAndReplay } from './rotateAndReplay';
 import { isFolioApiRequest } from './token-util';
 import {
   RTR_ERROR_EVENT,
+  RTR_FLS_TIMEOUT_EVENT,
+  RTR_TIMEOUT_EVENT,
 } from './constants';
 import { RTRError } from './Errors';
 
@@ -46,6 +48,12 @@ export default (deps) => {
       this.FFetchContext = deps;
 
       /**
+       * Cleanup function for session-timeout abort listeners; null when no
+       * in-flight Okapi request is active.
+       */
+      this._removeTimeoutListeners = null;
+
+      /**
        * Always route readystatechange through the wrapper so auth failures can
        * be handled before consumer callbacks are invoked.
        */
@@ -70,7 +78,7 @@ export default (deps) => {
      * Invoke the user callback with native XHR-style this binding.
      */
     invokeUserOnReadyStateChange = (event) => {
-      this.userOnReadyStateChange?.(this, event);
+      this.userOnReadyStateChange?.call(this, event);
     }
 
     /**
@@ -151,14 +159,20 @@ export default (deps) => {
       } catch (err) {
         if (err instanceof RTRError) {
           console.error('RTR failure while attempting XHR', err); // eslint-disable-line no-console
+          /* If rotation fails, abort the request. This should
+          * allow the application to handle the error / close the request in its own way
+          * so that any cancel confirmation modals attached to the operation can be circumvented
+          * and our logout navigation can be triggered when the RTR_ERROR_EVENT.
+          */
+          super.abort();
           window.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: err }));
-        }
-
-        /**
+        } else {
+          /**
          * Surface the original failed response to the XHR consumer when
          * rotation cannot recover the request.
          */
-        this.invokeUserOnReadyStateChange(event);
+          this.invokeUserOnReadyStateChange(event);
+        }
       }
     }
 
@@ -171,6 +185,8 @@ export default (deps) => {
         return;
       }
 
+      this._removeTimeoutListeners?.();
+
       const shouldRetry = this.shouldEnsureToken && !this.hasRetriedAuth && this.isAuthFailureResponse();
       if (shouldRetry) {
         this.handleAuthFailure(event);
@@ -182,6 +198,11 @@ export default (deps) => {
 
     /**
      * Capture replay inputs before first send, then pass through to native XHR.
+     * For Okapi requests, registers window listeners so the XHR is aborted if a
+     * session-terminating timeout event fires while the request is in flight.
+     * This allows the uploading application to receive the abort event, clean up
+     * any navigation guards (e.g. React Router <Prompt>), and let the logout
+     * navigation proceed without entering a confirmation-modal loop.
      */
     send = (payload) => {
       const { logger } = this.FFetchContext;
@@ -191,6 +212,19 @@ export default (deps) => {
 
       if (!this.shouldEnsureToken) {
         logger.log('rtr', 'request passed through, sending XHR...');
+      } else {
+        const abortOnTimeout = () => {
+          this.FFetchContext.logger?.log('rtr', 'aborting in-flight XHR due to session timeout');
+          this._removeTimeoutListeners?.();
+          super.abort();
+        };
+        window.addEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
+        window.addEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);
+        this._removeTimeoutListeners = () => {
+          window.removeEventListener(RTR_FLS_TIMEOUT_EVENT, abortOnTimeout);
+          window.removeEventListener(RTR_TIMEOUT_EVENT, abortOnTimeout);
+          this._removeTimeoutListeners = null;
+        };
       }
 
       super.send(payload);

--- a/src/components/Root/FXHR.js
+++ b/src/components/Root/FXHR.js
@@ -164,6 +164,7 @@ export default (deps) => {
           * so that any cancel confirmation modals attached to the operation can be circumvented
           * and our logout navigation can be triggered when the RTR_ERROR_EVENT.
           */
+          this._removeTimeoutListeners?.();
           super.abort();
           window.dispatchEvent(new Event(RTR_ERROR_EVENT, { detail: err }));
         } else {

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -154,7 +154,7 @@ describe('FXHR', () => {
     expect(mockHandler).toHaveBeenCalledTimes(1);
   });
 
-  describe('abort on session-timeout events', () => {
+  describe('abort on session-timeout events, rotation failures', () => {
     let abortSpy;
 
     // Dispatch a window event through EventTarget.prototype directly so that

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -33,7 +33,7 @@ describe('FXHR', () => {
     jest.clearAllMocks();
     FakeXHR = FXHR({ logger: { log: () => { } }, okapi: { url: 'okapiUrl' } });
     testXHR = new FakeXHR();
-    dispatchSpy = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
+    dispatchSpy = jest.spyOn(window, 'dispatchEvent');
   });
 
   afterEach(() => {
@@ -59,7 +59,7 @@ describe('FXHR', () => {
 
   it('calls other prototype methods...', () => {
     testXHR.addEventListener('abort', mockHandler);
-    testXHR.open('POST', 'okapiUrl');
+    testXHR.open('POST', 'notOkapiUrl');
     testXHR.send(new ArrayBuffer(8));
     expect(openSpy.mock.calls).toHaveLength(1);
     expect(aelSpy.mock.calls).toHaveLength(1);
@@ -157,19 +157,41 @@ describe('FXHR', () => {
   describe('abort on session-timeout events', () => {
     let abortSpy;
 
+    // Dispatch a window event through EventTarget.prototype directly so that
+    // real event listeners fire without going through the dispatchSpy mock.
+    const fireWindowEvent = (type) => {
+      EventTarget.prototype.dispatchEvent.call(window, new Event(type));
+    };
+
     beforeEach(() => {
-      abortSpy = jest.spyOn(XMLHttpRequest.prototype, 'abort').mockImplementation(() => {});
+      abortSpy = jest.spyOn(XMLHttpRequest.prototype, 'abort').mockImplementation(() => { });
     });
 
     afterEach(() => {
       abortSpy.mockRestore();
     });
 
+    it('when rotation fails, aborts the XHR, surfacing the error in the UI', async () => {
+      rotateAndReplay.mockRejectedValueOnce(new RTRError('Rotation failure!'));
+
+      testXHR.open('POST', 'okapiUrl/files');
+      testXHR.onreadystatechange = mockHandler;
+      testXHR.send(new ArrayBuffer(8));
+
+      setXhrState(testXHR, { readyState: 4, status: 401, responseText: '{}' });
+      testXHR.handleInternalReadyStateChange({});
+
+      await Promise.resolve();
+
+      expect(abortSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('aborts an in-flight Okapi request when RTR_FLS_TIMEOUT_EVENT fires', () => {
       testXHR.open('POST', 'okapiUrl/files');
       testXHR.send(new ArrayBuffer(8));
 
-      window.dispatchEvent(new Event(RTR_FLS_TIMEOUT_EVENT));
+      fireWindowEvent(RTR_FLS_TIMEOUT_EVENT);
 
       expect(abortSpy).toHaveBeenCalledTimes(1);
     });
@@ -178,7 +200,7 @@ describe('FXHR', () => {
       testXHR.open('POST', 'okapiUrl/files');
       testXHR.send(new ArrayBuffer(8));
 
-      window.dispatchEvent(new Event(RTR_TIMEOUT_EVENT));
+      fireWindowEvent(RTR_TIMEOUT_EVENT);
 
       expect(abortSpy).toHaveBeenCalledTimes(1);
     });
@@ -187,13 +209,13 @@ describe('FXHR', () => {
       testXHR.open('POST', 'https://external.example.com/upload');
       testXHR.send(new ArrayBuffer(8));
 
-      window.dispatchEvent(new Event(RTR_FLS_TIMEOUT_EVENT));
-      window.dispatchEvent(new Event(RTR_TIMEOUT_EVENT));
+      fireWindowEvent(RTR_FLS_TIMEOUT_EVENT);
+      fireWindowEvent(RTR_TIMEOUT_EVENT);
 
       expect(abortSpy).not.toHaveBeenCalled();
     });
 
-    it('removes timeout listeners after request reaches DONE state', () => {
+    it('does not abort after request reaches DONE state', () => {
       testXHR.open('POST', 'okapiUrl/files');
       testXHR.onreadystatechange = mockHandler;
       testXHR.send(new ArrayBuffer(8));
@@ -201,28 +223,11 @@ describe('FXHR', () => {
       setXhrState(testXHR, { readyState: 4, status: 200, responseText: '{"ok":true}' });
       testXHR.handleInternalReadyStateChange({});
 
-      // Listeners should have been removed; abort must not be called
-      window.dispatchEvent(new Event(RTR_FLS_TIMEOUT_EVENT));
-      window.dispatchEvent(new Event(RTR_TIMEOUT_EVENT));
+      // Listeners should have been removed at DONE; subsequent timeout events are no-ops.
+      fireWindowEvent(RTR_FLS_TIMEOUT_EVENT);
+      fireWindowEvent(RTR_TIMEOUT_EVENT);
 
       expect(abortSpy).not.toHaveBeenCalled();
     });
-  });
-
-  it('dispatches RTR_ERROR_EVENT and surfaces original failure when rotation fails', async () => {
-    rotateAndReplay.mockRejectedValueOnce(new RTRError('Rotation failure!'));
-
-    testXHR.open('POST', 'okapiUrl/files');
-    testXHR.onreadystatechange = mockHandler;
-    testXHR.send(new ArrayBuffer(8));
-
-    setXhrState(testXHR, { readyState: 4, status: 401, responseText: '{}' });
-    testXHR.handleInternalReadyStateChange({});
-
-    await Promise.resolve();
-
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(dispatchSpy.mock.calls[0][0].type).toBe(RTR_ERROR_EVENT);
-    expect(mockHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -171,7 +171,7 @@ describe('FXHR', () => {
       abortSpy.mockRestore();
     });
 
-    it('when rotation fails, aborts the XHR, surfacing the error in the UI', async () => {
+    it('when rotation fails, aborts the XHR and dispatch RTR_ERROR_EVENT, surfacing the error in the UI.', async () => {
       rotateAndReplay.mockRejectedValueOnce(new RTRError('Rotation failure!'));
 
       testXHR.open('POST', 'okapiUrl/files');
@@ -185,6 +185,7 @@ describe('FXHR', () => {
 
       expect(abortSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy.mock.calls[0][0].type).toContain('RTRError');
     });
 
     it('aborts an in-flight Okapi request when RTR_FLS_TIMEOUT_EVENT fires', () => {

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -1,5 +1,5 @@
 import { rotateAndReplay } from './rotateAndReplay';
-import { RTR_ERROR_EVENT } from './constants';
+import { RTR_ERROR_EVENT, RTR_FLS_TIMEOUT_EVENT, RTR_TIMEOUT_EVENT } from './constants';
 import { RTRError } from './Errors';
 import FXHR from './FXHR';
 
@@ -152,6 +152,61 @@ describe('FXHR', () => {
 
     expect(rotateAndReplay).toHaveBeenCalledTimes(1);
     expect(mockHandler).toHaveBeenCalledTimes(1);
+  });
+
+  describe('abort on session-timeout events', () => {
+    let abortSpy;
+
+    beforeEach(() => {
+      abortSpy = jest.spyOn(XMLHttpRequest.prototype, 'abort').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      abortSpy.mockRestore();
+    });
+
+    it('aborts an in-flight Okapi request when RTR_FLS_TIMEOUT_EVENT fires', () => {
+      testXHR.open('POST', 'okapiUrl/files');
+      testXHR.send(new ArrayBuffer(8));
+
+      window.dispatchEvent(new Event(RTR_FLS_TIMEOUT_EVENT));
+
+      expect(abortSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts an in-flight Okapi request when RTR_TIMEOUT_EVENT fires', () => {
+      testXHR.open('POST', 'okapiUrl/files');
+      testXHR.send(new ArrayBuffer(8));
+
+      window.dispatchEvent(new Event(RTR_TIMEOUT_EVENT));
+
+      expect(abortSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not abort non-Okapi requests when timeout events fire', () => {
+      testXHR.open('POST', 'https://external.example.com/upload');
+      testXHR.send(new ArrayBuffer(8));
+
+      window.dispatchEvent(new Event(RTR_FLS_TIMEOUT_EVENT));
+      window.dispatchEvent(new Event(RTR_TIMEOUT_EVENT));
+
+      expect(abortSpy).not.toHaveBeenCalled();
+    });
+
+    it('removes timeout listeners after request reaches DONE state', () => {
+      testXHR.open('POST', 'okapiUrl/files');
+      testXHR.onreadystatechange = mockHandler;
+      testXHR.send(new ArrayBuffer(8));
+
+      setXhrState(testXHR, { readyState: 4, status: 200, responseText: '{"ok":true}' });
+      testXHR.handleInternalReadyStateChange({});
+
+      // Listeners should have been removed; abort must not be called
+      window.dispatchEvent(new Event(RTR_FLS_TIMEOUT_EVENT));
+      window.dispatchEvent(new Event(RTR_TIMEOUT_EVENT));
+
+      expect(abortSpy).not.toHaveBeenCalled();
+    });
   });
 
   it('dispatches RTR_ERROR_EVENT and surfaces original failure when rotation fails', async () => {

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -164,10 +164,12 @@ describe('FXHR', () => {
     };
 
     beforeEach(() => {
+      jest.useFakeTimers();
       abortSpy = jest.spyOn(XMLHttpRequest.prototype, 'abort').mockImplementation(() => { });
     });
 
     afterEach(() => {
+      jest.useRealTimers();
       abortSpy.mockRestore();
     });
 
@@ -182,8 +184,10 @@ describe('FXHR', () => {
       testXHR.handleInternalReadyStateChange({});
 
       await Promise.resolve();
+      jest.runAllTimers();
 
       expect(abortSpy).toHaveBeenCalledTimes(1);
+
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy.mock.calls[0][0].type).toContain('RTRError');
     });

--- a/src/components/Root/FXHR.test.js
+++ b/src/components/Root/FXHR.test.js
@@ -1,5 +1,5 @@
 import { rotateAndReplay } from './rotateAndReplay';
-import { RTR_ERROR_EVENT, RTR_FLS_TIMEOUT_EVENT, RTR_TIMEOUT_EVENT } from './constants';
+import { RTR_FLS_TIMEOUT_EVENT, RTR_TIMEOUT_EVENT } from './constants';
 import { RTRError } from './Errors';
 import FXHR from './FXHR';
 


### PR DESCRIPTION
## [STCOR-1076](https://folio-org.atlassian.net/browse/STCOR-1076)

Currently, if a user executes a long-running upload when approaching their fixed-session timeout, they are caught in a loop without proper messaging as 
1.  Navigation to /logout is attempted
2.  The handler to interrupt navigation (confirmation modal) fires, providing hopeful messaging that the action can continue. 
Sadly, it cannot. No valid token means the action and any following actions will fail.

This PR will hopefully resolve this issue and abort the upload when either of the RTR_TIMEOUT events fire. This should make room for the `/logout` navigation to work and respect the token expiration/system functionality around token timeout.