### PR TITLE
STCOR-1099 supply rtrIgnore to forgot-* API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Supply `<EntitlementChangeBanner>` to indicate entitlement changes. Refs STCOR-780.
 * Correctly display session-remaining time after refresh. Refs STCOR-1087.
 * Rename `button.new` from "+ New" to "New". Refs STCOR-1093.
+* Supply `rtrIgnore` on forgot-password and forgot-username API requests. Refs STCOR-1099.
 
 ## [11.1.1](https://github.com/folio-org/stripes-core/tree/v11.1.1) (2026-04-20)
 [Full Changelog](https://github.com/folio-org/stripes-core/compare/v11.1.0...v11.1.1)

--- a/src/components/ForgotPassword/useForgotPasswordMutation.js
+++ b/src/components/ForgotPassword/useForgotPasswordMutation.js
@@ -15,7 +15,7 @@ import useOkapiKy from '../../useOkapiKy';
  */
 const useForgotPasswordMutation = () => {
   const stripes = useStripes();
-  const ky = useOkapiKy();
+  const ky = useOkapiKy({ rtrIgnore: true });
 
   const pathPrefix = stripes.okapi.authnUrl ? 'users-keycloak' : 'bl-users';
 

--- a/src/components/ForgotPassword/useForgotPasswordMutation.test.js
+++ b/src/components/ForgotPassword/useForgotPasswordMutation.test.js
@@ -1,0 +1,70 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook, act } from '@folio/jest-config-stripes/testing-library/react';
+
+import useForgotPasswordMutation from './useForgotPasswordMutation';
+import { useStripes } from '../../StripesContext';
+import useOkapiKy from '../../useOkapiKy';
+
+const mockPost = jest.fn();
+
+jest.mock('../../StripesContext', () => ({
+  useStripes: jest.fn(),
+}));
+
+jest.mock('../../useOkapiKy', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ post: mockPost })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+    },
+  });
+
+  // eslint-disable-next-line react/prop-types
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+};
+
+describe('useForgotPasswordMutation', () => {
+  beforeEach(() => {
+    mockPost.mockReturnValue({
+      json: jest.fn().mockResolvedValue({}),
+    });
+    useStripes.mockReturnValue({ okapi: { authnUrl: 'authn' } });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets `ignoreRtr: true` when creating the ky client', () => {
+    renderHook(() => useForgotPasswordMutation(), { wrapper: createWrapper() });
+
+    expect(useOkapiKy).toHaveBeenCalledWith({ rtrIgnore: true });
+  });
+
+  it.each([
+    [{ authnUrl: 'authn' }, 'users-keycloak'],
+    [{ authnUrl: '' }, 'bl-users'],
+  ])('posts the forgotten password request to %s', async (okapi, pathPrefix) => {
+    useStripes.mockReturnValue({ okapi });
+    const { result } = renderHook(() => useForgotPasswordMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('some-user');
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      `${pathPrefix}/forgotten/password`,
+      { json: { id: 'some-user' } },
+    );
+  });
+});

--- a/src/components/ForgotUserName/useForgotUsernameMutation.js
+++ b/src/components/ForgotUserName/useForgotUsernameMutation.js
@@ -15,7 +15,7 @@ import useOkapiKy from '../../useOkapiKy';
  */
 const useForgotPasswordMutation = () => {
   const stripes = useStripes();
-  const ky = useOkapiKy();
+  const ky = useOkapiKy({ rtrIgnore: true });
 
   const pathPrefix = stripes.okapi.authnUrl ? 'users-keycloak' : 'bl-users';
 

--- a/src/components/ForgotUserName/useForgotUsernameMutation.test.js
+++ b/src/components/ForgotUserName/useForgotUsernameMutation.test.js
@@ -1,0 +1,70 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook, act } from '@folio/jest-config-stripes/testing-library/react';
+
+import useForgotUsernameMutation from './useForgotUsernameMutation';
+import { useStripes } from '../../StripesContext';
+import useOkapiKy from '../../useOkapiKy';
+
+const mockPost = jest.fn();
+
+jest.mock('../../StripesContext', () => ({
+  useStripes: jest.fn(),
+}));
+
+jest.mock('../../useOkapiKy', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ post: mockPost })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+    },
+  });
+
+  // eslint-disable-next-line react/prop-types
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+};
+
+describe('useForgotUsernameMutation', () => {
+  beforeEach(() => {
+    mockPost.mockReturnValue({
+      json: jest.fn().mockResolvedValue({}),
+    });
+    useStripes.mockReturnValue({ okapi: { authnUrl: 'authn' } });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets `ignoreRtr: true` when creating the ky client', () => {
+    renderHook(() => useForgotUsernameMutation(), { wrapper: createWrapper() });
+
+    expect(useOkapiKy).toHaveBeenCalledWith({ rtrIgnore: true });
+  });
+
+  it.each([
+    [{ authnUrl: 'authn' }, 'users-keycloak'],
+    [{ authnUrl: '' }, 'bl-users'],
+  ])('posts the forgotten username request to %s', async (okapi, pathPrefix) => {
+    useStripes.mockReturnValue({ okapi });
+    const { result } = renderHook(() => useForgotUsernameMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('some-user');
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      `${pathPrefix}/forgotten/username`,
+      { json: { id: 'some-user' } },
+    );
+  });
+});


### PR DESCRIPTION
Supply `rtrIgnore: true` on the forgot-password and forgot-username API requests, allowing them to avoid invoking RTR when credentials are not present, which of course they **won't be because the whole reason for accessing these routes is that an end-user cannot remember their credentials.

This bug has been lurking for a while but was masked by the initial RTR implementation that amounted to "play a request; on failure, if credentials are required-but-missing, rotate; replay the request". The loophole is that all requests would be played once prior to invoking RTR. This meant requests that require credentials (as most do) would fail, polluting the console, but it also meant the requests that do NOT require credentials (and these two do NOT) would succeed, even though they do not specify `rtrIgnore: true` to indicate that they should bypass rotation.

The loophole was closed in [STCOR-1069](https://folio-org.atlassian.net/browse/STCOR-1069) in PRs #1732 and #1737 and was revealed by testing for [STCOR-993](https://folio-org.atlassian.net/browse/STCOR-993) in PR #1755.

New unit tests courtesy Codex GPT 5.6 Luna

Refs [STCOR-1099](https://folio-org.atlassian.net/browse/STCOR-1099)