### PR TITLE
STCOR-780 show a "please reload!" banner when entitlement changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Supply `isGuardable()` for globally determining whether a route can be guarded. Refs STCOR-1082.
 * Supply `mod-settings` permissions for managing others' settings. Refs STCOR-1072.
 * `<Settings>` - properly assign `paneTitleRef` for focus management. Refs STCOR-1083.
+* Supply `<EntitlementChangeBanner>` to indicate entitlement changes. Refs STCOR-780.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -41,6 +41,7 @@ import {
   QueryStateUpdater
 } from './components';
 import StaleBundleWarning from './components/StaleBundleWarning';
+import EntitlementChangeBanner from './components/EntitlementChangeBanner';
 import { StripesContext } from './StripesContext';
 import { CalloutProvider } from './CalloutContext';
 import AuthnLogin from './components/AuthnLogin';
@@ -112,6 +113,7 @@ const RootWithIntl = ({
                               <AppOrderProvider>
                                 <MainNav stripes={connectedStripes} queryClient={queryClient} />
                                 {typeof connectedStripes?.config?.staleBundleWarning === 'object' && <StaleBundleWarning />}
+                                <EntitlementChangeBanner />
                                 <HandlerManager
                                   event={events.LOGIN}
                                   stripes={connectedStripes}

--- a/src/RootWithIntl.test.js
+++ b/src/RootWithIntl.test.js
@@ -13,6 +13,7 @@ jest.mock('./components/OverlayContainer', () => () => '<OverlayContainer>');
 jest.mock('./components/ModuleContainer', () => ({ children }) => children);
 jest.mock('./components/MainContainer', () => ({ children }) => children);
 jest.mock('./components/StaleBundleWarning', () => () => '<StaleBundleWarning>');
+jest.mock('./components/EntitlementChangeBanner', () => () => '<EntitlementChangeBanner>');
 jest.mock('./components/SessionEventContainer', () => () => '<SessionEventContainer>');
 jest.mock('./components/MainNav/QueryStateUpdater', () => () => null);
 

--- a/src/components/EntitlementChangeBanner.js
+++ b/src/components/EntitlementChangeBanner.js
@@ -1,0 +1,30 @@
+import { FormattedMessage } from 'react-intl';
+import { Button, MessageBanner } from '@folio/stripes-components';
+
+import useEntitlementDidChange from '../hooks/useEntitlementDidChange';
+
+/**
+ * EntitlementChangeBanner
+ * Display an interactive banner containing a "reload" button when a change
+ * to entitlement is detected. useEntitlementDidChange() periodically polls
+ * the entitlement endpoint and compares previous/current results.
+ *
+ * @see StaleBundleWarning, which was the base for this component and hook but
+ *   which relies on a static path for its query and which compares the entire
+ *   response-body, rather than just the application-ids.
+ */
+const EntitlementChangeBanner = () => {
+  const stale = useEntitlementDidChange();
+
+  return (
+    <MessageBanner type="warning" show={stale}>
+      <FormattedMessage id="stripes-core.stale.warning" />
+      {' '}
+      <Button buttonStyle="link" onClick={() => window.location.reload(true)} marginBottom0>
+        <FormattedMessage id="stripes-core.stale.reload" />
+      </Button>
+    </MessageBanner>
+  );
+};
+
+export default EntitlementChangeBanner;

--- a/src/hooks/useEntitlementDidChange.js
+++ b/src/hooks/useEntitlementDidChange.js
@@ -1,0 +1,62 @@
+import { useQuery } from 'react-query';
+import { useRef, useState } from 'react';
+import { useStripes } from '../StripesContext';
+import useOkapiKy from '../useOkapiKy';
+
+/**
+ * useEntitlementChangeNotifier
+ * Periodically query the entitlement endpoint `/entitlements/${tenant}/applications`
+ * to determine whether entitlements have changed, returning true if they have,
+ * false otherwise. That endpoint returns A LOT of data, but only the
+ * application ids are compared. All other attributes are ignored.
+ *
+ * Set stripes.config.js::config.staleBundleWarning.interval to an integer value
+ * representing the interval, in minutes, between queries. Defaults to 15.
+ *
+ * @returns boolean true if entitlement has changed; false otherwise.
+ */
+const useEntitlementChangeNotifier = () => {
+  const INTERVAL_MINUTES = 15;
+
+  const stripes = useStripes();
+  const ky = useOkapiKy();
+  const config = stripes?.config?.staleBundleWarning;
+  const refetchInterval = (Number.isInteger(config?.interval) ? config.interval : INTERVAL_MINUTES) * 60 * 1000;
+  const previous = useRef();
+  const [isStale, setIsStale] = useState(false);
+
+  useQuery({
+    queryKey: ['EntitlementChangeWarning'],
+    queryFn: async () => {
+      const json = await ky(`entitlements/${stripes.okapi.tenant}/applications`, {
+        searchParams: { limit: 500 }
+      }).json();
+      /* entitlement data looks, in part, like this:
+       *
+       *   { "applicationDescriptors": [
+       *     { name: "foo", version: "1", id: "foo-1" }
+       *     { name: "bar", version: "2", id: "bar-2" }
+       *     { name: "bat", version: "1", id: "bat-1" }
+       *   ]}
+       *
+       * so we can use id as a unique identifier. The remainder of the response
+       * can be ignored. Sets allows for easy comparison regardless of order.
+       * When the version of a module inside an application changes, there will
+       * be a corresponding change in the application's version.
+       */
+      const idSet = new Set(json.applicationDescriptors.map(i => i.id));
+      if (previous.current) {
+        setIsStale(Boolean(previous.current.difference(idSet).size));
+      }
+
+      previous.current = idSet;
+    },
+    staleTime: refetchInterval,
+    refetchInterval,
+    enabled: !isStale,
+  });
+
+  return isStale;
+};
+
+export default useEntitlementChangeNotifier;

--- a/src/hooks/useEntitlementDidChange.test.js
+++ b/src/hooks/useEntitlementDidChange.test.js
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import useEntitlementDidChange from './useEntitlementDidChange';
+import useOkapiKy from '../useOkapiKy';
+
+const interfaceProviders = [
+];
+
+jest.mock('../useOkapiKy');
+jest.mock('../components', () => ({
+  useNamespace: () => ([]),
+}));
+jest.mock('../StripesContext', () => ({
+  useStripes: () => ({
+    okapi: {
+      tenant: 't',
+    },
+    discovery: {
+      interfaceProviders,
+    }
+  }),
+}));
+
+const initialResponse = {
+  applicationDescriptors: [
+    { id: 'one' },
+    { id: 'two' },
+  ],
+};
+
+const changedResponse = {
+  applicationDescriptors: [
+    { id: 'one' },
+    { id: 'three' },
+  ],
+};
+
+describe('useEntitlementDidChange', () => {
+  let queryClient;
+  let wrapper;
+  let kyMock;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    kyMock = jest.fn();
+    useOkapiKy.mockReturnValue(kyMock);
+    // eslint-disable-next-line react/prop-types
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('returns false after the initial query', async () => {
+    kyMock.mockImplementation(() => ({
+      json: () => initialResponse,
+    }));
+    const { result } = renderHook(() => useEntitlementDidChange(), { wrapper });
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('returns false when entitlement data remains constant', async () => {
+    kyMock.mockImplementation(() => ({
+      json: () => initialResponse,
+    }));
+    const { result } = renderHook(() => useEntitlementDidChange(), { wrapper });
+    await waitFor(() => expect(result.current).toBe(false));
+    await act(async () => {
+      await queryClient.refetchQueries(['EntitlementChangeWarning']);
+    });
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('returns true when entitlement data changes', async () => {
+    kyMock
+      .mockImplementationOnce(() => ({
+        json: () => initialResponse
+      }))
+      .mockImplementationOnce(() => ({
+        json: () => changedResponse
+      }));
+
+    const { result } = renderHook(() => useEntitlementDidChange(), { wrapper });
+    await waitFor(() => expect(result.current).toBe(false));
+    await act(async () => {
+      await queryClient.refetchQueries(['EntitlementChangeWarning']);
+    });
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+});


### PR DESCRIPTION
Periodically poll the entitlement endpoint `entitlements/${tenant}/applications` and compare the previous/current list of application versions. When there are changes, show an interactive "please reload" banner.

This implementation borrows heavily from StaleBundleWarning but is different in several important ways:
* Only poll the entitlement API, not an arbitrary path. Because this path is dynamic (it contains the tenant as a path param) it could not easily be listed as a config param in `stripes.config.js`.
* Only compare changes to entitlement, not the entire API response. The entitlement response contains a lot of data. A LOT. Much of it is operational, e.g. memory allocation, port bindings, etc., which could change but which do not correpond to an entitlement change.

Refs [STCOR-780](https://folio-org.atlassian.net/browse/STCOR-780)