### PR TITLE
STCOR-993 codesmell cleanup for ForgotUserName, ForgotPassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Supply `<EntitlementChangeBanner>` to indicate entitlement changes. Refs STCOR-780.
 * Correctly display session-remaining time after refresh. Refs STCOR-1087.
 * Rename `button.new` from "+ New" to "New". Refs STCOR-1093.
+* Codesmell cleanup in ForgotUserName, ForgotPassword. Refs STCOR-993.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Redirect,
-} from 'react-router-dom';
+import { useHistory } from 'react-router';
 
 import processBadResponse from '../../processBadResponse';
 import { defaultErrors } from '../../constants';
@@ -9,28 +7,23 @@ import ForgotPasswordForm from './ForgotPasswordForm';
 import useForgotPasswordMutation from './useForgotPasswordMutation';
 
 const ForgotPassword = () => {
-  const [userEmail, setUserEmail] = useState(null);
+  const history = useHistory();
   const [authFailure, setAuthFailure] = useState([]);
   const sendReminderMutation = useForgotPasswordMutation();
 
   const onSubmit = async (values) => {
-    setUserEmail(null);
     setAuthFailure([]);
     const { userInput } = values;
     const { FORGOTTEN_PASSWORD_CLIENT_ERROR } = defaultErrors;
 
     try {
       await sendReminderMutation.mutateAsync(userInput);
-      setUserEmail(userInput);
+      history.push('/check-email', { userEmail: userInput });
     } catch (error) {
       const res = await processBadResponse(undefined, error.response, FORGOTTEN_PASSWORD_CLIENT_ERROR);
       setAuthFailure(res);
     }
   };
-
-  if (userEmail) {
-    return <Redirect to={{ pathname: '/check-email', state: { userEmail } }} />;
-  }
 
   return (
     <ForgotPasswordForm

--- a/src/components/ForgotPassword/ForgotPassword.test.js
+++ b/src/components/ForgotPassword/ForgotPassword.test.js
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import { userEvent } from '@folio/jest-config-stripes/testing-library/user-event';
+import { useHistory } from 'react-router';
 
 import ForgotPasswordForm from './ForgotPasswordForm';
 import ForgotPassword from './ForgotPassword';
@@ -20,9 +21,7 @@ jest.mock('../../StripesContext', () => ({
 
 jest.mock('../OrganizationLogo', () => () => 'OrganizationLogo');
 jest.mock('../AuthErrorsContainer', () => ({ errors = [] }) => errors[0]?.code);
-jest.mock('react-router-dom', () => ({
-  Redirect: () => '<Redirect />',
-}));
+jest.mock('react-router');
 
 // PreLoginLanding tests don't handle button.disabled
 // and I don't feel like expanding this PR even further
@@ -45,9 +44,9 @@ describe('ForgotPasswordForm', () => {
   it('displays headline, input field, submit button', () => {
     render(<ForgotPasswordForm onSubmit={jest.fn()} />);
 
-    expect(screen.getByText('stripes-core.label.forgotPassword'));
-    expect(screen.getByText('stripes-core.placeholder.field.forgotPassword'));
-    expect(screen.getByText('stripes-core.button.continue'));
+    screen.getByText('stripes-core.label.forgotPassword');
+    screen.getByText('stripes-core.placeholder.field.forgotPassword');
+    screen.getByText('stripes-core.button.continue');
   });
 
   it('enables submit conditionally', async () => {
@@ -68,7 +67,7 @@ describe('ForgotPasswordForm', () => {
     ];
 
     render(<ForgotPasswordForm errors={errors} onSubmit={jest.fn()} />);
-    expect(screen.getByText(errors[0].code));
+    screen.getByText(errors[0].code);
   });
 
   it('calls onSubmit', async () => {
@@ -94,6 +93,8 @@ describe('ForgotPassword', () => {
   it('handles success', async () => {
     const user = userEvent.setup();
     const userInput = 'some-username';
+    const history = { push: jest.fn() };
+    useHistory.mockReturnValue(history);
 
     const mockUseForgotPasswordMutation = useForgotPasswordMutation;
     mockUseForgotPasswordMutation.mockReturnValue({
@@ -110,7 +111,7 @@ describe('ForgotPassword', () => {
     await user.click(submit);
 
     await waitFor(() => {
-      expect(screen.getByText('<Redirect />'));
+      expect(history.push).toHaveBeenCalledWith('/check-email', { userEmail: userInput });
     });
   });
 
@@ -140,7 +141,7 @@ describe('ForgotPassword', () => {
     await user.click(submit);
 
     await waitFor(() => {
-      expect(screen.getByText(defaultErrors.FORGOTTEN_PASSWORD_CLIENT_ERROR.code));
+      screen.getByText(defaultErrors.FORGOTTEN_PASSWORD_CLIENT_ERROR.code);
     });
   });
 });

--- a/src/components/ForgotUserName/ForgotUserName.js
+++ b/src/components/ForgotUserName/ForgotUserName.js
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Redirect,
-} from 'react-router-dom';
+import { useHistory } from 'react-router';
 
 import processBadResponse from '../../processBadResponse';
 import { defaultErrors } from '../../constants';
@@ -10,13 +8,12 @@ import useForgotUsernameMutation from './useForgotUsernameMutation';
 import { validateForgotUsernameForm as isValidUsername } from '../../validators';
 
 const ForgotUserName = () => {
-  const [userEmail, setUserEmail] = useState(null);
+  const history = useHistory();
   const [isValidInput, setIsValidInput] = useState(true);
   const [authFailure, setAuthFailure] = useState([]);
   const sendReminderMutation = useForgotUsernameMutation();
 
   const handleSubmit = async (values) => {
-    setUserEmail(null);
     setAuthFailure([]);
     const { userInput } = values;
     const { FORGOTTEN_USERNAME_CLIENT_ERROR } = defaultErrors;
@@ -24,7 +21,7 @@ const ForgotUserName = () => {
     if (isValidUsername(userInput)) {
       try {
         await sendReminderMutation.mutateAsync(userInput);
-        setUserEmail(userInput);
+        history.push('/check-email', { userEmail: userInput });
       } catch (error) {
         const res = await processBadResponse(undefined, error.response, FORGOTTEN_USERNAME_CLIENT_ERROR);
         setIsValidInput(true);
@@ -34,10 +31,6 @@ const ForgotUserName = () => {
       setIsValidInput(false);
     }
   };
-
-  if (userEmail) {
-    return <Redirect to={{ pathname: '/check-email', state: { userEmail } }} />;
-  }
 
   return (
     <ForgotUserNameForm

--- a/src/components/ForgotUserName/ForgotUserName.test.js
+++ b/src/components/ForgotUserName/ForgotUserName.test.js
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import { userEvent } from '@folio/jest-config-stripes/testing-library/user-event';
+import { useHistory } from 'react-router';
 
 import ForgotUserNameForm from './ForgotUserNameForm';
 import ForgotUserName from './ForgotUserName';
@@ -20,9 +21,7 @@ jest.mock('../../StripesContext', () => ({
 
 jest.mock('../OrganizationLogo', () => () => 'OrganizationLogo');
 jest.mock('../AuthErrorsContainer', () => ({ errors = [] }) => errors[0]?.code);
-jest.mock('react-router-dom', () => ({
-  Redirect: () => '<Redirect />',
-}));
+jest.mock('react-router');
 
 // PreLoginLanding tests don't handle button.disabled
 // and I don't feel like expanding this PR even further
@@ -45,9 +44,9 @@ describe('ForgotUserNameForm', () => {
   it('displays headline, input field, submit button', () => {
     render(<ForgotUserNameForm onSubmit={jest.fn()} isValid />);
 
-    expect(screen.getByText('stripes-core.label.forgotUsername'));
-    expect(screen.getByText('stripes-core.placeholder.forgotUsername'));
-    expect(screen.getByText('stripes-core.button.continue'));
+    screen.getByText('stripes-core.label.forgotUsername');
+    screen.getByText('stripes-core.placeholder.forgotUsername');
+    screen.getByText('stripes-core.button.continue');
   });
 
   it('enables submit conditionally', async () => {
@@ -68,7 +67,7 @@ describe('ForgotUserNameForm', () => {
     ];
 
     render(<ForgotUserNameForm errors={errors} onSubmit={jest.fn()} isValid />);
-    expect(screen.getByText(errors[0].code));
+    screen.getByText(errors[0].code);
   });
 
   it('calls onSubmit', async () => {
@@ -94,6 +93,8 @@ describe('ForgotUserName', () => {
   it('handles success', async () => {
     const user = userEvent.setup();
     const userInput = 'some-username@some-school.edu';
+    const history = { push: jest.fn() };
+    useHistory.mockReturnValue(history);
 
     const mockUseForgotUsernameMutation = useForgotUsernameMutation;
     mockUseForgotUsernameMutation.mockReturnValue({
@@ -110,7 +111,7 @@ describe('ForgotUserName', () => {
     await user.click(submit);
 
     await waitFor(() => {
-      expect(screen.getByText('<Redirect />'));
+      expect(history.push).toHaveBeenCalledWith('/check-email', { userEmail: userInput });
     });
   });
 
@@ -140,7 +141,7 @@ describe('ForgotUserName', () => {
     await user.click(submit);
 
     await waitFor(() => {
-      expect(screen.getByText(defaultErrors.FORGOTTEN_USERNAME_CLIENT_ERROR.code));
+      screen.getByText(defaultErrors.FORGOTTEN_USERNAME_CLIENT_ERROR.code);
     });
   });
 });


### PR DESCRIPTION
Given we can call `history.push()` in the event handler, there is zero value in copying values into state and then rendering a `<Redirect>` after the state change.

Minor cleanup of existing tests where `expect()` was called without an assertion as an unnecessary wrapper around `screen.getBy...()` calls.

Refs [STCOR-993](https://folio-org.atlassian.net/browse/STCOR-993)