### PR TITLE
STCOR-1083 - Use ref for paneTitleRef instead of element for focus-management fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * During rotation, allow non-rotation errors to bubble. Refs STCOR-1080.
 * Supply `isGuardable()` for globally determining whether a route can be guarded. Refs STCOR-1082.
 * Supply `mod-settings` permissions for managing others' settings. Refs STCOR-1072.
+* `<Settings>` - properly assign `paneTitleRef` for focus management. Refs STCOR-1083.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -2,6 +2,7 @@ import React, {
   useRef,
   useEffect,
   useMemo,
+  useCallback,
   Suspense,
 } from 'react';
 import {
@@ -121,7 +122,7 @@ const Settings = ({ stripes }) => {
         <Pane
           defaultWidth="20%"
           paneTitle={<FormattedMessage id="stripes-core.settings" />}
-          paneTitleRef={paneTitleRef.current}
+          paneTitleRef={paneTitleRef}
           id="settings-nav-pane"
         >
           <NavList aria-label={intl.formatMessage({ id: 'stripes-core.settings' })}>

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -2,7 +2,6 @@ import React, {
   useRef,
   useEffect,
   useMemo,
-  useCallback,
   Suspense,
 } from 'react';
 import {


### PR DESCRIPTION
## [STCOR-1083](https://folio-org.atlassian.net/browse/STCOR-1083)
This resolved the focus-management issue where focus should move to the listing pane when the user navigates to Settings from the Apps dropdown in the main navigation.

This was a simple fix of providing a ref instead of the `ref.current` for `paneTitleRef` on the listing pane of Settings.