### PR TITLE
STCOR-1082 supply isGuardable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Reliably handle unsynchronized FOLIO/Keycloak sessions. Refs STCOR-1067.
 * Declare `Root.js` as having side-effects to avoid improperly optimizing it away in `webpack` >= 5.108.0. Refs STCOR-1081.
 * During rotation, allow non-rotation errors to bubble. Refs STCOR-1080.
+* Supply `isGuardable()` for globally determining whether a route can be guarded. Refs STCOR-1082.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ export { default as withOkapiKy } from './src/withOkapiKy';
 export { default as useCustomFields } from './src/useCustomFields';
 export { default as createReactQueryClient } from './src/createReactQueryClient';
 export { useAppOrderContext } from './src/components/MainNav/AppOrderProvider';
+export { default as isGuardable } from './src/helpers/isGuardable';
 
 /* components */
 export { default as AppContextMenu } from './src/components/MainNav/CurrentApp/AppContextMenu';

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,2 +1,3 @@
 export { default as parseJWT } from './parseJWT';
 export { default as hideEmail } from './hideEmail';
+export { default as isGuardable } from './isGuardable';

--- a/src/helpers/isGuardable.js
+++ b/src/helpers/isGuardable.js
@@ -1,0 +1,18 @@
+/**
+ * isGuardable
+ * Return true if a route may show a navigation-guard when there is work in
+ * progress (e.g. due to a dirty form or ongoing upload) to prompt whether the
+ * user wants to abandon this work, or false if the navigation is obligatory
+ * (e.g. due to a session being terminated) and user input is irrelevant.
+ *
+ * @param {string} route the destination route
+ * @returns {boolean} true if a route may be guarded; false otherwise
+ */
+const isGuardable = route => {
+  const obligatoryRoutes = ['/logout'];
+
+  // if the given route matches an obligator route, it cannot be guarded
+  return !(obligatoryRoutes.some(i => route.startsWith(i)));
+};
+
+export default isGuardable;

--- a/src/helpers/isGuardable.js
+++ b/src/helpers/isGuardable.js
@@ -8,11 +8,11 @@
  * @param {string} route the destination route
  * @returns {boolean} true if a route may be guarded; false otherwise
  */
-const isGuardable = route => {
+const isGuardable = (route) => {
   const obligatoryRoutes = ['/logout'];
 
   // if the given route matches an obligator route, it cannot be guarded
-  return !(obligatoryRoutes.some(i => route.startsWith(i)));
+  return !obligatoryRoutes.includes(route);
 };
 
 export default isGuardable;

--- a/src/helpers/isGuardable.test.js
+++ b/src/helpers/isGuardable.test.js
@@ -1,0 +1,12 @@
+import isGuardable from './isGuardable';
+
+describe('isGuardable', () => {
+  it('returns true for guardable routes', () => {
+    expect(isGuardable('/nowhere-fast')).toBe(true);
+  });
+
+  it('returns false for unguardable routes', () => {
+    expect(isGuardable('/logout')).toBe(false);
+    expect(isGuardable('/logout-timeout')).toBe(false);
+  });
+});

--- a/src/helpers/isGuardable.test.js
+++ b/src/helpers/isGuardable.test.js
@@ -1,12 +1,13 @@
 import isGuardable from './isGuardable';
 
 describe('isGuardable', () => {
-  it('returns true for guardable routes', () => {
+  it('returns true for routes other than "/logout"', () => {
     expect(isGuardable('/nowhere-fast')).toBe(true);
+    expect(isGuardable('/logout-good')).toBe(true);
+    expect(isGuardable('/logout/cheap')).toBe(true);
   });
 
-  it('returns false for unguardable routes', () => {
+  it('returns false for "/logout"', () => {
     expect(isGuardable('/logout')).toBe(false);
-    expect(isGuardable('/logout-timeout')).toBe(false);
   });
 });


### PR DESCRIPTION
Supply `isGuardable(route)`, a function that returns `true` if the given route may be protected by a navigation-guard to allow the user the opportunity to avoid navigating away from work-in-progress such as a dirty form or ongoing upload, or `false` if the navigation is obligatory, such as redirecting to `/logout` upon session termination.

Refs [STCOR-1082](https://folio-org.atlassian.net/browse/STCOR-1082)