### PR TITLE
STCOR-1087 always display correct session-time-remaining in banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Supply `mod-settings` permissions for managing others' settings. Refs STCOR-1072.
 * `<Settings>` - properly assign `paneTitleRef` for focus management. Refs STCOR-1083.
 * Supply `<EntitlementChangeBanner>` to indicate entitlement changes. Refs STCOR-780.
+* Correctly display session-remaining time after refresh. Refs STCOR-1087.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/OIDCLanding.js
+++ b/src/components/OIDCLanding.js
@@ -42,13 +42,9 @@ const OIDCLanding = ({ handleRotation }) => {
    */
   const initSession = (tokenData) => {
     if (tokenData) {
-      handleRotation(tokenData)
-        .then(() => {
-          return storeLogoutTenant(okapi.tenant);
-        })
-        .then(() => {
-          return requestUserWithPerms(okapi, store, okapi.tenant, '');
-        });
+      storeLogoutTenant(okapi.tenant);
+      requestUserWithPerms(okapi, store, okapi.tenant, '')
+        .then(() => handleRotation(tokenData));
     }
   };
 

--- a/src/components/OIDCLanding.test.js
+++ b/src/components/OIDCLanding.test.js
@@ -1,11 +1,16 @@
-import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import { useHistory } from 'react-router';
 
 import OIDCLanding from './OIDCLanding';
 import useExchangeCode from './useExchangeCode';
-import { LOGOUT_MESSAGES } from '../loginServices';
+import { LOGOUT_MESSAGES, requestUserWithPerms, storeLogoutTenant } from '../loginServices';
 
 jest.mock('react-router');
+jest.mock('../loginServices', () => ({
+  ...jest.requireActual('../loginServices'),
+  requestUserWithPerms: jest.fn(),
+  storeLogoutTenant: jest.fn(),
+}));
 jest.mock('../StripesContext', () => ({
   useStripes: () => ({
     okapi: { tenant: 'diku' },
@@ -15,6 +20,11 @@ jest.mock('../StripesContext', () => ({
 jest.mock('./useExchangeCode');
 
 describe('OIDCLanding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    requestUserWithPerms.mockResolvedValue();
+  });
+
   it('displays session-init progress message', () => {
     const history = { push: jest.fn() };
     useHistory.mockReturnValue(history);
@@ -55,5 +65,22 @@ describe('OIDCLanding', () => {
     render(<OIDCLanding handleRotation={jest.fn()} />);
 
     expect(history.push).toHaveBeenCalledWith(`/logout?reason=${LOGOUT_MESSAGES.INIT_ERROR}`);
+  });
+
+  it('loads the user before rotating the tokens', async () => {
+    const history = { push: jest.fn() };
+    const handleRotation = jest.fn();
+    const tokenData = { accessTokenExpiration: 1, refreshTokenExpiration: 2 };
+    useHistory.mockReturnValue(history);
+    useExchangeCode.mockImplementationOnce((initSession) => {
+      initSession(tokenData);
+      return { tokenData, isLoading: false, error: null };
+    });
+
+    render(<OIDCLanding handleRotation={handleRotation} />);
+
+    expect(storeLogoutTenant).toHaveBeenCalledWith('diku');
+    await waitFor(() => expect(requestUserWithPerms).toHaveBeenCalledWith({ tenant: 'diku' }, {}, 'diku', ''));
+    await waitFor(() => expect(handleRotation).toHaveBeenCalledWith(tokenData));
   });
 });

--- a/src/components/Root/Root.js
+++ b/src/components/Root/Root.js
@@ -81,15 +81,15 @@ class Root extends Component {
     const rtrConfig = configureRtr(this.props.config.rtr);
 
     // pings when the session ends
-    this.sessionTimeoutTimer = new ResetTimer(() => {
+    this.sessionTimeoutTimer = new ResetTimer((detail) => {
       this.props.logger?.log('rtr-fls', 'emitting RTR_FLS_TIMEOUT_EVENT');
-      globalThis.dispatchEvent(new Event(RTR_FLS_TIMEOUT_EVENT));
+      globalThis.dispatchEvent(new CustomEvent(RTR_FLS_TIMEOUT_EVENT, { detail }));
     }, this.props.logger);
 
     // pings when we need to show a "session is ending!" countdown-banner
-    this.sessionTimeoutWarningTimer = new ResetTimer(() => {
+    this.sessionTimeoutWarningTimer = new ResetTimer((detail) => {
       this.props.logger?.log('rtr-fls', 'emitting RTR_FLS_WARNING_EVENT');
-      globalThis.dispatchEvent(new Event(RTR_FLS_WARNING_EVENT));
+      globalThis.dispatchEvent(new CustomEvent(RTR_FLS_WARNING_EVENT, { detail }));
     }, this.props.logger);
 
     // configure the rotation handler:

--- a/src/components/Root/Root.test.js
+++ b/src/components/Root/Root.test.js
@@ -1,7 +1,10 @@
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import Root from './Root';
+import { RTR_FLS_TIMEOUT_EVENT, RTR_FLS_WARNING_EVENT } from './constants';
 import { modulesInitialState } from '../../ModulesContext';
+
+let mockResetTimerCallbacks = [];
 
 jest.mock('../../loginServices', () => ({
   loadTranslations: jest.fn(),
@@ -15,6 +18,7 @@ jest.mock('./token-util', () => ({
     constructor(callback, logger) {
       this.callback = callback;
       this.logger = logger;
+      mockResetTimerCallbacks.push(callback);
     }
 
     reset() { }
@@ -108,6 +112,7 @@ const renderRoot = (props = {}) => render(getRootComponent(props));
 describe('Root component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockResetTimerCallbacks = [];
     latestContextFns = {};
   });
 
@@ -235,6 +240,37 @@ describe('Root component', () => {
     expect(latestContextFns.addEpic('epic1', epic)).toBe(true);
     expect(latestContextFns.addEpic('epic1', epic)).toBe(false);
     expect(mockAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches fixed-length timer events with timer details', () => {
+    const dispatchEvent = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => {});
+    const store = makeStore({
+      okapi: {
+        okapiReady: true,
+        translations: { title: 'Home' },
+      },
+    });
+
+    renderRoot({ store });
+
+    mockResetTimerCallbacks[0]({ timeRemaining: 1000 });
+    mockResetTimerCallbacks[1]({ timeRemaining: 42000 });
+
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        type: RTR_FLS_TIMEOUT_EVENT,
+        detail: { timeRemaining: 1000 },
+      }),
+    );
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        type: RTR_FLS_WARNING_EVENT,
+        detail: { timeRemaining: 42000 },
+      }),
+    );
+    dispatchEvent.mockRestore();
   });
 
   it('updates queryResourceStateKey on modules change', () => {

--- a/src/components/Root/token-util.js
+++ b/src/components/Root/token-util.js
@@ -121,11 +121,22 @@ export const rotationHandler = (handleSaveTokens, timeoutTimer, warningTimer, rt
     const rtExpires = new Date(expiry.refreshTokenExpiration).getTime();
     await handleSaveTokens({ atExpires, rtExpires });
 
-    const rtTimeoutInterval = rtExpires - Date.now();
-    timeoutTimer.reset(rtTimeoutInterval - RTR_TIME_MARGIN_IN_MS);
+    // how long until the "session is over" timer pings?
+    const rtTimeoutInterval = rtExpires - Date.now() - RTR_TIME_MARGIN_IN_MS;
 
+    // how long until the "session will end soon" timer pings?
+    // this may be < 0, which is fine; calling setTimeout(function, -1) fires
+    // the timer immediately. the value will be < 0 e.g. if there are 15 left
+    // in the session but the warning is supposed to display for 20 seconds.
     const rtWarningInterval = rtTimeoutInterval - ms(rtrConfig.fixedLengthSessionWarningTTL);
-    warningTimer.reset(rtWarningInterval - RTR_TIME_MARGIN_IN_MS);
+
+    timeoutTimer.reset(rtTimeoutInterval);
+
+    // calculate how many milliseconds will be remaining in the session when
+    // this timer pings and pass that value through the timer so it can then be
+    // passed through to the callback when the timer pings.
+    const timeRemaining = rtWarningInterval < 0 ? rtTimeoutInterval : ms(rtrConfig.fixedLengthSessionWarningTTL);
+    warningTimer.reset(rtWarningInterval, { timeRemaining });
   };
 };
 
@@ -158,7 +169,7 @@ export class ResetTimer {
     }
   }
 
-  reset = (interval) => {
+  reset = (interval, args = {}) => {
     const timeout = (typeof interval === 'string') ? ms(interval) : interval;
     if (typeof timeout !== 'number') throw new TypeError('Expected `interval` to be a number');
 
@@ -167,7 +178,7 @@ export class ResetTimer {
       clearTimeout(this.#id);
     }
 
-    this.#id = setTimeout(this.#callback, timeout);
+    this.#id = setTimeout(() => this.#callback(args), timeout);
     this.#logger?.log('rtrv', `ResetTimer: setting ${this.#id}`);
   };
 

--- a/src/components/Root/token-util.test.js
+++ b/src/components/Root/token-util.test.js
@@ -102,6 +102,18 @@ describe('ResetTimer', () => {
       expect(callback).toHaveBeenCalled();
     });
 
+    it('passes callback arguments when the timer fires', () => {
+      jest.useFakeTimers();
+      const callback = jest.fn();
+      const rt = new ResetTimer(callback);
+
+      rt.reset(100, { timeRemaining: 42 });
+      jest.advanceTimersByTime(100);
+
+      expect(callback).toHaveBeenCalledWith({ timeRemaining: 42 });
+      jest.useRealTimers();
+    });
+
     it('resets existing timer', async () => {
       const callback = jest.fn();
       const logger = { log: jest.fn() };
@@ -136,16 +148,31 @@ describe('ResetTimer', () => {
 });
 
 describe('rotationHandler', () => {
-  const hst = jest.fn(async () => { });
-  const tt = { reset: jest.fn() };
-  const wt = { reset: jest.fn() };
-
-  const rt = rotationHandler(hst, tt, wt, { fixedLengthSessionWarningTTL: 1 });
-
   it('calls dem callbacks', async () => {
-    await rt({ accessTokenExpiration: 1, refreshTokenExpiration: 2 });
+    jest.spyOn(Date, 'now').mockReturnValue(1000);
+    const hst = jest.fn(async () => { });
+    const timeoutTimer = { reset: jest.fn() };
+    const warningTimer = { reset: jest.fn() };
+
+    const rotate = rotationHandler(
+      hst,
+      timeoutTimer,
+      warningTimer,
+      { fixedLengthSessionWarningTTL: '5s' }
+    );
+    await rotate({ accessTokenExpiration: 10000, refreshTokenExpiration: 30000 });
+
+    // calls handleSaveTokens callback
     expect(hst).toHaveBeenCalled();
-    expect(tt.reset).toHaveBeenCalled();
-    expect(wt.reset).toHaveBeenCalled();
+
+    // configures end-of-session timer
+    // av[0]: RT - currentTime - margin
+    expect(timeoutTimer.reset).toHaveBeenCalledWith(28800);
+
+    // configures session-will-end-banner timer
+    // av[0]: RT - currentTime - margin - FLSTWarningTTL
+    // av[1]: FLST TTL
+    expect(warningTimer.reset).toHaveBeenCalledWith(23800, { timeRemaining: 5000 });
+    Date.now.mockRestore();
   });
 });

--- a/src/components/SessionEventContainer/SessionEventContainer.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.js
@@ -42,8 +42,9 @@ export const thisWindowRtrIstTimeout = (_e, stripes, history) => {
 };
 
 // fixed-length session warning in this window: show banner
-export const thisWindowRtrFlsWarning = (_e, stripes, setIsFlsVisible) => {
+export const thisWindowRtrFlsWarning = (e, stripes, setIsFlsVisible, setFlsTimeRemaining) => {
   stripes.logger.log('rtr', 'fixed-length session warning');
+  setFlsTimeRemaining(e.detail.timeRemaining)
   setIsFlsVisible(true);
 };
 
@@ -250,7 +251,7 @@ const SessionEventContainer = ({ history }) => {
     });
 
     // fixed-length session: show session-is-ending warning
-    channels.window[RTR_FLS_WARNING_EVENT] = (e) => thisWindowRtrFlsWarning(e, stripes, setIsFlsVisible);
+    channels.window[RTR_FLS_WARNING_EVENT] = (e) => thisWindowRtrFlsWarning(e, stripes, setIsFlsVisible, setFlsTimeRemaining);
 
     // fixed-length session: terminate session
     channels.window[RTR_FLS_TIMEOUT_EVENT] = (e) => thisWindowRtrFlsTimeout(e, stripes, history);

--- a/src/components/SessionEventContainer/SessionEventContainer.test.js
+++ b/src/components/SessionEventContainer/SessionEventContainer.test.js
@@ -7,6 +7,7 @@ import SessionEventContainer, {
   otherWindowStorage,
   thisWindowActivity,
   thisWindowRtrError,
+  thisWindowRtrFlsWarning,
   thisWindowRtrIstTimeout,
 } from './SessionEventContainer';
 import {
@@ -92,6 +93,22 @@ describe('SessionEventContainer event listeners', () => {
 
     thisWindowRtrIstTimeout(null, s, history);
     expect(history.push).toHaveBeenCalledWith(`/logout?reason=${LOGOUT_MESSAGES.INACTIVITY}`);
+  });
+
+  it('thisWindowRtrFlsWarning', () => {
+    const setIsFlsVisible = jest.fn();
+    const setFlsTimeRemaining = jest.fn();
+    const stripesForWarning = { logger: { log: jest.fn() } };
+
+    thisWindowRtrFlsWarning(
+      { detail: { timeRemaining: 42000 } },
+      stripesForWarning,
+      setIsFlsVisible,
+      setFlsTimeRemaining,
+    );
+
+    expect(setFlsTimeRemaining).toHaveBeenCalledWith(42000);
+    expect(setIsFlsVisible).toHaveBeenCalledWith(true);
   });
 
   describe('otherWindowStorage', () => {


### PR DESCRIPTION
If Stripes is initialized or tokens rotated close to the end of the session in the interval when the "warning, session is ending in MM:SS" banner is displayed, the countdown timer needs to be correctly initialized with the actual time remaining. Previously, it was always initialized with the config-value, e.g. 30s. If the page is reloaded with only 15s remaining in the session, the display would be inaccurate.

Rather than reading the config value when the timer pings in SessionEventContainer, this implementation performs the calculation when the ResetTimers are configured during Stripes-init and during rotation, and then passes that value through when the timer pings. This keeps timer-related logic centralized in the token-util functions, and insulates SessionEventContainer from having to lookup session-expiration data when responding to events.

The minor rearrangement of functions in OIDCLanding is so that SessionEventContainer has a chance to render and configure its event listeners before the rotation handler is called to configure the end-of-session timers. If RT expiration is very short, or the RT-warning TTL is very long, it's possible the timers could ping immediately on setup, before the listeners have been configured, causing the event to be ignored.

An initial implementation simply added an effect to SessionEventContainer, looking up the end-of-session timestamp and doing the math there. This was a little simpler, but it felt icky. 1. It added an effect. 2. It polluted SessionEventContainer with logic that felt unrelated.

Refs [STCOR-1087](https://folio-org.atlassian.net/browse/STCOR-1087)