### PR TITLE
STCOR-1080 do not handle non-rotation errors as fatal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Inspect local expiry information prior to initial request, avoiding 401's in rtr flow. Refs STCOR-1069.
 * Rotate preventively prior to logout. Refs STCOR-1068.
 * Reliably handle unsynchronized FOLIO/Keycloak sessions. Refs STCOR-1067.
+* During rotation, allow non-rotation errors to bubble. Refs STCOR-1080.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/Root/FFetch.js
+++ b/src/components/Root/FFetch.js
@@ -153,17 +153,17 @@ export class FFetch {
     // rotate
     // handle rotation
     rotate: async () => {
-      const res = await this.nativeFetch.apply(globalThis, [`${this.okapi.url}/authn/refresh`, {
-        headers: {
-          'content-type': 'application/json',
-          'x-okapi-tenant': this.okapi.tenant,
-        },
-        method: 'POST',
-        credentials: 'include',
-        mode: 'cors',
-      }]);
-
       try {
+        const res = await this.nativeFetch.apply(globalThis, [`${this.okapi.url}/authn/refresh`, {
+          headers: {
+            'content-type': 'application/json',
+            'x-okapi-tenant': this.okapi.tenant,
+          },
+          method: 'POST',
+          credentials: 'include',
+          mode: 'cors',
+        }]);
+
         if (res.ok) {
           const json = await res.json();
           if (json.accessTokenExpiration && json.refreshTokenExpiration) {
@@ -186,7 +186,12 @@ export class FFetch {
     // onSuccess
     // rotation succeeded: call the success-callback
     onSuccess: async (newTokens) => {
-      await this.onRotate(newTokens);
+      try {
+        await this.onRotate(newTokens);
+      } catch (err) {
+        console.error(err); // eslint-disable-line no-console
+        throw new RTRError('Rotation failure; could not save!', { cause: err });
+      }
     },
 
     // onFailure

--- a/src/components/Root/rotateAndReplay.js
+++ b/src/components/Root/rotateAndReplay.js
@@ -151,11 +151,14 @@ export const rotateAndReplay = async (fetchfx, config, original) => {
       return replayRequest(fetchfx, config, original);
     } catch (err) {
       // 💥 Ruhroh, Raggy, rotation railed!
-      // Report the failure via the provided callback. Reject with the original
-      // response if available, allowing it to bubble to the caller. Otherwise,
-      // rethrow, i.e. reject with the object we just caught.
-      config.logger.log('rtr', 'RTR error!', err);
-      await config.onFailure(err);
+      // If this is a rotation-specific error then report the failure via the
+      // provided callback (e.g. failure in the rotation callback, timeout,
+      // failure in the rotation-success handler). Otherwise, reject with the
+      // original response or with this error.
+      if (err instanceof RTRError) {
+        config.logger.log('rtr', 'RTR error!', err);
+        await config.onFailure(err);
+      }
       if (original?.response) {
         throw original;
       }

--- a/src/components/Root/rotateAndReplay.test.js
+++ b/src/components/Root/rotateAndReplay.test.js
@@ -1,3 +1,4 @@
+import { RTRError } from './Errors';
 import { rotateAndReplay, RTR_LOCK_KEY } from './rotateAndReplay';
 
 describe('rotateAndReplay', () => {
@@ -29,7 +30,7 @@ describe('rotateAndReplay', () => {
     jest.clearAllMocks();
   });
 
-  describe('with an error response', () => {
+  describe('with an original response', () => {
     describe('resolves', () => {
       test('short-circuits to replay when token is already valid', async () => {
         const expected = { ok: true, body: 'replayed-response' };
@@ -146,9 +147,9 @@ describe('rotateAndReplay', () => {
     });
 
     describe('rejects', () => {
-      test('when rotation fails, calls onFailure and rejects with the original error when rotation fails', async () => {
+      test('when rotation itself fails, calls onFailure and rejects with the original error', async () => {
         const fetchfx = jest.fn().mockResolvedValueOnce({ status: 401 });
-        const rotateErr = new Error('rotate failed');
+        const rotateErr = new RTRError('rotate failed');
         const config = {
           logger: makeLogger(),
           rotate: jest.fn().mockRejectedValue(rotateErr),
@@ -162,6 +163,25 @@ describe('rotateAndReplay', () => {
 
         await expect(rotateAndReplay(fetchfx, config, originalError)).rejects.toBe(originalError);
         expect(config.onFailure).toHaveBeenCalled();
+        expect(fetchfx).toHaveBeenCalledWith(originalError.resource, originalError.options);
+      });
+
+      test('when replay fails, rejects with the original error', async () => {
+        const fetchfx = jest.fn().mockRejectedValue({ status: 401 });
+
+        const config = {
+          logger: makeLogger(),
+          rotate: jest.fn().mockResolvedValue(undefined),
+          onSuccess: jest.fn().mockResolvedValue(undefined),
+          onFailure: jest.fn().mockResolvedValue(undefined),
+          options: jest.fn((opts) => opts),
+          shouldRotate: async () => true,
+        };
+
+        const originalError = { resource: '/baz', options: {}, response: { status: 401 } };
+
+        await expect(rotateAndReplay(fetchfx, config, originalError)).rejects.toBe(originalError);
+        expect(config.onFailure).not.toHaveBeenCalled();
         expect(fetchfx).toHaveBeenCalledWith(originalError.resource, originalError.options);
       });
     });


### PR DESCRIPTION
`rotateAndReplay()` has two jobs: rotate and replay. Rotation-related errors are fatal, but replay-related errors are not. For example, if the rotation request itself fails, or times out, or the response data cannot be stored, those are all fatal errors that need to cause session termination. But if a replay request fails, then such errors should bubble back to the caller, same as they would if the request failed outside `rotateAndReplay()`. Until this PR, this PR, both failures called `config.onFailure()`, effectively treating non-rotation (non-fatal) errors as fatal errors. Whoops.

This PR wraps all rotation-related errors in `RTRError` in order to make it easy for the `rotateAndReplay()` catch-block to distinguish fatal rotation errors from non-fatal fetch errors, calling `config.onFailure()` only for the former.

A common-cause of fetch-failures appears to be AbortControllers used to interrupt fetch calls when navigating away from the route that fired the fetch. For example, some stripes-smart-components provide `useQuery` functions that accept a `signal` argument that react-query can use to cancel an in-flight fetch. As noted at [MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal#examples), 
> When abort() is called, the fetch() promise rejects with a DOMException named AbortError.

There are two approaches we could take in the catch clause:
1. call `config.onFailure()` only when we find specific errors we know are fatal (e.g. an RTRError)
2. call `config.onFailure()` by default, skipping it only when we find specific errors we know are non-fatal (e.g. an AbortError)

Given the severe consequences of a fatal error (i.e. forced logout), this PR implements the former, choosing to look only for the specific errors we know to be fatal. The tradeoff is that this allows non-fatal errors to escape back to the application where it may not be completely clear how to handle them. At present, this feels like an acceptable tradeoff. 

Refs [STCOR-1080](https://folio-org.atlassian.net/browse/STCOR-1080)