### PR TITLE
STCOR-1081 label Root.js as having side-effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Inspect local expiry information prior to initial request, avoiding 401's in rtr flow. Refs STCOR-1069.
 * Rotate preventively prior to logout. Refs STCOR-1068.
 * Reliably handle unsynchronized FOLIO/Keycloak sessions. Refs STCOR-1067.
+* Declare `Root.js` as having side-effects to avoid improperly optimizing it away in `webpack` >= 5.108.0. Refs STCOR-1081.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-core",
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "**/Root/Root.js"
   ],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
As described and solved by @Dmytro-Melnyshyn:
> `webpack` 5.108.0 introduced a `LazyBarrelController` optimization that defers side-effect-only imports (`import './Root.css'`) inside modules marked as side-effect-free. Since sideEffects: `['*.css']` marks all JS files (including `Root.js`) as side-effect-free, `Root.css` gets permanently deferred and is dropped from the bundle.
>
> Fix: add `"**/Root/Root.js"` to the `sideEffects` array in `package.json`. This marks `Root.js` as having side effects, so the optimization is skipped for it and the CSS import is processed normally.

LazyBarrelOptimization has not made it into the webpack documentation yet, but is described in other bundlers ([rspack](https://rspack.rs/guide/optimization/lazy-barrel), [rolldown](https://rolldown.rs/in-depth/lazy-barrel-optimization)).

Refs [STCOR-1081](https://folio-org.atlassian.net/browse/STCOR-1081)