### PR TITLE
STCOR-997 refactor from HotKeys to CommandList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Supply `mod-settings` permissions for managing others' settings. Refs STCOR-1072.
 * `<Settings>` - properly assign `paneTitleRef` for focus management. Refs STCOR-1083.
 * Supply `<EntitlementChangeBanner>` to indicate entitlement changes. Refs STCOR-780.
+* Refactor from `<HotKeys>` to `<CommandList>`. Refs STCOR-997.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/RootWithIntl.js
+++ b/src/RootWithIntl.js
@@ -9,7 +9,7 @@ import { Provider } from 'react-redux';
 import { CookiesProvider } from 'react-cookie';
 
 import { connectFor } from '@folio/stripes-connect';
-import { Callout, HotKeys } from '@folio/stripes-components';
+import { Callout, CommandList } from '@folio/stripes-components';
 
 import ModuleRoutes from './ModuleRoutes';
 import events from './events';
@@ -89,11 +89,7 @@ const RootWithIntl = ({
         <ModuleTranslator>
           <EntitlementLoader>
             <TitleManager>
-              <HotKeys
-                keyMap={connectedStripes.bindings}
-                attach={document.body}
-                noWrapper
-              >
+              <CommandList commands={connectedStripes.bindings}>
                 <Provider store={connectedStripes.store}>
                   <Router history={history}>
                     {isAuthenticated || token || disableAuth ?
@@ -209,7 +205,7 @@ const RootWithIntl = ({
                     }
                   </Router>
                 </Provider>
-              </HotKeys>
+              </CommandList>
             </TitleManager>
           </EntitlementLoader>
         </ModuleTranslator>

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -37,6 +37,9 @@ jest.mock('@folio/stripes-components', () => ({
     <span {...rest}>{children}</span>
   )),
   Col: jest.fn(({ children }) => <div className="col">{children}</div>),
+  CommandList: jest.fn(({ children }) => (
+    <>{children}</>
+  )),
   ConfirmationModal: jest.fn(({ heading, message, onConfirm, onCancel }) => (
     <div>
       <span>ConfirmationModal</span>


### PR DESCRIPTION
Replace `<HotKeys>` with `<CommandList>`. `<CommandList>` delegates to `<HotKeys>` internally, so there is no net effect to this change.

The history is a little murky, but I think it amounts to "We started with `<HotKeys>`, and then wrote `<CommandList>` to provide better ergonomics and to delegate to `<HotKeys>` internally, but we didn't notice that stripes-core still called out to `<HotKeys>` directly."

Converting to `<CommandList>` here removes the last external consumer of `<HotKeys>` from `@folio/stripes-components`, allowing it to be removed there as a public export, freeing us from needing to protect that API, since it will now be for internal use only.

Refs [STCOR-997](https://folio-org.atlassian.net/browse/STCOR-997)