### PR TITLE
STCOR-1093: Rename `button.new` from `+ New` to `New`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Supply `mod-settings` permissions for managing others' settings. Refs STCOR-1072.
 * `<Settings>` - properly assign `paneTitleRef` for focus management. Refs STCOR-1083.
 * Supply `<EntitlementChangeBanner>` to indicate entitlement changes. Refs STCOR-780.
+* Rename `button.new` from "+ New" to "New". Refs STCOR-1093.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/translations/stripes-core/en.json
+++ b/translations/stripes-core/en.json
@@ -21,7 +21,7 @@
   "front.error.general.message": "The requested URL {br}{url}{br} was not found on this server.",
   "front.error.noPermission": "You don't have permission to view this app/record",
   "front.error.setPassword.message": "Please log out of your current FOLIO session to set password. Once logged out please try to set your password with this link again.",
-  "button.new": "+ New",
+  "button.new": "New",
   "button.new_tooltip": "Add {entry}",
   "button.edit": "Edit",
   "button.duplicate": "Duplicate",

--- a/translations/stripes-core/en_US.json
+++ b/translations/stripes-core/en_US.json
@@ -2,7 +2,7 @@
     "front.welcome": "Welcome, the Future Of Libraries Is OPEN!",
     "front.home": "Home",
     "front.about": "Software versions",
-    "button.new": "+ New",
+    "button.new": "New",
     "button.new_tooltip": "Add {entry}",
     "button.edit": "Edit",
     "button.delete": "Delete",


### PR DESCRIPTION
## Purpose
Rename `button.new` from `+ New` to `New`.

## Issues
It is required in the first scenario of https://folio-org.atlassian.net/browse/STCOR-1093 and in https://folio-org.atlassian.net/browse/STCOM-1505
