### PR TITLE
STCOR-1094 Support module-contributed main navigation entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Supply `<EntitlementChangeBanner>` to indicate entitlement changes. Refs STCOR-780.
 * Correctly display session-remaining time after refresh. Refs STCOR-1087.
 * Rename `button.new` from "+ New" to "New". Refs STCOR-1093.
+* Support module-contributed main navigation entries. STCOR-1094.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The documentation roadmap has moved.  Please refer to the [Stripes](https://gith
 * [A component hierarchy example: the "Patrons" module](doc/component-hierarchy.md) shows by example how a set of components -- some connected, some not -- can work together to implement part of an application. **NOTE that this is somewhat out of date**, but still helpfully illustrative.
 * [Adding new permissions to FOLIO UI modules](doc/adding-permissions.md).
 * UX and implementation concerns for [Settings and Preferences](doc/settings-and-preferences.md)
+* [Main Navigation links developer guide](doc/main-navigation-links.md)
 
 
 ## Additional information

--- a/doc/main-navigation-links.md
+++ b/doc/main-navigation-links.md
@@ -1,0 +1,426 @@
+# Main Navigation Links: Developer Guide
+
+## Overview
+
+Stripes Core allows modules to contribute entries to the top-level Main Navigation through `stripes.links.mainNavigation` in `package.json`.
+
+Each entry renders as a canonical Stripes nav trigger and can behave in one of four ways:
+
+- `route`: navigate to an internal route.
+- `href`: open a link.
+- `event`: run event-handling logic.
+- `render`: let the module render a custom, stateful trigger-based UI.
+
+This document describes all supported `mainNavigation` link modes, when to use each one, and how the runtime resolves them.
+
+## Registration
+
+Register entries under `stripes.links.mainNavigation`:
+
+```json
+{
+  "stripes": {
+    "links": {
+      "mainNavigation": [
+        {
+          "route": "/inventory",
+          "icon": "books",
+          "caption": "ui-inventory.meta.title"
+        }
+      ]
+    }
+  }
+}
+```
+
+Each item in `mainNavigation` becomes one button in the Main Navigation area.
+
+## Supported fields
+
+Common fields:
+
+- `icon` (string): icon name rendered in the nav trigger.
+- `caption` (string): i18n key used for the accessible label.
+- `check` (string): optional static method name on the module root used to decide visibility.
+
+Behavior fields:
+
+- `route` (string): internal route target.
+- `href` (string): href target.
+- `event` (string): event name to pass into the module event handler.
+- `render` (string): static renderer method name on the module root.
+
+In normal usage, an entry should define one behavior field. If more than one is present, Stripes resolves them in this order:
+
+1. `render`
+2. `event`
+3. `href`
+4. `route`
+
+That priority matters. For example, if a link has both `render` and `route`, the custom renderer wins and the route is ignored for rendering behavior.
+
+## Visibility checks
+
+If `check` is configured, Stripes Core looks up a static method with that name on the module root and calls it as:
+
+```ts
+import type { StripesType } from '@folio/stripes-types';
+
+type CheckFn = (stripes: StripesType) => boolean;
+```
+
+Use `check` for:
+
+- Feature flags.
+- Permission checks.
+- Tenant-specific availability.
+- Configuration-based visibility.
+
+Example:
+
+```js
+export const checkConsortiumAffiliations = (stripes) => {
+  return stripes.hasPerm('ui-consortia-settings.affiliations.view');
+};
+```
+
+Class-based root:
+
+```js
+class Root extends React.Component {
+  static checkConsortiumAffiliations = checkConsortiumAffiliations;
+
+  render() {
+    return <AppRoutes />;
+  }
+}
+
+export default Root;
+```
+
+Function-based root:
+
+```js
+function Root() {
+  return <AppRoutes />;
+}
+
+Root.checkConsortiumAffiliations = checkConsortiumAffiliations;
+
+export default Root;
+```
+
+## Route mode
+
+### When to use it
+
+Use `route` when the nav button should behave like normal app navigation to a route owned by the module.
+
+Typical use cases:
+
+- Open the module landing page.
+- Open a stable home screen.
+- Navigate to a settings or dashboard route.
+
+### Example
+
+```json
+{
+  "route": "/inventory",
+  "icon": "books",
+  "caption": "ui-inventory.meta.title"
+}
+```
+
+### Notes
+
+- This is the simplest and preferred mode for standard application navigation.
+- If you only need navigation, do not use `event` or `render`.
+
+## Href mode
+
+### When to use it
+
+Use `href` when the nav button should be rendered as a native anchor element instead of a React Router link.
+
+Typical use cases:
+
+- Link to an absolute external URL.
+- Force browser-level navigation instead of client-side router navigation.
+- Reuse an existing destination that should remain an `href` contractually.
+
+### Example
+
+```json
+{
+  "href": "https://docs.folio.org",
+  "icon": "info",
+  "caption": "ui-your-module.help"
+}
+```
+
+### Notes
+
+- `route` can also carry search parameters because its value is passed to the `to` prop of `react-router` `Link`.
+- Prefer `route` for in-app navigation, including cases like `"/inventory?sort=title"`.
+- Use `href` when you specifically need anchor semantics or an external URL.
+
+## Event mode
+
+### When to use it
+
+Use `event` when clicking the nav button should trigger logic rather than navigate directly.
+
+Typical use cases:
+
+- Open an existing flow managed by an event handler.
+- Perform side effects before a route change.
+- Let a handler return an interceding component to render.
+
+### Example
+
+```json
+{
+  "event": "CHANGE_ACTIVE_AFFILIATION",
+  "check": "checkConsortiumAffiliations",
+  "icon": "flag",
+  "caption": "ui-consortia-settings.affiliations"
+}
+```
+
+The module must also expose an event handler method through its module definition so Stripes can resolve and invoke it.
+
+At runtime, Stripes calls the module's event handler with the declared event string, the `stripes` object, and click-related data. A handler may:
+
+- return `null` and only perform side effects.
+- return a component, which Stripes will render.
+
+Useful event names are exported as `coreEvents` from the package root:
+
+```js
+import { coreEvents } from '@folio/stripes/core';
+```
+
+### Notes
+
+- Use `event` when a click side effect is the primary behavior.
+- If the trigger itself needs local UI state, overlay anchoring, or dynamic badges, `render` is usually the better fit.
+
+## Render mode
+
+### When to use it
+
+Use `render` when the module needs to own the full interaction model while still using the canonical Stripes nav trigger.
+
+Typical use cases:
+
+- Custom trigger with dynamic badge or counter.
+- Toggle that opens a popover or panel.
+- Real-time indicator subscribed to backend events.
+- Stateful trigger that should not be reduced to navigation or side effect only.
+
+### Registration example
+
+```json
+{
+  "render": "renderCustomFeature",
+  "icon": "flag",
+  "caption": "ui-custom-feature.meta.title",
+  "check": "checkCustomFeatureVisibility"
+}
+```
+
+### Module root wiring
+
+Class-based root:
+
+```js
+class Root extends React.Component {
+  static checkCustomFeatureVisibility = checkCustomFeatureVisibility;
+
+  static renderCustomFeature = renderCustomFeature;
+
+  render() {
+    return <AppRoutes />;
+  }
+}
+
+export default Root;
+```
+
+Function-based root:
+
+```js
+function Root() {
+  return <AppRoutes />;
+}
+
+Root.checkCustomFeatureVisibility = checkCustomFeatureVisibility;
+Root.renderCustomFeature = renderCustomFeature;
+
+export default Root;
+```
+
+### Render function contract
+
+```ts
+import { Icon } from '@folio/stripes/components';
+
+interface TriggerProps {
+  'aria-label': string;
+  id: string;
+  ref: React.Ref<HTMLElement>;
+  icon: typeof Icon;
+}
+
+interface RenderProps {
+  renderTrigger: (extraProps?: Optional<NavButtonProps>) => React.ReactNode;
+  triggerProps: TriggerProps;
+}
+
+type RenderFn = (props: RenderProps) => React.ReactNode;
+```
+
+`renderTrigger(extraProps?)`
+
+- Returns the canonical Stripes `NavButton` with baseline props already applied.
+- Baseline props include stable `id`, `ref`, `icon`, and `aria-label`.
+- `extraProps` are spread on top so the module can supply `onClick`, `aria-expanded`, `className`, badge props, and data attributes.
+
+`triggerProps`
+
+- Exposes the resolved props object used for the trigger.
+- Most importantly, it provides a stable `ref` suitable for anchored overlays.
+
+### Render mode example
+
+```js
+import React from 'react';
+
+import { Popper } from '@folio/stripes/components';
+
+export const renderCustomFeature = (props = {}) => {
+  return <CustomFeatureContainer {...props} />;
+};
+
+function CustomFeatureContainer({ renderTrigger, triggerProps }) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [itemCount] = React.useState(0);
+
+  if (!renderTrigger) {
+    return null;
+  }
+
+  return (
+    <div>
+      {renderTrigger({
+        onClick: () => setIsOpen((prev) => !prev),
+        badge: itemCount,
+        badgeSize: 'small',
+        'aria-expanded': isOpen,
+        'aria-haspopup': 'dialog',
+      })}
+
+      {isOpen && triggerProps?.ref?.current && (
+        <Popper
+          anchorEl={triggerProps.ref.current}
+          placement="bottom-end"
+        >
+          <CustomFeaturePanel />
+        </Popper>
+      )}
+    </div>
+  );
+}
+```
+
+### Notes
+
+- Use `renderTrigger` to render the trigger instead of creating a separate main-nav button.
+- Use `triggerProps.ref.current` when you need to anchor UI to the button.
+- Use `render` when the interaction is stateful or richer than navigation/click handling.
+
+## Choosing the right mode
+
+Use `route` when:
+
+- The button should open a module route.
+- There is no custom interaction model.
+
+Use `href` when:
+
+- The target is an external URL.
+- You specifically need native anchor semantics.
+
+Use `event` when:
+
+- Clicking should invoke handler logic.
+- You may need side effects or handler-driven intercession.
+
+Use `render` when:
+
+- The button owns local UI state.
+- You need anchored UI such as a dropdown or popover.
+- You need badges, indicators, or live updates.
+
+## Accessibility and styling
+
+For all modes:
+
+- Provide meaningful `caption` text for the accessible label.
+- Choose an `icon` that communicates intent.
+- Keep behavior predictable and mode-appropriate.
+
+For `render` specifically:
+
+- Keep `aria-expanded` synchronized with open state.
+- Add `aria-haspopup` when rendering popup content.
+- Support `Escape` to close overlays.
+- Return focus to the trigger when the overlay closes.
+
+## Troubleshooting
+
+Button does not render:
+
+- `links.mainNavigation` is missing or not an array.
+- `check` returns false.
+- `caption` does not resolve to a valid i18n message.
+
+Unexpected behavior mode is chosen:
+
+- Multiple behavior fields are set on one entry.
+- Stripes is applying the documented priority: `render`, then `event`, then `href`, then `route`.
+
+Event mode does nothing:
+
+- The event name is declared, but the module does not expose the expected event handler.
+- The handler runs side effects and intentionally returns `null`.
+
+Render mode cannot anchor overlay:
+
+- `triggerProps.ref.current` is read before mount.
+- The trigger is not rendered through `renderTrigger`.
+
+## Testing guidance
+
+For `route` mode, test:
+
+- Trigger renders with correct label and icon.
+- Navigation points to the expected route.
+
+For `href` mode, test:
+
+- Trigger renders as a native anchor element.
+- External URL target is preserved correctly.
+
+For `event` mode, test:
+
+- Click invokes the handler.
+- Side effects or returned interceding components behave as expected.
+
+For `render` mode, test:
+
+- `renderTrigger` is called.
+- Trigger click updates component state.
+- Overlay opens, anchors, and closes correctly.
+- Optional `check` hides or shows the entry correctly.

--- a/doc/main-navigation-links.md
+++ b/doc/main-navigation-links.md
@@ -264,7 +264,7 @@ export default Root;
 ### Render function contract
 
 ```ts
-import { Icon } from '@folio/stripes/components';
+import { Icon } from '@folio/stripes-components';
 
 interface TriggerProps {
   'aria-label': string;
@@ -297,7 +297,7 @@ type RenderFn = (props: RenderProps) => React.ReactNode;
 ```js
 import React from 'react';
 
-import { Popper } from '@folio/stripes/components';
+import { Popper } from '@folio/stripes-components';
 
 export const renderCustomFeature = (props = {}) => {
   return <CustomFeatureContainer {...props} />;

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ export { default as isGuardable } from './src/helpers/isGuardable';
 
 /* components */
 export { default as AppContextMenu } from './src/components/MainNav/CurrentApp/AppContextMenu';
+export { default as NavButton } from './src/components/MainNav/NavButton';
 export { default as IfInterface } from './src/components/IfInterface';
 export { default as IfPermission } from './src/components/IfPermission';
 export { default as IfAnyPermission } from './src/components/IfAnyPermission';

--- a/src/components/MainNav/MainNav.js
+++ b/src/components/MainNav/MainNav.js
@@ -1,10 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
-import { Icon } from '@folio/stripes-components';
-
 import css from './MainNav.css';
-import NavButton from './NavButton';
 import NavDivider from './NavDivider';
 import { CurrentAppGroup } from './CurrentApp';
 import ProfileDropdown from './ProfileDropdown';
@@ -12,6 +9,7 @@ import AppList from './AppList';
 import { SkipLink } from './components';
 import { useAppOrderContext } from './AppOrderProvider';
 import { useStripes } from '../../StripesContext';
+import { MainNavButtons } from './MainNavButtons';
 
 const MainNav = () => {
   const {
@@ -21,7 +19,6 @@ const MainNav = () => {
   const intl = useIntl();
 
   const [selectedApp, setSelectedApp] = useState(apps.find(entry => entry.active));
-  const helpUrl = useRef(stripes.config.helpUrl ?? 'https://docs.folio.org').current;
 
   // This logic changes the visible current app at the starting side of the Main Navigation.
   useEffect(() => {
@@ -41,17 +38,7 @@ const MainNav = () => {
           dropdownToggleId="app-list-dropdown-toggle"
         />
         <NavDivider md="hide" />
-        <NavButton
-          aria-label={intl.formatMessage({ id: 'stripes-core.help' })}
-          data-test-item-help-button
-          href={helpUrl}
-          icon={<Icon
-            icon="question-mark"
-            size="large"
-          />}
-          id="helpButton"
-          target="_blank"
-        />
+        <MainNavButtons />
         <NavDivider md="hide" />
         <ProfileDropdown stripes={stripes} />
       </nav>

--- a/src/components/MainNav/MainNavButtons/MainNavButtons.css
+++ b/src/components/MainNav/MainNavButtons/MainNavButtons.css
@@ -1,0 +1,4 @@
+.mainNavButtons {
+  display: flex;
+  gap: var(--gutter-static-one-third);
+}

--- a/src/components/MainNav/MainNavButtons/MainNavButtons.js
+++ b/src/components/MainNav/MainNavButtons/MainNavButtons.js
@@ -1,0 +1,266 @@
+import {
+  isFunction,
+  kebabCase,
+  uniqBy,
+} from 'lodash';
+import {
+  createRef,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useIntl } from 'react-intl';
+
+import { Icon } from '@folio/stripes/components';
+
+import { handleEvent } from '../../../handlerService';
+import { useModules } from '../../../ModulesContext';
+import { useStripes } from '../../../StripesContext';
+import NavButton from '../NavButton';
+
+import css from './MainNavButtons.css';
+
+/**
+ * Build a stable DOM id for a main navigation button.
+ *
+ * @param {object} module Module descriptor from useModules.
+ * @param {object} link Main navigation link configuration.
+ * @returns {string}
+ */
+const getMainNavButtonId = (module, link) => {
+  return `${kebabCase(module.displayName)}-clickable-mainNavButton-${link.icon}`;
+};
+
+/**
+ * Return a stable ref for a main navigation button.
+ *
+ * A fresh createRef on every render can invalidate overlay anchors that depend
+ * on the trigger element remaining stable while open.
+ *
+ * @param {Map<string, React.RefObject<HTMLElement>>} refsMap Ref cache.
+ * @param {string} id Unique button id.
+ * @returns {React.RefObject<HTMLElement>}
+ */
+const getMainNavButtonRef = (refsMap, id) => {
+  if (!refsMap.has(id)) {
+    refsMap.set(id, createRef());
+  }
+
+  return refsMap.get(id);
+};
+
+/**
+ * Create click handler for event-driven main nav buttons.
+ *
+ * @param {object} params Handler parameters.
+ * @param {string} params.event Event name to send through handlerService.
+ * @param {object} params.module Module descriptor from useModules.
+ * @param {object} params.stripes Stripes context.
+ * @param {Map<string, React.ComponentType>} params.handlerComponentsMap Registered handler components.
+ * @param {Function} params.setHandlerComponentsMap State setter for handler components.
+ * @param {React.RefObject<HTMLElement>} params.triggerRef Trigger element ref.
+ * @returns {(clickEvent: React.MouseEvent) => void}
+ */
+const getMainNavEventClickHandler = ({
+  event,
+  module,
+  stripes,
+  handlerComponentsMap,
+  setHandlerComponentsMap,
+  triggerRef,
+}) => {
+  return (clickEvent) => {
+    const component = handleEvent(
+      event,
+      stripes,
+      module,
+      {
+        clickEvent,
+        handlerComponentsMap,
+        setHandlerComponentsMap,
+        triggerRef,
+      },
+    );
+
+    if (component) {
+      setHandlerComponentsMap((prev) => new Map(prev).set(event, component));
+    }
+  };
+};
+
+/**
+ * Determine whether link should be rendered through a custom render function.
+ *
+ * @param {unknown} renderFn Candidate render function from module root.
+ * @returns {boolean}
+ */
+const hasMainNavCustomRender = (renderFn) => isFunction(renderFn);
+
+/**
+ * Resolve the props needed to render a styled MainNav button.
+ *
+ * This helper stays intentionally neutral: it only resolves trigger props and
+ * leaves any overlay/menu rendering decisions to the module-provided renderFn.
+ *
+ * @param {object} params Resolver parameters.
+ * @param {object} params.link Main navigation link configuration.
+ * @param {object} params.module Module descriptor from useModules.
+ * @param {object} params.stripes Stripes context.
+ * @param {object} params.intl react-intl instance.
+ * @param {Function} params.setHandlerComponentsMap State setter for handler components.
+ * @param {Map<string, React.ComponentType>} params.handlerComponentsMap Registered handler components.
+ * @param {Map<string, React.RefObject<HTMLElement>>} params.buttonRefs Ref cache for main nav buttons.
+ * @param {boolean} params.hasCustomRender Whether the link uses custom renderFn.
+ * @returns {object}
+ */
+const resolveNavButtonProps = ({
+  link,
+  module,
+  stripes,
+  intl,
+  setHandlerComponentsMap,
+  handlerComponentsMap,
+  buttonRefs,
+  hasCustomRender,
+}) => {
+  const id = getMainNavButtonId(module, link);
+  const ref = getMainNavButtonRef(buttonRefs, id);
+
+  const resolvers = [
+    {
+      select: () => hasCustomRender,
+      resolve: (_candidateLink, props) => props,
+    },
+    {
+      select: (candidateLink) => candidateLink.event,
+      resolve: (candidateLink, props) => ({
+        ...props,
+        onClick: getMainNavEventClickHandler({
+          event: candidateLink.event,
+          module,
+          stripes,
+          handlerComponentsMap,
+          setHandlerComponentsMap,
+          triggerRef: ref,
+        }),
+      }),
+    },
+    {
+      select: (candidateLink) => candidateLink.href,
+      resolve: (candidateLink, props) => ({ ...props, href: candidateLink.href }),
+    },
+    {
+      select: (candidateLink) => candidateLink.route,
+      resolve: (candidateLink, props) => ({ ...props, to: candidateLink.route }),
+    },
+    {
+      select: () => true,
+      resolve: (_candidateLink, props) => props,
+    },
+  ];
+
+  const props = {
+    'aria-label': intl.formatMessage({ id: link.caption }),
+    id,
+    key: id,
+    ref,
+    icon: (
+      <Icon
+        icon={link.icon}
+        size="large"
+      />
+    ),
+  };
+
+  return resolvers
+    .find((resolver) => resolver.select(link))
+    .resolve(link, props);
+};
+
+export const MainNavButtons = () => {
+  const intl = useIntl();
+  const modules = useModules();
+  const stripes = useStripes();
+
+  const [handlerComponentsMap, setHandlerComponentsMap] = useState(new Map());
+  const buttonRefs = useRef(new Map()).current;
+
+  const helpUrl = useRef(stripes.config.helpUrl ?? 'https://docs.folio.org').current;
+
+  const renderButton = useCallback(({ link, module: m }) => {
+    const moduleRoot = m.getModule();
+    const checkFn = link.check && moduleRoot[link.check];
+    const renderFn = link.render && moduleRoot[link.render];
+    const hasCustomRender = hasMainNavCustomRender(renderFn);
+
+    const navButtonProps = resolveNavButtonProps({
+      link,
+      module: m,
+      stripes,
+      intl,
+      setHandlerComponentsMap,
+      handlerComponentsMap,
+      buttonRefs,
+      hasCustomRender,
+    });
+
+    if (checkFn && isFunction(checkFn) && !checkFn(stripes)) {
+      return null;
+    }
+
+    if (hasCustomRender) {
+      const renderTrigger = (extraProps = {}) => {
+        return (
+          <NavButton
+            {...navButtonProps}
+            {...extraProps}
+          />
+        );
+      };
+
+      return renderFn({
+        renderTrigger,
+        triggerProps: navButtonProps,
+      });
+    }
+
+    return <NavButton {...navButtonProps} />;
+  }, [buttonRefs, intl, stripes, handlerComponentsMap]);
+
+  const mainNavigationButtons = useMemo(() => {
+    return uniqBy(Object.values(modules).flat(), 'module')
+      .filter(({ links }) => links && Array.isArray(links.mainNavigation))
+      .flatMap((module) => module.links.mainNavigation.map(link => ({ link, module })))
+      .map(renderButton)
+      .filter(Boolean);
+  }, [modules, renderButton]);
+
+  const handlerElements = useMemo(() => {
+    return Array.from(handlerComponentsMap.entries())
+      .map(([event, HandlerComponent]) => (
+        HandlerComponent && <HandlerComponent key={event} stripes={stripes} />
+      ))
+      .filter(Boolean);
+  }, [handlerComponentsMap, stripes]);
+
+  return (
+    <>
+      {handlerElements}
+      <div className={css.mainNavButtons}>
+        <NavButton
+          aria-label={intl.formatMessage({ id: 'stripes-core.help' })}
+          data-test-item-help-button
+          href={helpUrl}
+          icon={<Icon
+            icon="question-mark"
+            size="large"
+          />}
+          id="helpButton"
+          target="_blank"
+        />
+        {mainNavigationButtons}
+      </div>
+    </>
+  );
+};

--- a/src/components/MainNav/MainNavButtons/MainNavButtons.js
+++ b/src/components/MainNav/MainNavButtons/MainNavButtons.js
@@ -12,7 +12,7 @@ import {
 } from 'react';
 import { useIntl } from 'react-intl';
 
-import { Icon } from '@folio/stripes/components';
+import { Icon } from '@folio/stripes-components';
 
 import { handleEvent } from '../../../handlerService';
 import { useModules } from '../../../ModulesContext';

--- a/src/components/MainNav/MainNavButtons/MainNavButtons.test.js
+++ b/src/components/MainNav/MainNavButtons/MainNavButtons.test.js
@@ -1,0 +1,273 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  act,
+  render,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import * as handlerService from '../../../handlerService';
+import { ModulesContext } from '../../../ModulesContext';
+import { StripesContext } from '../../../StripesContext';
+import { MainNavButtons } from './MainNavButtons';
+
+jest.unmock('@folio/stripes-components');
+
+const STRIPES = {
+  config: {},
+};
+
+const buildModule = (overrides = {}) => ({
+  module: 'ui-test',
+  displayName: 'Test Module',
+  links: {},
+  getModule: jest.fn(() => ({})),
+  ...overrides,
+});
+
+const defaultModules = {
+  app: [],
+  handler: [],
+};
+
+const renderMainNavButtons = (modules = defaultModules, stripes = STRIPES) => render(
+  <MainNavButtons />,
+  {
+    wrapper: ({ children }) => (
+      <MemoryRouter>
+        <StripesContext.Provider value={stripes}>
+          <ModulesContext.Provider value={modules}>
+            {children}
+          </ModulesContext.Provider>
+        </StripesContext.Provider>
+      </MemoryRouter>
+    ),
+  },
+);
+
+describe('MainNavButtons', () => {
+  let handleEventSpy;
+
+  beforeEach(() => {
+    handleEventSpy = jest.spyOn(handlerService, 'handleEvent').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    handleEventSpy.mockRestore();
+  });
+
+  describe('Help button', () => {
+    it('renders the help button', () => {
+      renderMainNavButtons();
+
+      expect(screen.getByRole('link', { name: 'stripes-core.help' })).toBeInTheDocument();
+    });
+
+    it('uses config.helpUrl when provided', () => {
+      renderMainNavButtons(defaultModules, { config: { helpUrl: 'https://custom-help.example.com' } });
+
+      expect(screen.getByRole('link', { name: 'stripes-core.help' })).toHaveAttribute('href', 'https://custom-help.example.com');
+    });
+
+    it('falls back to docs.folio.org when helpUrl is not configured', () => {
+      renderMainNavButtons();
+
+      expect(screen.getByRole('link', { name: 'stripes-core.help' })).toHaveAttribute('href', 'https://docs.folio.org');
+    });
+  });
+
+  describe('route mode', () => {
+    it('renders a nav button linking to the configured route', () => {
+      const modules = {
+        ...defaultModules,
+        app: [buildModule({
+          links: {
+            mainNavigation: [{ route: '/inventory', icon: 'books', caption: 'stripes-core.test.nav' }],
+          },
+          getModule: jest.fn(() => ({})),
+        })],
+      };
+
+      renderMainNavButtons(modules);
+
+      expect(screen.getByRole('link', { name: 'stripes-core.test.nav' })).toBeInTheDocument();
+    });
+  });
+
+  describe('href mode', () => {
+    it('renders a nav button with the configured href', () => {
+      const modules = {
+        ...defaultModules,
+        app: [buildModule({
+          links: {
+            mainNavigation: [{ href: 'https://example.com', icon: 'external-link', caption: 'stripes-core.test.nav' }],
+          },
+          getModule: jest.fn(() => ({})),
+        })],
+      };
+
+      renderMainNavButtons(modules);
+
+      expect(screen.getByRole('link', { name: 'stripes-core.test.nav' })).toHaveAttribute('href', 'https://example.com');
+    });
+  });
+
+  describe('event mode', () => {
+    it('calls handleEvent when the button is clicked', async () => {
+      const modules = {
+        ...defaultModules,
+        app: [buildModule({
+          links: {
+            mainNavigation: [{ event: 'TEST_EVENT', icon: 'flag', caption: 'stripes-core.test.nav' }],
+          },
+          getModule: jest.fn(() => ({})),
+        })],
+      };
+
+      renderMainNavButtons(modules);
+
+      const btn = screen.getByRole('button', { name: 'stripes-core.test.nav' });
+
+      await act(() => userEvent.click(btn));
+
+      expect(handleEventSpy).toHaveBeenCalledWith(
+        'TEST_EVENT',
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ clickEvent: expect.anything() }),
+      );
+    });
+
+    it('mounts the handler component returned by handleEvent', async () => {
+      const HandlerComponent = () => <div data-testid="handler-output">Handler</div>;
+      handleEventSpy.mockReturnValue(HandlerComponent);
+
+      const modules = {
+        ...defaultModules,
+        app: [buildModule({
+          links: {
+            mainNavigation: [{ event: 'TEST_EVENT', icon: 'flag', caption: 'stripes-core.test.nav' }],
+          },
+          getModule: jest.fn(() => ({})),
+        })],
+      };
+
+      renderMainNavButtons(modules);
+
+      const btn = screen.getByRole('button', { name: 'stripes-core.test.nav' });
+
+      await act(() => userEvent.click(btn));
+
+      expect(screen.getByTestId('handler-output')).toBeInTheDocument();
+    });
+  });
+
+  describe('render mode', () => {
+    it('calls the module render function with renderTrigger and triggerProps', () => {
+      const renderFn = jest.fn(() => <div data-testid="custom-render" />);
+
+      const modules = {
+        ...defaultModules,
+        app: [buildModule({
+          links: {
+            mainNavigation: [{ render: 'renderCustomFeature', icon: 'flag', caption: 'stripes-core.test.nav' }],
+          },
+          getModule: jest.fn(() => ({ renderCustomFeature: renderFn })),
+        })],
+      };
+
+      renderMainNavButtons(modules);
+
+      expect(renderFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          renderTrigger: expect.any(Function),
+          triggerProps: expect.objectContaining({
+            id: expect.any(String),
+            ref: expect.any(Object),
+          }),
+        }),
+      );
+      expect(screen.getByTestId('custom-render')).toBeInTheDocument();
+    });
+
+    it('renderTrigger renders a NavButton with merged extraProps', () => {
+      const renderFn = jest.fn(({ renderTrigger }) => {
+        return renderTrigger({ 'data-testid': 'trigger-btn', onClick: jest.fn() });
+      });
+
+      const modules = {
+        ...defaultModules,
+        app: [buildModule({
+          links: {
+            mainNavigation: [{ render: 'renderCustomFeature', icon: 'flag', caption: 'stripes-core.test.nav' }],
+          },
+          getModule: jest.fn(() => ({ renderCustomFeature: renderFn })),
+        })],
+      };
+
+      renderMainNavButtons(modules);
+
+      expect(screen.getByTestId('trigger-btn')).toBeInTheDocument();
+    });
+  });
+
+  describe('visibility check', () => {
+    it('renders the button when check returns true', () => {
+      const checkFn = jest.fn(() => true);
+
+      const modules = {
+        ...defaultModules,
+        app: [buildModule({
+          links: {
+            mainNavigation: [{ route: '/test', icon: 'flag', caption: 'stripes-core.test.nav', check: 'checkVisibility' }],
+          },
+          getModule: jest.fn(() => ({ checkVisibility: checkFn })),
+        })],
+      };
+
+      renderMainNavButtons(modules);
+
+      expect(screen.getByRole('link', { name: 'stripes-core.test.nav' })).toBeInTheDocument();
+    });
+
+    it('hides the button when check returns false', () => {
+      const checkFn = jest.fn(() => false);
+
+      const modules = {
+        ...defaultModules,
+        app: [buildModule({
+          links: {
+            mainNavigation: [{ route: '/test', icon: 'flag', caption: 'stripes-core.test.nav', check: 'checkVisibility' }],
+          },
+          getModule: jest.fn(() => ({ checkVisibility: checkFn })),
+        })],
+      };
+
+      renderMainNavButtons(modules);
+
+      expect(screen.queryByRole('link', { name: 'stripes-core.test.nav' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('deduplication', () => {
+    it('renders only one button when the same module appears in multiple module type buckets', () => {
+      const mod = buildModule({
+        module: 'ui-test',
+        links: {
+          mainNavigation: [{ route: '/test', icon: 'flag', caption: 'stripes-core.test.nav' }],
+        },
+        getModule: jest.fn(() => ({})),
+      });
+
+      const modules = {
+        app: [mod],
+        handler: [mod],
+      };
+
+      renderMainNavButtons(modules);
+
+      expect(screen.getAllByRole('link', { name: 'stripes-core.test.nav' })).toHaveLength(1);
+    });
+  });
+});

--- a/src/components/MainNav/MainNavButtons/index.js
+++ b/src/components/MainNav/MainNavButtons/index.js
@@ -1,0 +1,1 @@
+export { MainNavButtons } from './MainNavButtons';

--- a/src/components/MainNav/NavButton/NavButton.js
+++ b/src/components/MainNav/NavButton/NavButton.js
@@ -27,6 +27,7 @@ const propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
+  badgeSize: PropTypes.oneOf(['small', 'medium']),
   onClick: PropTypes.func,
   open: PropTypes.bool,
   selected: PropTypes.bool,
@@ -37,6 +38,7 @@ const propTypes = {
 const NavButton = React.forwardRef(({
   ariaLabel,
   badge,
+  badgeSize,
   className,
   href,
   icon,
@@ -118,7 +120,7 @@ const NavButton = React.forwardRef(({
   return (
     <Element ref={ref} id={id} aria-label={ariaLabel || title} className={rootClasses} {...rest} {...clickableProps}>
       <span className={classNames(css.inner, { [css.isInteractive]: isInteractive }, innerClassName)}>
-        { badge && (<Badge color="red" className={css.badge}>{badge}</Badge>) }
+        { badge && (<Badge size={badgeSize} color="red" className={css.badge}>{badge}</Badge>) }
         { renderedIcon }
         { label && <span className={classNames(css.label, labelClassName)}>{label}</span>}
         {typeof open === 'boolean' && (


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/STCOR-1094

Stripes Core currently renders a static Main Navigation bar with only hard-coded buttons (Help, Profile). There is no API for FOLIO modules to contribute their own entries to the main navigation area, which blocks use cases that require a module-owned, always-visible nav trigger — such as a stateful popover, a real-time badge indicator, or a custom event-driven action.

This PR introduces the `stripes.links.mainNavigation` registration API and the `MainNavButtons` component that powers it.

## Approach

Module authors declare nav entries in package.json under `stripes.links.mainNavigation`. Each entry specifies an icon, an i18n caption key, an optional visibility `check`, and exactly one behavior field. Stripes Core resolves the behavior at runtime in priority order:

1. **`render`** — the module root exposes a renderer function that receives `renderTrigger` and `triggerProps`. This covers stateful triggers (popovers, overlays, badges) where the module owns the interaction model.
2. **`event`** — the click is dispatched through the existing `handlerService`, keeping side-effect-only actions out of the render tree.
3. **`href`** — renders a plain link nav button.
4. **`route`** — renders an internal-route nav button.

Button refs are cached in a stable `Map` across renders so that overlay anchors (e.g. `Popper`) remain valid while a panel is open.

The existing hard-coded Help button was moved into `MainNavButtons` to consolidate all right-side nav rendering in one place.

## Changes

- **MainNavButtons.js** *(new)* — core component; resolves and renders all module-contributed nav entries plus the Help button.
- **MainNavButtons.css** *(new)* — flex layout with design-token gap for the button group.
- **index.js** *(new)* — barrel export.
- **MainNav.js** — replaces inline Help button markup with `<MainNavButtons />`.
- **NavButton.js** — adds `badgeSize` prop (`'small' | 'medium'`) forwarded to `Badge`, enabling `render`-mode modules to control badge sizing.
- **index.js** — exports `NavButton` as part of the public API so `render`-mode modules can use it directly if needed.
- **main-navigation-links.md** *(new)* — full developer guide: registration, all four modes, visibility checks, the `renderTrigger`/`triggerProps` contract, and annotated examples.
- **README.md** — links to the new guide.
- **CHANGELOG.md** — entry added.

## Screen recording


https://github.com/user-attachments/assets/408b5e2c-1732-407c-9ba2-ed92045d11af

